### PR TITLE
Remove hardcoded agent counts, add new agents to rosters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🎭 The Agency: 51 AI Specialists Ready to Transform Your Workflow
+# 🎭 The Agency: AI Specialists Ready to Transform Your Workflow
 
 > **A complete AI agency at your fingertips** - From frontend wizards to Reddit community ninjas, from whimsy injectors to reality checkers. Each agent is a specialized expert with personality, processes, and proven deliverables.
 
@@ -10,7 +10,7 @@
 
 ## 🚀 What Is This?
 
-Born from a Reddit thread and months of iteration, **The Agency** is a collection of 51 meticulously crafted AI agent personalities. Each agent is:
+Born from a Reddit thread and months of iteration, **The Agency** is a growing collection of meticulously crafted AI agent personalities. Each agent is:
 
 - **🎯 Specialized**: Deep expertise in their domain (not generic prompt templates)
 - **🧠 Personality-Driven**: Unique voice, communication style, and approach
@@ -47,7 +47,7 @@ Browse the agents below and copy/adapt the ones you need!
 
 ## 🎨 The Agency Roster
 
-### 💻 Engineering Division (7 Agents)
+### 💻 Engineering Division
 
 Building the future, one commit at a time.
 
@@ -61,7 +61,7 @@ Building the future, one commit at a time.
 | ⚡ [Rapid Prototyper](engineering/engineering-rapid-prototyper.md) | Fast POC development, MVPs | Quick proof-of-concepts, hackathon projects, fast iteration |
 | 💎 [Senior Developer](engineering/engineering-senior-developer.md) | Laravel/Livewire, advanced patterns | Complex implementations, architecture decisions |
 
-### 🎨 Design Division (6 Agents)
+### 🎨 Design Division
 
 Making it beautiful, usable, and delightful.
 
@@ -73,8 +73,9 @@ Making it beautiful, usable, and delightful.
 | 🎭 [Brand Guardian](design/design-brand-guardian.md) | Brand identity, consistency, positioning | Brand strategy, identity development, guidelines |
 | 📖 [Visual Storyteller](design/design-visual-storyteller.md) | Visual narratives, multimedia content | Compelling visual stories, brand storytelling |
 | ✨ [Whimsy Injector](design/design-whimsy-injector.md) | Personality, delight, playful interactions | Adding joy, micro-interactions, Easter eggs, brand personality |
+| 📷 [Image Prompt Engineer](design/design-image-prompt-engineer.md) | AI image generation prompts, photography | Photography prompts for Midjourney, DALL-E, Stable Diffusion |
 
-### 📢 Marketing Division (8 Agents)
+### 📢 Marketing Division
 
 Growing your audience, one authentic interaction at a time.
 
@@ -89,7 +90,7 @@ Growing your audience, one authentic interaction at a time.
 | 📱 [App Store Optimizer](marketing/marketing-app-store-optimizer.md) | ASO, conversion optimization, discoverability | App marketing, store optimization, app growth |
 | 🌐 [Social Media Strategist](marketing/marketing-social-media-strategist.md) | Cross-platform strategy, campaigns | Overall social strategy, multi-platform campaigns |
 
-### 📊 Product Division (3 Agents)
+### 📊 Product Division
 
 Building the right thing at the right time.
 
@@ -99,7 +100,7 @@ Building the right thing at the right time.
 | 🔍 [Trend Researcher](product/product-trend-researcher.md) | Market intelligence, competitive analysis | Market research, opportunity assessment, trend identification |
 | 💬 [Feedback Synthesizer](product/product-feedback-synthesizer.md) | User feedback analysis, insights extraction | Feedback analysis, user insights, product priorities |
 
-### 🎬 Project Management Division (5 Agents)
+### 🎬 Project Management Division
 
 Keeping the trains running on time (and under budget).
 
@@ -111,7 +112,7 @@ Keeping the trains running on time (and under budget).
 | 🧪 [Experiment Tracker](project-management/project-management-experiment-tracker.md) | A/B tests, hypothesis validation | Experiment management, data-driven decisions, testing |
 | 👔 [Senior Project Manager](project-management/project-manager-senior.md) | Realistic scoping, task conversion | Converting specs to tasks, scope management |
 
-### 🧪 Testing Division (7 Agents)
+### 🧪 Testing Division
 
 Breaking things so users don't have to.
 
@@ -125,7 +126,7 @@ Breaking things so users don't have to.
 | 🛠️ [Tool Evaluator](testing/testing-tool-evaluator.md) | Technology assessment, tool selection | Evaluating tools, software recommendations, tech decisions |
 | 🔄 [Workflow Optimizer](testing/testing-workflow-optimizer.md) | Process analysis, workflow improvement | Process optimization, efficiency gains, automation opportunities |
 
-### 🛟 Support Division (6 Agents)
+### 🛟 Support Division
 
 The backbone of the operation.
 
@@ -138,7 +139,7 @@ The backbone of the operation.
 | ⚖️ [Legal Compliance Checker](support/support-legal-compliance-checker.md) | Compliance, regulations, legal review | Legal compliance, regulatory requirements, risk management |
 | 📑 [Executive Summary Generator](support/support-executive-summary-generator.md) | C-suite communication, strategic summaries | Executive reporting, strategic communication, decision support |
 
-### 🥽 Spatial Computing Division (6 Agents)
+### 🥽 Spatial Computing Division
 
 Building the immersive future.
 
@@ -151,7 +152,7 @@ Building the immersive future.
 | 🍎 [visionOS Spatial Engineer](spatial-computing/visionos-spatial-engineer.md) | Apple Vision Pro development | Vision Pro apps, spatial computing experiences |
 | 🔌 [Terminal Integration Specialist](spatial-computing/terminal-integration-specialist.md) | Terminal integration, command-line tools | CLI tools, terminal workflows, developer tools |
 
-### 🎯 Specialized Division (3 Agents)
+### 🎯 Specialized Division
 
 The unique specialists who don't fit in a box.
 
@@ -160,6 +161,9 @@ The unique specialists who don't fit in a box.
 | 🎭 [Agents Orchestrator](specialized/agents-orchestrator.md) | Multi-agent coordination, workflow management | Complex projects requiring multiple agent coordination |
 | 📊 [Data Analytics Reporter](specialized/data-analytics-reporter.md) | Business intelligence, data insights | Deep data analysis, business metrics, strategic insights |
 | 🔍 [LSP/Index Engineer](specialized/lsp-index-engineer.md) | Language Server Protocol, code intelligence | Code intelligence systems, LSP implementation, semantic indexing |
+| 📥 [Sales Data Extraction Agent](specialized/sales-data-extraction-agent.md) | Excel monitoring, sales metric extraction | Sales data ingestion, MTD/YTD/Year End metrics |
+| 📈 [Data Consolidation Agent](specialized/data-consolidation-agent.md) | Sales data aggregation, dashboard reports | Territory summaries, rep performance, pipeline snapshots |
+| 📬 [Report Distribution Agent](specialized/report-distribution-agent.md) | Automated report delivery | Territory-based report distribution, scheduled sends |
 
 ---
 
@@ -286,7 +290,7 @@ Each agent is designed with:
 
 ## 📊 Stats
 
-- 🎭 **51 Specialized Agents** across 9 divisions
+- 🎭 **55+ Specialized Agents** across 9 divisions
 - 📝 **10,000+ lines** of personality, process, and code examples
 - ⏱️ **Months of iteration** from real-world usage
 - 🌟 **Battle-tested** in production environments

--- a/design/design-image-prompt-engineer.md
+++ b/design/design-image-prompt-engineer.md
@@ -1,5 +1,5 @@
 ---
-name: design-image-prompt-engineer
+name: Image Prompt Engineer
 description: Expert photography prompt engineer specializing in crafting detailed, evocative prompts for AI image generation. Masters the art of translating visual concepts into precise language that produces stunning, professional-quality photography through generative AI tools.
 color: amber
 ---

--- a/strategy/EXECUTIVE-BRIEF.md
+++ b/strategy/EXECUTIVE-BRIEF.md
@@ -6,7 +6,7 @@
 
 ## 1. SITUATION OVERVIEW
 
-The Agency comprises 51 specialized AI agents across 9 divisions — engineering, design, marketing, product, project management, testing, support, spatial computing, and specialized operations. Individually, each agent delivers expert-level output. **Without coordination, they produce conflicting decisions, duplicated effort, and quality gaps at handoff boundaries.** NEXUS transforms this collection into an orchestrated intelligence network with defined pipelines, quality gates, and measurable outcomes.
+The Agency comprises specialized AI agents across 9 divisions — engineering, design, marketing, product, project management, testing, support, spatial computing, and specialized operations. Individually, each agent delivers expert-level output. **Without coordination, they produce conflicting decisions, duplicated effort, and quality gaps at handoff boundaries.** NEXUS transforms this collection into an orchestrated intelligence network with defined pipelines, quality gates, and measurable outcomes.
 
 ## 2. KEY FINDINGS
 
@@ -30,7 +30,7 @@ The Agency comprises 51 specialized AI agents across 9 divisions — engineering
 
 | Deliverable | Description |
 |-------------|-------------|
-| **Master Strategy** | 800+ line operational doctrine covering all 51 agents across 7 phases |
+| **Master Strategy** | 800+ line operational doctrine covering all agents across 7 phases |
 | **Phase Playbooks** (7) | Step-by-step activation sequences with agent prompts, timelines, and quality gates |
 | **Activation Prompts** | Ready-to-use prompt templates for every agent in every pipeline role |
 | **Handoff Templates** (7) | Standardized formats for QA pass/fail, escalation, phase gates, sprints, incidents |
@@ -41,7 +41,7 @@ The Agency comprises 51 specialized AI agents across 9 divisions — engineering
 
 | Mode | Agents | Timeline | Use Case |
 |------|--------|----------|----------|
-| **NEXUS-Full** | All 51 | 12-24 weeks | Complete product lifecycle |
+| **NEXUS-Full** | All | 12-24 weeks | Complete product lifecycle |
 | **NEXUS-Sprint** | 15-25 | 2-6 weeks | Feature or MVP build |
 | **NEXUS-Micro** | 5-10 | 1-5 days | Targeted task execution |
 
@@ -92,4 +92,4 @@ strategy/
 
 ---
 
-*NEXUS: 51 Agents. 9 Divisions. 7 Phases. One Unified Strategy.*
+*NEXUS: 9 Divisions. 7 Phases. One Unified Strategy.*

--- a/strategy/QUICKSTART.md
+++ b/strategy/QUICKSTART.md
@@ -6,13 +6,13 @@
 
 ## What is NEXUS?
 
-**NEXUS** (Network of EXperts, Unified in Strategy) turns The Agency's 51 AI specialists into a coordinated pipeline. Instead of activating agents one at a time and hoping they work together, NEXUS defines exactly who does what, when, and how quality is verified at every step.
+**NEXUS** (Network of EXperts, Unified in Strategy) turns The Agency's AI specialists into a coordinated pipeline. Instead of activating agents one at a time and hoping they work together, NEXUS defines exactly who does what, when, and how quality is verified at every step.
 
 ## Choose Your Mode
 
 | I want to... | Use | Agents | Time |
 |-------------|-----|--------|------|
-| Build a complete product from scratch | **NEXUS-Full** | All 51 | 12-24 weeks |
+| Build a complete product from scratch | **NEXUS-Full** | All | 12-24 weeks |
 | Build a feature or MVP | **NEXUS-Sprint** | 15-25 | 2-6 weeks |
 | Do a specific task (bug fix, campaign, audit) | **NEXUS-Micro** | 5-10 | 1-5 days |
 
@@ -152,20 +152,20 @@ Evidence Collector verifies improvements.
 
 ---
 
-## 🎭 The 51 Agents at a Glance
+## 🎭 The Agents at a Glance
 
 ```
-ENGINEERING (7)     │ DESIGN (6)          │ MARKETING (8)
+ENGINEERING         │ DESIGN              │ MARKETING
 Frontend Developer  │ UI Designer         │ Growth Hacker
 Backend Architect   │ UX Researcher       │ Content Creator
 Mobile App Builder  │ UX Architect        │ Twitter Engager
 AI Engineer         │ Brand Guardian      │ TikTok Strategist
 DevOps Automator    │ Visual Storyteller  │ Instagram Curator
 Rapid Prototyper    │ Whimsy Injector     │ Reddit Community Builder
-Senior Developer    │                     │ App Store Optimizer
+Senior Developer    │ Image Prompt Eng.   │ App Store Optimizer
                     │                     │ Social Media Strategist
 ────────────────────┼─────────────────────┼──────────────────────
-PRODUCT (3)         │ PROJECT MGMT (5)    │ TESTING (7)
+PRODUCT             │ PROJECT MGMT        │ TESTING
 Sprint Prioritizer  │ Studio Producer     │ Evidence Collector
 Trend Researcher    │ Project Shepherd    │ Reality Checker
 Feedback Synthesizer│ Studio Operations   │ Test Results Analyzer
@@ -174,13 +174,13 @@ Feedback Synthesizer│ Studio Operations   │ Test Results Analyzer
                     │                     │ Tool Evaluator
                     │                     │ Workflow Optimizer
 ────────────────────┼─────────────────────┼──────────────────────
-SUPPORT (6)         │ SPATIAL (6)         │ SPECIALIZED (3)
+SUPPORT             │ SPATIAL             │ SPECIALIZED
 Support Responder   │ XR Interface Arch.  │ Agents Orchestrator
 Analytics Reporter  │ macOS Spatial/Metal │ Data Analytics Reporter
 Finance Tracker     │ XR Immersive Dev    │ LSP/Index Engineer
-Infra Maintainer    │ XR Cockpit Spec.    │
-Legal Compliance    │ visionOS Spatial    │
-Exec Summary Gen.   │ Terminal Integration│
+Infra Maintainer    │ XR Cockpit Spec.    │ Sales Data Extraction
+Legal Compliance    │ visionOS Spatial    │ Data Consolidation
+Exec Summary Gen.   │ Terminal Integration│ Report Distribution
 ```
 
 ---

--- a/strategy/nexus-strategy.md
+++ b/strategy/nexus-strategy.md
@@ -2,7 +2,7 @@
 
 ## The Agency's Complete Operational Playbook for Multi-Agent Orchestration
 
-> **NEXUS** transforms 51 independent AI specialists into a synchronized intelligence network. This is not a prompt collection — it is a **deployment doctrine** that turns The Agency into a force multiplier for any project, product, or organization.
+> **NEXUS** transforms The Agency's independent AI specialists into a synchronized intelligence network. This is not a prompt collection — it is a **deployment doctrine** that turns The Agency into a force multiplier for any project, product, or organization.
 
 ---
 
@@ -54,19 +54,19 @@ Individual agents are powerful. But without coordination, they produce:
 | **Fail Fast, Fix Fast** | Maximum 3 retries per task before escalation |
 | **Single Source of Truth** | One canonical spec, one task list, one architecture doc |
 
-### 1.3 The 51-Agent Roster by Division
+### 1.3 The Agent Roster by Division
 
 | Division | Agents | Primary NEXUS Role |
 |----------|--------|--------------------|
-| **Engineering** (7) | Frontend Developer, Backend Architect, Mobile App Builder, AI Engineer, DevOps Automator, Rapid Prototyper, Senior Developer | Build, deploy, and maintain all technical systems |
-| **Design** (6) | UI Designer, UX Researcher, UX Architect, Brand Guardian, Visual Storyteller, Whimsy Injector | Define visual identity, user experience, and brand consistency |
-| **Marketing** (8) | Growth Hacker, Content Creator, Twitter Engager, TikTok Strategist, Instagram Curator, Reddit Community Builder, App Store Optimizer, Social Media Strategist | Drive acquisition, engagement, and market presence |
-| **Product** (3) | Sprint Prioritizer, Trend Researcher, Feedback Synthesizer | Define what to build, when, and why |
-| **Project Management** (5) | Studio Producer, Project Shepherd, Studio Operations, Experiment Tracker, Senior Project Manager | Orchestrate timelines, resources, and cross-functional coordination |
-| **Testing** (7) | Evidence Collector, Reality Checker, Test Results Analyzer, Performance Benchmarker, API Tester, Tool Evaluator, Workflow Optimizer | Verify quality through evidence-based assessment |
-| **Support** (6) | Support Responder, Analytics Reporter, Finance Tracker, Infrastructure Maintainer, Legal Compliance Checker, Executive Summary Generator | Sustain operations, compliance, and business intelligence |
-| **Spatial Computing** (6) | XR Interface Architect, macOS Spatial/Metal Engineer, XR Immersive Developer, XR Cockpit Interaction Specialist, visionOS Spatial Engineer, Terminal Integration Specialist | Build immersive and spatial computing experiences |
-| **Specialized** (3) | Agents Orchestrator, Data Analytics Reporter, LSP/Index Engineer | Cross-cutting coordination, deep analytics, and code intelligence |
+| **Engineering** | Frontend Developer, Backend Architect, Mobile App Builder, AI Engineer, DevOps Automator, Rapid Prototyper, Senior Developer | Build, deploy, and maintain all technical systems |
+| **Design** | UI Designer, UX Researcher, UX Architect, Brand Guardian, Visual Storyteller, Whimsy Injector, Image Prompt Engineer | Define visual identity, user experience, and brand consistency |
+| **Marketing** | Growth Hacker, Content Creator, Twitter Engager, TikTok Strategist, Instagram Curator, Reddit Community Builder, App Store Optimizer, Social Media Strategist | Drive acquisition, engagement, and market presence |
+| **Product** | Sprint Prioritizer, Trend Researcher, Feedback Synthesizer | Define what to build, when, and why |
+| **Project Management** | Studio Producer, Project Shepherd, Studio Operations, Experiment Tracker, Senior Project Manager | Orchestrate timelines, resources, and cross-functional coordination |
+| **Testing** | Evidence Collector, Reality Checker, Test Results Analyzer, Performance Benchmarker, API Tester, Tool Evaluator, Workflow Optimizer | Verify quality through evidence-based assessment |
+| **Support** | Support Responder, Analytics Reporter, Finance Tracker, Infrastructure Maintainer, Legal Compliance Checker, Executive Summary Generator | Sustain operations, compliance, and business intelligence |
+| **Spatial Computing** | XR Interface Architect, macOS Spatial/Metal Engineer, XR Immersive Developer, XR Cockpit Interaction Specialist, visionOS Spatial Engineer, Terminal Integration Specialist | Build immersive and spatial computing experiences |
+| **Specialized** | Agents Orchestrator, Data Analytics Reporter, LSP/Index Engineer, Sales Data Extraction Agent, Data Consolidation Agent, Report Distribution Agent | Cross-cutting coordination, deep analytics, and code intelligence |
 
 ---
 
@@ -121,7 +121,7 @@ NEXUS supports three deployment configurations:
 
 | Mode | Agents Active | Use Case | Timeline |
 |------|--------------|----------|----------|
-| **NEXUS-Full** | All 51 | Enterprise product launch, full lifecycle | 12-24 weeks |
+| **NEXUS-Full** | All | Enterprise product launch, full lifecycle | 12-24 weeks |
 | **NEXUS-Sprint** | 15-25 | Feature development, MVP build | 2-6 weeks |
 | **NEXUS-Micro** | 5-10 | Bug fix, content campaign, single deliverable | 1-5 days |
 
@@ -954,6 +954,7 @@ Use the NEXUS QA Feedback Loop Protocol format
 | Brand Guardian | Brand identity, consistency, positioning | Brand strategy or consistency audit |
 | Visual Storyteller | Visual narratives, multimedia content | Visual content or storytelling needs |
 | Whimsy Injector | Micro-interactions, delight, personality | Adding joy and personality to UX |
+| Image Prompt Engineer | AI image generation prompts, photography | Photography prompt creation for AI tools |
 
 ### Marketing Division — "Grow It Fast"
 | Agent | Superpower | Activation Trigger |
@@ -1020,6 +1021,9 @@ Use the NEXUS QA Feedback Loop Protocol format
 | Agents Orchestrator | Multi-agent pipeline management | Any multi-agent workflow |
 | Data Analytics Reporter | Business intelligence, deep analytics | Deep data analysis |
 | LSP/Index Engineer | Language Server Protocol, code intelligence | Code intelligence systems |
+| Sales Data Extraction Agent | Excel monitoring, sales metric extraction | Sales data ingestion |
+| Data Consolidation Agent | Sales data aggregation, dashboard reports | Territory and rep reporting |
+| Report Distribution Agent | Automated report delivery | Scheduled report distribution |
 
 ---
 
@@ -1088,7 +1092,7 @@ Use the NEXUS QA Feedback Loop Protocol format
 | **Handoff** | Structured transfer of work and context between agents |
 | **Gate Keeper** | Agent(s) with authority to approve or reject phase advancement |
 | **Escalation** | Routing a blocked task to higher authority after retry exhaustion |
-| **NEXUS-Full** | Complete pipeline activation with all 51 agents |
+| **NEXUS-Full** | Complete pipeline activation with all agents |
 | **NEXUS-Sprint** | Focused pipeline with 15-25 agents for feature/MVP work |
 | **NEXUS-Micro** | Targeted activation of 5-10 agents for specific tasks |
 | **Pipeline Integrity** | Principle that no phase advances without passing its quality gate |
@@ -1099,7 +1103,7 @@ Use the NEXUS QA Feedback Loop Protocol format
 
 <div align="center">
 
-**🌐 NEXUS: 51 Agents. 9 Divisions. 7 Phases. One Unified Strategy. 🌐**
+**🌐 NEXUS: 9 Divisions. 7 Phases. One Unified Strategy. 🌐**
 
 *From discovery to sustained operations — every agent knows their role, their timing, and their handoff.*
 


### PR DESCRIPTION
## Summary
- Remove all hardcoded "51" agent counts from README and strategy docs (NEXUS, QUICKSTART, EXECUTIVE-BRIEF) to eliminate maintenance burden as new agents are contributed
- Add 4 new agents to all roster listings: Image Prompt Engineer (Design, from PR #10), Sales Data Extraction Agent, Data Consolidation Agent, Report Distribution Agent (Specialized, from PR #14)
- Fix slug-style `name:` on Image Prompt Engineer frontmatter to match naming convention from PR #15

## Test plan
- [ ] `grep -rn "\b51\b" README.md strategy/` returns no matches
- [ ] All division roster tables include the new agents
- [ ] QUICKSTART ASCII roster grid includes new agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)