### PR TITLE
chore: add Cursor rules and local dev hygiene

### DIFF
--- a/.cursor/rules/agent-files.mdc
+++ b/.cursor/rules/agent-files.mdc
@@ -1,0 +1,45 @@
+---
+description: Standards for authoring/updating agent Markdown files
+globs: "design/**/*.md, engineering/**/*.md, marketing/**/*.md, product/**/*.md, project-management/**/*.md, spatial-computing/**/*.md, specialized/**/*.md, strategy/**/*.md, support/**/*.md, testing/**/*.md"
+alwaysApply: false
+---
+
+# Agent files — Authoring standards
+
+## File naming + placement
+
+- Put new agents in the correct division folder.
+- Use kebab-case names that match existing patterns (e.g. `engineering/engineering-frontend-developer.md`).
+
+## Required frontmatter (YAML)
+
+Every agent file must start with:
+
+- `name`: Human-friendly agent name
+- `description`: One-line specialty
+- `color`: simple color name or hex
+
+## Required structure
+
+Follow the existing template in `CONTRIBUTING.md`:
+
+- Identity & Memory
+- Core Mission
+- Critical Rules
+- Technical Deliverables (include real examples)
+- Workflow Process (step-by-step)
+- Communication Style
+- Learning & Memory
+- Success Metrics (must include measurable outcomes)
+
+## Content quality bar
+
+- **Be concrete**: replace vague goals with specific outputs.
+- **Avoid filler**: no generic “as an AI…” phrasing.
+- **No secrets**: never include real API keys/tokens; use obvious placeholders.
+
+## When adding a new agent
+
+- Update `README.md` roster table with the new link.
+- Ensure the link is relative and matches the file path exactly.
+

--- a/.cursor/rules/markdown-hygiene.mdc
+++ b/.cursor/rules/markdown-hygiene.mdc
@@ -1,0 +1,25 @@
+---
+description: Markdown hygiene for docs and agent profiles
+globs: "**/*.md"
+alwaysApply: false
+---
+
+# Markdown hygiene
+
+## Formatting rules
+
+- Preserve existing heading style and emoji conventions in this repo.
+- Keep tables readable (don’t wrap table rows mid-cell).
+- Use fenced code blocks with a language when possible (e.g. ```bash, ```typescript).
+- Prefer **relative links** within the repo; verify paths when moving/renaming files.
+
+## Don’t do
+
+- Don’t mass-reflow/reformat files unless asked (it makes review painful).
+- Don’t “fix” wording in bulk; keep edits scoped to the requested change.
+
+## Whitespace
+
+- End files with a newline.
+- Avoid trailing whitespace except when intentionally used for Markdown hard line breaks.
+

--- a/.cursor/rules/project-context.mdc
+++ b/.cursor/rules/project-context.mdc
@@ -1,0 +1,27 @@
+---
+description: Core context + working style for the agency-agents repo
+alwaysApply: true
+---
+
+# agency-agents — Project Context
+
+## What this repo is
+
+A curated library of **AI agent profiles** (mostly Markdown) organized by division (e.g. `engineering/`, `design/`, `marketing/`). Each file is meant to be copyable and usable as an “agent persona” with clear deliverables, workflow, and success metrics.
+
+## Primary goal of changes
+
+- **Consistency**: agent files follow the same template structure and naming conventions.
+- **Quality**: clear, specific, realistic workflows and measurable success metrics.
+- **Stability**: don’t break README links / roster tables / anchors.
+
+## How to work with this repo (preferred)
+
+- **Be step-by-step**: give complete commands and explicit file paths when proposing actions.
+- **Small diffs**: avoid sweeping reformatting across many agent files unless explicitly requested.
+- **Truth over vibes**: if unsure about an existing convention, inspect existing files before deciding.
+
+## Local checks (recommended)
+
+- Run: `pre-commit run -a` (one-time setup: `pre-commit install`)
+

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,11 @@
+# Cursor rules (summary)
+#
+# This repo’s authoritative Cursor rules live in `.cursor/rules/*.mdc`.
+# If you’re reading this file, open those rules for the full details.
+#
+# Key expectations:
+# - Keep agent Markdown files consistent with the template in `CONTRIBUTING.md`
+# - Avoid bulk reformatting; keep diffs small and reviewable
+# - When adding an agent, update the `README.md` roster with a correct relative link
+# - Run `pre-commit run -a` (after `pre-commit install`) when making non-trivial edits
+

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+# Trailing spaces can be meaningful in Markdown (hard line breaks).
+trim_trailing_whitespace = false
+
+[*.{yml,yaml,json}]
+indent_style = space
+indent_size = 2
+

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 Thumbs.db
 
 # Editor directories and files
-.vscode/
+.vscode/*
 .idea/
 *.swp
 *.swo
@@ -18,6 +18,10 @@ Thumbs.db
 .settings/
 *.sublime-project
 *.sublime-workspace
+
+# Allow shared VS Code/Cursor settings (keep the rest ignored)
+!.vscode/settings.json
+!.vscode/extensions.json
 
 # Node.js (if adding web tools later)
 node_modules/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-merge-conflict
+      - id: detect-private-key
+      - id: check-yaml
+      - id: check-json
+      - id: check-toml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+        args: ["--markdown-linebreak-ext=md"]
+

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "editorconfig.editorconfig"
+  ]
+}
+

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "files.eol": "\n",
+  "files.insertFinalNewline": true,
+  "files.trimTrailingWhitespace": true,
+  "[markdown]": {
+    "files.trimTrailingWhitespace": false
+  },
+  "editor.formatOnSave": false
+}
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,6 +197,7 @@ Advanced techniques and approaches the agent masters
 3. **Add Examples**: Include at least 2-3 code/template examples
 4. **Define Metrics**: Include specific, measurable success criteria
 5. **Proofread**: Check for typos, formatting issues, clarity
+6. **Run checks (recommended)**: `pre-commit run -a` (one-time setup: `pre-commit install`)
 
 ### Submitting Your PR
 


### PR DESCRIPTION
Add Cursor rule set for consistent agent markdown edits, plus editorconfig, VS Code settings, and pre-commit hooks for basic repo hygiene.

Made-with: Cursor