### PR TITLE
Fix agent frontmatter name consistency

### DIFF
--- a/design/design-ux-architect.md
+++ b/design/design-ux-architect.md
@@ -1,5 +1,5 @@
 ---
-name: ArchitectUX
+name: UX Architect
 description: Technical architecture and UX specialist who provides developers with solid foundations, CSS systems, and clear implementation guidance
 color: purple
 ---

--- a/design/design-visual-storyteller.md
+++ b/design/design-visual-storyteller.md
@@ -1,5 +1,5 @@
 ---
-name: design-visual-storyteller
+name: Visual Storyteller
 description: Expert visual communication specialist focused on creating compelling visual narratives, multimedia content, and brand storytelling through design. Specializes in transforming complex information into engaging visual stories that connect with audiences and drive emotional engagement.
 color: purple
 ---

--- a/engineering/engineering-ai-engineer.md
+++ b/engineering/engineering-ai-engineer.md
@@ -1,5 +1,5 @@
 ---
-name: engineering-ai-engineer
+name: AI Engineer
 description: Expert AI/ML engineer specializing in machine learning model development, deployment, and integration into production systems. Focused on building intelligent features, data pipelines, and AI-powered applications with emphasis on practical, scalable solutions.
 color: blue
 ---

--- a/engineering/engineering-senior-developer.md
+++ b/engineering/engineering-senior-developer.md
@@ -1,5 +1,5 @@
 ---
-name: engineering-senior-developer
+name: Senior Developer
 description: Premium implementation specialist - Masters Laravel/Livewire/FluxUI, advanced CSS, Three.js integration
 color: green
 ---

--- a/marketing/marketing-content-creator.md
+++ b/marketing/marketing-content-creator.md
@@ -1,5 +1,5 @@
 ---
-name: marketing-content-creator
+name: Content Creator
 description: Expert content strategist and creator for multi-platform campaigns. Develops editorial calendars, creates compelling copy, manages brand storytelling, and optimizes content for engagement across all digital channels.
 tools: WebFetch, WebSearch, Read, Write, Edit, Bash
 ---

--- a/marketing/marketing-growth-hacker.md
+++ b/marketing/marketing-growth-hacker.md
@@ -1,5 +1,5 @@
 ---
-name: marketing-growth-hacker
+name: Growth Hacker
 description: Expert growth strategist specializing in rapid user acquisition through data-driven experimentation. Develops viral loops, optimizes conversion funnels, and finds scalable growth channels for exponential business growth.
 tools: WebFetch, WebSearch, Read, Write, Edit, Bash
 ---

--- a/marketing/marketing-instagram-curator.md
+++ b/marketing/marketing-instagram-curator.md
@@ -1,5 +1,5 @@
 ---
-name: marketing-instagram-curator
+name: Instagram Curator
 description: Expert Instagram marketing specialist focused on visual storytelling, community building, and multi-format content optimization. Masters aesthetic development and drives meaningful engagement.
 color: "#E4405F"
 ---

--- a/marketing/marketing-reddit-community-builder.md
+++ b/marketing/marketing-reddit-community-builder.md
@@ -1,5 +1,5 @@
 ---
-name: marketing-reddit-community-builder
+name: Reddit Community Builder
 description: Expert Reddit marketing specialist focused on authentic community engagement, value-driven content creation, and long-term relationship building. Masters Reddit culture navigation.
 color: "#FF4500"
 ---

--- a/marketing/marketing-social-media-strategist.md
+++ b/marketing/marketing-social-media-strategist.md
@@ -1,5 +1,5 @@
 ---
-name: marketing-social-media-strategist
+name: Social Media Strategist
 description: Expert social media strategist for Twitter, LinkedIn, and professional platforms. Creates viral campaigns, builds communities, manages real-time engagement, and develops thought leadership strategies.
 tools: WebFetch, WebSearch, Read, Write, Edit, Bash
 ---

--- a/marketing/marketing-tiktok-strategist.md
+++ b/marketing/marketing-tiktok-strategist.md
@@ -1,5 +1,5 @@
 ---
-name: marketing-tiktok-strategist
+name: TikTok Strategist
 description: Expert TikTok marketing specialist focused on viral content creation, algorithm optimization, and community building. Masters TikTok's unique culture and features for brand growth.
 color: "#000000"
 ---

--- a/marketing/marketing-twitter-engager.md
+++ b/marketing/marketing-twitter-engager.md
@@ -1,5 +1,5 @@
 ---
-name: marketing-twitter-engager
+name: Twitter Engager
 description: Expert Twitter marketing specialist focused on real-time engagement, thought leadership building, and community-driven growth. Masters LinkedIn campaigns and professional social media strategy.
 color: "#1DA1F2"
 ---

--- a/product/product-feedback-synthesizer.md
+++ b/product/product-feedback-synthesizer.md
@@ -1,5 +1,5 @@
 ---
-name: product-feedback-synthesizer
+name: Feedback Synthesizer
 description: Expert in collecting, analyzing, and synthesizing user feedback from multiple channels to extract actionable product insights. Transforms qualitative feedback into quantitative priorities and strategic recommendations.
 color: blue
 tools: WebFetch, WebSearch, Read, Write, Edit, Bash

--- a/product/product-sprint-prioritizer.md
+++ b/product/product-sprint-prioritizer.md
@@ -1,5 +1,5 @@
 ---
-name: product-sprint-prioritizer
+name: Sprint Prioritizer
 description: Expert product manager specializing in agile sprint planning, feature prioritization, and resource allocation. Focused on maximizing team velocity and business value delivery through data-driven prioritization frameworks.
 color: green
 tools: WebFetch, WebSearch, Read, Write, Edit, Bash

--- a/product/product-trend-researcher.md
+++ b/product/product-trend-researcher.md
@@ -1,5 +1,5 @@
 ---
-name: product-trend-researcher
+name: Trend Researcher
 description: Expert market intelligence analyst specializing in identifying emerging trends, competitive analysis, and opportunity assessment. Focused on providing actionable insights that drive product strategy and innovation decisions.
 color: purple
 tools: WebFetch, WebSearch, Read, Write, Edit, Bash

--- a/project-management/project-manager-senior.md
+++ b/project-management/project-manager-senior.md
@@ -1,5 +1,5 @@
 ---
-name: project-manager-senior
+name: Senior Project Manager
 description: Converts specs to tasks, remembers previous projects\n - Focused on realistic scope, no background processes, exact spec requirements
 color: blue
 ---

--- a/spatial-computing/terminal-integration-specialist.md
+++ b/spatial-computing/terminal-integration-specialist.md
@@ -1,3 +1,9 @@
+---
+name: Terminal Integration Specialist
+description: Terminal emulation, text rendering optimization, and SwiftTerm integration for modern Swift applications
+color: green
+---
+
 # Terminal Integration Specialist
 
 **Specialization**: Terminal emulation, text rendering optimization, and SwiftTerm integration for modern Swift applications.

--- a/spatial-computing/visionos-spatial-engineer.md
+++ b/spatial-computing/visionos-spatial-engineer.md
@@ -1,3 +1,9 @@
+---
+name: visionOS Spatial Engineer
+description: Native visionOS spatial computing, SwiftUI volumetric interfaces, and Liquid Glass design implementation
+color: indigo
+---
+
 # visionOS Spatial Engineer
 
 **Specialization**: Native visionOS spatial computing, SwiftUI volumetric interfaces, and Liquid Glass design implementation.

--- a/specialized/agents-orchestrator.md
+++ b/specialized/agents-orchestrator.md
@@ -1,5 +1,5 @@
 ---
-name: agents-orchestrator
+name: Agents Orchestrator
 description: Autonomous pipeline manager that orchestrates the entire development workflow. You are the leader of this process.
 color: cyan
 ---

--- a/specialized/data-analytics-reporter.md
+++ b/specialized/data-analytics-reporter.md
@@ -1,5 +1,5 @@
 ---
-name: data-analytics-reporter
+name: Data Analytics Reporter
 description: Expert data analyst transforming raw data into actionable business insights. Creates dashboards, performs statistical analysis, tracks KPIs, and provides strategic decision support through data visualization and reporting.
 tools: WebFetch, WebSearch, Read, Write, Edit, Bash
 ---

--- a/testing/testing-evidence-collector.md
+++ b/testing/testing-evidence-collector.md
@@ -1,5 +1,5 @@
 ---
-name: EvidenceQA
+name: Evidence Collector
 description: Screenshot-obsessed, fantasy-allergic QA specialist - Default to finding 3-5 issues, requires visual proof for everything
 color: orange
 ---

--- a/testing/testing-reality-checker.md
+++ b/testing/testing-reality-checker.md
@@ -1,5 +1,5 @@
 ---
-name: testing-reality-checker
+name: Reality Checker
 description: Stops fantasy approvals, evidence-based certification - Default to "NEEDS WORK", requires overwhelming proof for production readiness
 color: red
 ---


### PR DESCRIPTION
## Summary
- Update 19 agent `name:` fields from slug-style (e.g. `engineering-ai-engineer`) or code-style (e.g. `ArchitectUX`) to clean human-readable names (e.g. `AI Engineer`, `UX Architect`)
- Add missing YAML frontmatter to 2 spatial-computing agents (`visionos-spatial-engineer.md`, `terminal-integration-specialist.md`)
- All 51 agents now use consistent naming that aligns with the NEXUS strategy docs from PR #12

## Test plan
- [ ] Run `for f in {design,engineering,marketing,product,project-management,spatial-computing,specialized,support,testing}/*.md; do grep -m1 "^name:" "$f"; done` — confirm all 51 agents have human-readable names
- [ ] Confirm no slug-style or code-style names remain in frontmatter
- [ ] Spot-check names match what PR #12 strategy docs reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)