### PR TITLE
Add 30-day content strategy for Ina J Photography coaching business

### DIFF
--- a/marketing/inaj-photography-30-day-content-strategy.md
+++ b/marketing/inaj-photography-30-day-content-strategy.md
@@ -1,0 +1,1047 @@
+# Ina J Photography: 30-Day Content Strategy
+## Building Authority as a Pet Photography Business Coach
+
+**Goal:** Build Ina's authority as THE go-to business coach for pet photographers, grow the Pet Photographers Collective Skool community, and drive enrolments in the [Consistent Bookings Program 2026](https://www.inajphotography.com.au/the-consistent-bookings-program-2026).
+
+**Ideal Client:** Established pet photographers who already have the talent but can't crack consistent bookings with clients who invest $1,000+. They're tired of feast-or-famine cycles, relying on word of mouth, and piecing together advice from random Facebook groups.
+
+**Voice:** Warm, direct, practical. Mentor-in-the-trenches. Not a pedestal. Coffee-across-the-table honesty. Never toxic-positive. Normalises struggle without romanticising it.
+
+**Skills applied:** `Claude-brand-voice-skill` (coaching register) + `ideal-client-lens` checkpoints
+
+---
+
+## Content Architecture
+
+### Four Pillars
+| Pillar | Purpose | Frequency |
+|--------|---------|-----------|
+| **Educate** | Frameworks, diagnostics, tactics (3 Gaps, Selling as Service, Client Journey) | 40% |
+| **Story** | Real moments from Ina's business + member journey stories | 30% |
+| **Social Proof** | Member wins, results, community highlights | 20% |
+| **Conversion** | Collective invites, CBP 2026 enrolment, workshops | 10% |
+
+### Weekly Volume
+- **Instagram:** 3–4 posts (mix of Reels, Carousels, Single Images)
+- **Skool Community:** 3 posts per week
+- **Email Newsletter:** 1 per week (sent Tuesdays)
+
+### Buyer Journey Arc
+| Week | Stage | Theme |
+|------|-------|-------|
+| Week 1 (Days 1–7) | Unaware → Problem-Aware | "You're not alone" |
+| Week 2 (Days 8–14) | Problem-Aware → Solution-Aware | "Here's what's actually going on" |
+| Week 3 (Days 15–21) | Solution-Aware → Product-Aware | "Here's what's possible" |
+| Week 4 (Days 22–28) | Product-Aware → Conversion | "Here's the system" |
+| Days 29–30 | Active Members | "The community is the point" |
+
+---
+
+## Week 1: "You're Not Alone"
+**Goal:** Name the pain point before they can. Establish Ina as someone who genuinely gets the pet photography struggle. Build awareness with photographers who are lurking.
+
+---
+
+### DAY 1 — Instagram Reel
+**Pillar:** Story + Authority | **Buyer Stage:** Unaware → Problem-Aware
+
+**Hook (first 3 seconds):**
+> "If your calendar is looking emptier than you'd like right now — this is for you."
+
+**Script:**
+> Your work is good. That is not the problem.
+>
+> I've spoken to hundreds of pet photographers over the past few years. And almost every single one of them starts by apologising for their work. "I know I still have a lot to learn..." "My portfolio isn't quite there yet..."
+>
+> And then I look at their work and it's *stunning.*
+>
+> The problem isn't your photography. The problem is that good work plus random marketing equals random bookings. Every single time.
+>
+> You post when you feel inspired. You promote when you panic. You get a great enquiry and then nothing for three weeks. Sound familiar?
+>
+> There's a name for what's happening. And once you know what it is, you can fix it.
+>
+> Stay with me this month — I'll show you exactly what I mean.
+
+**CTA:** "Follow for more — this month I'm pulling back the curtain on what actually drives consistent bookings."
+
+**Caption:**
+> Your work is good. That is not the problem.
+>
+> I've talked to hundreds of pet photographers over the years, and almost every single one starts the conversation by apologising for their work.
+>
+> "I know my portfolio isn't quite there yet..."
+> "I still have so much to learn..."
+>
+> And then I look at their images. And they're stunning.
+>
+> The issue isn't the photography. It's this:
+>
+> Good work + random marketing = random bookings. Every single time.
+>
+> You post when you feel inspired. You promote when you panic. Rinse and repeat.
+>
+> This month I'm talking about what actually drives consistent bookings — the kind where you know where your next client is coming from, and why.
+>
+> Follow along. This one's for you.
+>
+> Drop a comment if this sounds familiar. I'd love to know where you're at right now.
+
+---
+
+### DAY 2 — Skool Community Post
+**Pillar:** Community + Diagnose | **Buyer Stage:** Active Members
+
+**Post:**
+> Let's start with some honesty.
+>
+> Where did your last three bookings come from?
+>
+> Not your last three enquiries — your last three *actual bookings.*
+>
+> Real answers only. I'll go first: mine came from my fortnightly email newsletter, a returning client, and a Google search.
+>
+> Drop yours below. No judgment — this is exactly the kind of data we need to look at if we want to create consistency rather than crossing our fingers.
+
+**Why this works:** Mirrors the VoC language ("real answers", "consistency") and the internal dialogue of someone who feels random/unpredictable. Creates immediate engagement while building diagnostic data Ina can reference in future content.
+
+---
+
+### DAY 3 — Email Newsletter
+**Pillar:** Story + Educate | **Buyer Stage:** Problem-Aware
+**Subject line:** `Good work + random marketing = ?`
+**Send day:** Tuesday
+
+**Body:**
+> Something a pet photographer told me last month has stayed with me.
+>
+> She'd been in business for seven years. Award-winning images. Genuinely lovely client experience. And she said: *"I had a good year last year. Awards, great clients. But this year I just feel... nowhere near."*
+>
+> I hear versions of this constantly.
+>
+> Great photographers. Inconsistent bookings. And a creeping sense that maybe the work isn't good enough after all.
+>
+> Here's what I want you to hear: your work is good. That is not the problem.
+>
+> The problem — and I say this with genuine care — is that most pet photographers are running their marketing on vibes and hope. You post when you feel inspired. You send an email when you remember you have a list. You run a promotion when the calendar looks empty and you're starting to panic.
+>
+> And then you wonder why enquiries feel random and unpredictable.
+>
+> Because they are. Not because of your work. Because of the system.
+>
+> Or rather, the lack of one.
+>
+> Next week I'm going to show you the exact framework I use to diagnose what's actually going wrong when bookings are inconsistent. It's called the 3 Gaps — and it changes everything once you see it.
+>
+> But before I do, I want to ask you one thing:
+>
+> **When did you last actually look at where your clients are coming from?**
+>
+> Not a rough guess. The actual breakdown. Hit reply and tell me in one sentence. I read every single one.
+>
+> Ina
+
+---
+
+### DAY 4 — Instagram Carousel
+**Pillar:** Educate | **Buyer Stage:** Problem-Aware
+**Slides:**
+
+**Slide 1 (Hook):**
+> 5 signs your bookings are inconsistent for fixable reasons
+> (Not because your work isn't good enough)
+
+**Slide 2:**
+> You can't trace your last 5 clients back to a specific channel.
+> Word of mouth "just happened." You're not sure why they found you.
+
+**Slide 3:**
+> You promote when you panic.
+> When the calendar looks empty, you suddenly remember you should be marketing. Then it fills up and you stop again.
+
+**Slide 4:**
+> You're getting enquiries but they're the wrong fit.
+> People who only want digitals. People who baulk at your prices. You're visible — just to the wrong audience.
+
+**Slide 5:**
+> You feel like you need to lower your prices to compete.
+> But something in you knows that's not actually the answer.
+
+**Slide 6:**
+> You know you need to market but you don't know what to prioritise.
+> Instagram? Email? Ads? Referral program? You start things and don't finish them.
+
+**Slide 7 (CTA):**
+> If two or more of these felt familiar — it's not a you problem. It's a system problem.
+> Comment **GAPS** below and I'll send you the one-pager that explains what's actually happening.
+
+**Caption (carousel):**
+> 5 signs your bookings are inconsistent for fixable reasons — not because your work isn't good enough.
+>
+> Swipe through and see how many feel familiar.
+>
+> The hard truth? Inconsistent bookings are almost never a photography problem. They're almost always a system problem. And systems can be fixed.
+>
+> Comment GAPS below and I'll send you a free one-pager that helps you identify exactly which gap is yours — visibility, message, or conversion.
+
+---
+
+### DAY 5 — Skool Community Post
+**Pillar:** Community + Diagnose | **Buyer Stage:** Active Members
+
+**Post:**
+> Real talk time. I'm planning next month's content and workshops around what *you* are actually dealing with — not what I think you're dealing with.
+>
+> Honest poll below. What's your biggest struggle right now?
+>
+> 🔴 Inconsistent bookings (not enough leads coming in)
+> 🟠 Selling / conversion (leads come in but don't convert, or don't spend what I want)
+> 🟡 Not knowing what to focus on (I have ideas but no clear priority)
+> 🟢 Time and overwhelm (I know what to do, I just can't seem to do it)
+> 🔵 Messaging (I'm not sure I'm attracting the right clients)
+>
+> Drop your emoji in the comments. I genuinely mean this: your answer shapes what I create next.
+
+---
+
+### DAY 6 — Instagram Single Image
+**Pillar:** Story | **Buyer Stage:** Unaware → Problem-Aware
+
+**Caption:**
+> An email came in from a client this week that I wasn't expecting.
+>
+> She wrote that she'd had to unexpectedly put her cat down that day, and that she was forever grateful for the photos we had taken together. That she would cherish them always.
+>
+> I sat with that for a long time.
+>
+> Because here's the thing — she booked that session because my fortnightly newsletter landed in her inbox at exactly the right moment. She'd been thinking about it. She just needed the nudge.
+>
+> If I hadn't sent that email — if I'd talked myself out of it because "I don't want to be salesy" — she wouldn't have those images.
+>
+> If you're holding back from putting your work out there because you're afraid of coming across as pushy... I want to gently offer this:
+>
+> You're not being pushy. You're making it possible for someone to say yes before it's too late.
+>
+> What's your current follow-up system? Drop it below — I'm genuinely curious.
+
+---
+
+### DAY 7 — Instagram Stories Series
+**Pillar:** Authority + Behind-the-Scenes | **Buyer Stage:** Unaware
+
+**Story 1:** Behind-the-scenes clip of a session day.
+> "Day in the life: running a pet photography business in Canberra. It's a lot."
+
+**Story 2:** Poll
+> "Did you know I also coach pet photographers?"
+> 🟢 Yes! / 🔴 Wait, what?
+
+**Story 3:** (Auto-sends to those who voted "Wait, what?")
+> "Yep! I run a free community called Pet Photographers Collective — 300 photographers working on consistent bookings and ideal client marketing. Totally free. Link in bio if you want to come check it out."
+
+**Story 4:** Quick tip
+> "One thing I wish someone had told me earlier about booking $1,000+ clients: it's not about your pricing. It's about your positioning. More on this in a post this week."
+
+---
+
+## Week 2: "Here's What's Actually Going On"
+**Goal:** Give language to the struggle. Introduce the 3 Gaps framework. Shift from problem-naming to diagnosis. Position Ina as the person with the framework, not just the empathy.
+
+---
+
+### DAY 8 — Email Newsletter
+**Pillar:** Educate | **Buyer Stage:** Problem-Aware → Solution-Aware
+**Subject line:** `Is it a visibility problem or a conversion problem? (Most photographers guess wrong)`
+**Send day:** Tuesday
+
+**Body:**
+> Last week I asked where your last three clients came from.
+>
+> I heard back from a lot of you. And I noticed a pattern.
+>
+> Almost everyone assumed their problem was one of two things: either "I need more followers" or "I need to be better at selling."
+>
+> But when I looked at the actual situation — most of you had a *third* problem. One you hadn't even named yet.
+>
+> Here's the framework I use when bookings are inconsistent. I call it the 3 Gaps:
+>
+> **Gap 1: Visibility**
+> People don't know you exist, or they forget about you between sessions. Your marketing is sporadic. You show up in bursts and disappear for weeks. This is a reach and consistency problem.
+>
+> **Gap 2: Message**
+> People find you but don't *get* you. They enquire asking for "just digitals." They can't see why you're worth the investment. Your work is beautiful but your words aren't doing their job. This is a positioning and communication problem.
+>
+> **Gap 3: Conversion**
+> People love you, they want to book, but something's going wrong between "I'm interested" and "I'm in." Ghosting after consults. Sticker shock at the sales appointment. They need to think about it and then disappear. This is a process and confidence problem.
+>
+> Most photographers assume it's Gap 3 (selling skills). But in my experience, it's usually Gap 1 or Gap 2.
+>
+> **You can't convert people who haven't found you. And you can't convince people who haven't been pre-sold by your messaging.**
+>
+> Which gap is yours? Hit reply and tell me. I'll give you my honest take.
+>
+> Ina
+>
+> P.S. Next week I'm sharing what one of our Collective members did to shift from offering digitals only to her first $2,000+ sale. Worth watching for.
+
+---
+
+### DAY 9 — Instagram Reel
+**Pillar:** Educate | **Buyer Stage:** Problem-Aware → Solution-Aware
+
+**Hook (first 3 seconds):**
+> "Stop trying to fix your booking problem if you haven't done this first."
+
+**Script:**
+> Before you spend more on ads. Before you redesign your website. Before you post another reel hoping it'll change things — you need to know which gap is actually your problem.
+>
+> Here's the thing. When bookings are inconsistent, it's almost always one of three things: visibility, message, or conversion.
+>
+> Visibility means people don't know you exist. Your marketing is sporadic and you disappear between sessions.
+>
+> Message means people find you but they don't get why you're worth it. They enquire asking for "just digitals" because your content hasn't pre-sold the full experience.
+>
+> Conversion means the leads are coming in but something breaks down between "interested" and "booked." Ghosting after consults, sticker shock, radio silence after you send pricing.
+>
+> Most photographers assume it's a selling problem. But nine times out of ten it's actually a messaging problem, or a visibility problem.
+>
+> And those have completely different solutions.
+>
+> Comment **GAPS** below and I'll DM you a free one-page diagnostic to work out which one is yours.
+
+**Caption:**
+> Most pet photographers assume their booking problem is a selling problem.
+>
+> It usually isn't.
+>
+> When enquiries are inconsistent, it almost always comes down to one of three gaps:
+>
+> Visibility — people don't know you exist (or forget about you between sessions).
+> Message — people find you but don't understand why you're worth the investment.
+> Conversion — leads come in but something breaks between "interested" and "booked."
+>
+> Before you spend another dollar on ads or another hour redesigning your website — diagnose which gap is actually yours.
+>
+> Comment GAPS below and I'll DM you the free one-page diagnostic. Takes about 10 minutes and will tell you exactly what to focus on.
+
+---
+
+### DAY 10 — Skool Community Post
+**Pillar:** Educate + Community | **Buyer Stage:** Active Members
+
+**Post:**
+> Task time. (And yes — this one is worth doing.)
+>
+> Your challenge this week: trace your last five bookings back to their origin.
+>
+> Not just "word of mouth" — go deeper. *Who* referred them? What did they see or hear about you first? What was the touchpoint that made them think of you?
+>
+> And if you can't trace it? That's data too. That means your marketing is invisible to you, which often means it's invisible to them.
+>
+> Drop your findings in the comments. I'll look at each one and give you a specific observation back.
+>
+> No guessing. Real answers. This is how we build something you can actually replicate.
+
+---
+
+### DAY 11 — Instagram Carousel
+**Pillar:** Educate | **Buyer Stage:** Problem-Aware → Solution-Aware
+**Slides:**
+
+**Slide 1:**
+> The difference between a busy photographer and a profitable one
+> (It's not what you think)
+
+**Slide 2:**
+> **The busy photographer:**
+> Takes every enquiry. Runs promotions to fill gaps. Wonders why revenue doesn't match her effort. Exhausted.
+
+**Slide 3:**
+> **The profitable photographer:**
+> Books fewer sessions. Earns more per session. Has a waiting list. Has time to breathe.
+
+**Slide 4:**
+> The shift? Not working harder at marketing.
+> It's changing *what* she sells and *who* she sells it to.
+
+**Slide 5:**
+> "I noticed I worked less but generated the same revenue.
+> This means I was working with more of my ideal clients."
+> — Real quote from a Collective member
+
+**Slide 6:**
+> You don't have to book more sessions to make more money.
+> You have to change what you sell.
+
+**Slide 7 (CTA):**
+> Save this for when you're tempted to run another discount promotion.
+> And if you want to work through this — the Pet Photographers Collective is free. Link in bio.
+
+**Caption (carousel):**
+> You don't have to book more sessions to make more money.
+>
+> You have to change what you sell.
+>
+> Swipe to see the actual difference between a busy photographer and a profitable one — because they're not the same thing, and understanding the gap changed everything for me.
+>
+> Save this one. You'll want to come back to it.
+>
+> And if you want to work through this with 300 other pet photographers — the Collective is free. Link in bio.
+
+---
+
+### DAY 12 — Skool Community Post
+**Pillar:** Educate + Story | **Buyer Stage:** Active Members
+
+**Post:**
+> Real talk: selling doesn't have to feel salesy.
+>
+> I know. I know how that sounds. But stay with me.
+>
+> A few years ago I dreaded the sales conversation. I'd send the pricing and then just... wait. Hoping they'd say yes. Cringing when they didn't.
+>
+> Then someone reframed it for me in a way that genuinely changed things: **selling is service.** If I believe my work will genuinely enrich someone's life — and I do — then sharing it is an act of care, not an act of greed.
+>
+> The pet photographer who doesn't follow up because she doesn't want to be "pushy"? She's not protecting the client. She's protecting herself from discomfort.
+>
+> And in the meantime, someone out there doesn't have images of their dog. Yet.
+>
+> Where does selling feel uncomfortable for you? Tell me honestly — the specifics matter. Is it the follow-up? The in-person sales appointment? The pricing page? Let's talk about it.
+
+---
+
+### DAY 13 — Instagram Single Image
+**Pillar:** Story + Authority | **Buyer Stage:** Problem-Aware
+
+**Caption:**
+> Here's the truth nobody says when they talk about consistent bookings.
+>
+> I had a year where my calendar was basically empty. I had the work. I had the experience. I'd been in business long enough to know what I was doing.
+>
+> But I was doing what most photographers do: posting when I felt like it, promoting when I panicked, and relying on word of mouth to do the heavy lifting.
+>
+> And word of mouth is great — until it's not enough.
+>
+> What changed wasn't a magic marketing tactic. It was building a simple, boring, repeatable rhythm. A fortnightly newsletter. A clear weekly content plan. A system that worked even when I was exhausted or uninspired.
+>
+> "Consistency isn't about posting more. It's about having a simple weekly rhythm that tells you exactly what to do."
+>
+> Have you had a feast-or-famine phase? Tell me about it in the comments. You are not alone in this.
+
+---
+
+### DAY 14 — Email Newsletter
+**Pillar:** Story + Soft Offer | **Buyer Stage:** Solution-Aware
+**Subject line:** `What I actually changed to go from "hopefully it'll pick up" to fully booked`
+**Send day:** Tuesday
+
+**Body:**
+> I want to tell you about three specific things I changed in my photography business that shifted everything.
+>
+> Not motivation. Not mindset. Actual, practical things.
+>
+> **1. I stopped marketing reactively.**
+> Instead of posting when I felt inspired or promoting when I panicked, I built a simple weekly rhythm. Fortnightly email newsletter. Two to three social posts a week with a clear theme. A client follow-up sequence that ran whether I remembered or not.
+>
+> **2. I got obsessively clear on who I was talking to.**
+> I stopped trying to be for everyone. My content started speaking directly to a specific person — someone who loved their dog like a family member, who wanted artwork not just files, who understood the investment. When that happened, my enquiries changed quality overnight.
+>
+> **3. I stopped pricing apologetically.**
+> I had been defending my prices for years. Explaining them. Justifying them. The day I stopped doing that — the day I just stated them calmly and let my messaging do the work beforehand — my conversion rate went up.
+>
+> None of this is magic. All of it is learnable.
+>
+> If you want to be in a community of pet photographers who are working through exactly this — the Pet Photographers Collective is free to join. 300 photographers, real conversations, no fluff.
+>
+> Link below. Come find your people.
+>
+> [Join the Pet Photographers Collective — Free →](https://www.skool.com/pet-photographers-collective)
+>
+> Ina
+
+---
+
+## Week 3: "Here's What's Possible"
+**Goal:** Build trust through social proof, show real results, paint the before/after clearly. Shift from "this makes sense" to "I want that for myself."
+
+---
+
+### DAY 15 — Instagram Reel
+**Pillar:** Social Proof | **Buyer Stage:** Solution-Aware → Product-Aware
+
+**Hook:**
+> "She went from offering digitals only to her first $2,000+ sale in six weeks. Here's what changed."
+
+**Script:**
+> When she joined the Collective, she told me her biggest challenge was that every client seemed to only want digitals. She'd tried showing wall art samples. She'd tried product credits. Nothing was landing.
+>
+> But the problem wasn't her sales skills.
+>
+> It was that her messaging was attracting digital-only clients before they even enquired. Her content was talking about the photos. Not the experience. Not the artwork. Not the legacy.
+>
+> So we changed that. Not dramatically — just intentionally.
+>
+> Six weeks later she sent me a message. Her first $2,000+ sale. A client who came in asking specifically for a wall art collection.
+>
+> Her work hadn't changed. Her prices hadn't changed. Her messaging had.
+>
+> Comment **STORY** below and I'll tell you more about what she specifically changed.
+
+**Caption:**
+> She went from "everyone only wants digitals" to her first $2,000+ sale in six weeks.
+>
+> Her work didn't change.
+> Her prices didn't change.
+> Her messaging did.
+>
+> Before she joined the Collective, her content was all about the photos. Beautiful images. Technical skill. All of it.
+>
+> What it wasn't doing: showing the experience. The consultation. The artwork reveal. The wall piece that makes her clients cry happy tears every single time they walk past it.
+>
+> Once her content started telling THAT story — clients who wanted that experience started finding her.
+>
+> Comment STORY below and I'll share more about exactly what she changed.
+
+---
+
+### DAY 16 — Skool Community Post
+**Pillar:** Social Proof + Community | **Buyer Stage:** Active Members
+
+**Post:**
+> Wins thread — drop yours below.
+>
+> Big wins. Small wins. "I finally did the thing I've been putting off for three months" wins.
+>
+> A new enquiry. A completed task. A mindset shift. A sale that felt good. A conversation where you held your price and they said yes.
+>
+> All of it counts. We're celebrating it all this week.
+>
+> I'll start: this week I sent a newsletter to my photography clients that I'd been procrastinating on for two weeks. It went out. Two enquiries came in within 24 hours. Imperfect action, every time.
+>
+> Your turn.
+
+---
+
+### DAY 17 — Email Newsletter
+**Pillar:** Social Proof + Soft Sell | **Buyer Stage:** Product-Aware
+**Subject line:** `"I know I'm capable of this too" — what that moment looks like`
+**Send day:** Tuesday
+
+**Body:**
+> There's a moment I see over and over again inside the Collective.
+>
+> Someone shares a win. A $2,500 sale, a fully booked month, a client who came specifically for a wall art collection after seeing the newsletter. And someone else reads it and types:
+>
+> *"This is exactly what I want. I know I'm capable of this too."*
+>
+> That moment — that specific feeling of ambition lit up by someone else's proof — is what I built the Consistent Bookings Program for.
+>
+> Because "capable" is the right word. You already have the talent. You already care about your work in a way that most people never do for theirs.
+>
+> What you don't have yet is the system.
+>
+> The Consistent Bookings Program 2026 is a structured six-week program built specifically for pet photographers who want to:
+>
+> - Stop relying on word of mouth as their only source of bookings
+> - Attract clients who want artwork, not just files
+> - Build a simple marketing rhythm that doesn't require a social media addiction
+> - Charge what they're worth without apologising for it
+>
+> It's not a generic business course. Every example, every framework, every scenario is specific to pet photography.
+>
+> If you've been thinking about it — [here's the full details and enrolment link](https://www.inajphotography.com.au/the-consistent-bookings-program-2026).
+>
+> Questions? Hit reply. I'll give you a straight answer.
+>
+> Ina
+
+---
+
+### DAY 18 — Instagram Carousel
+**Pillar:** Social Proof + Educate | **Buyer Stage:** Product-Aware
+**Slides:**
+
+**Slide 1:**
+> What pet photographers in the Collective did differently this month
+> (Real results. Real shifts.)
+
+**Slide 2:**
+> **She traced her bookings for the first time.**
+> Discovered 80% came from one source she'd been ignoring. Doubled down. Her enquiries doubled within a month.
+
+**Slide 3:**
+> **She stopped offering digitals as the default.**
+> Changed her enquiry page, her consultation language, and her pricing structure. First wall art collection sale came 3 weeks later.
+
+**Slide 4:**
+> **She sent her first email newsletter.**
+> Had been putting it off for over a year. 47 subscribers. Two enquiries within 48 hours. "Why did I wait so long?"
+
+**Slide 5:**
+> None of these photographers changed their photography.
+> They changed their systems. Their messaging. Their rhythm.
+
+**Slide 6 (CTA):**
+> The Pet Photographers Collective is free.
+> 300 photographers doing exactly this work, every week.
+> Link in bio → come join the conversation.
+
+**Caption (carousel):**
+> None of these photographers changed their photography.
+>
+> They changed their systems. Their messaging. Their rhythm.
+>
+> Swipe to see three real shifts from photographers inside the Pet Photographers Collective this month — and the simple thing behind each one.
+>
+> None of it is dramatic. All of it is repeatable.
+>
+> The Collective is free. 300 pet photographers working on exactly this. Link in bio to join us.
+
+---
+
+### DAY 19 — Instagram Reel
+**Pillar:** Authority + Behind-the-Scenes | **Buyer Stage:** Solution-Aware
+
+**Hook:**
+> "What running both a photography business AND a coaching community actually looks like."
+
+**Script:**
+> People ask me how I do both. Honest answer: it's not always elegant.
+>
+> Monday is usually client editing and newsletter writing. Tuesday I'll have a consult or session. Wednesday I'm usually prepping for a coaching call or working on Collective content. Thursday and Friday rotate depending on what's on.
+>
+> The thing that makes it work isn't hustle. It's systems.
+>
+> My photography business runs on a fortnightly newsletter, a simple content plan, and a client journey that I've refined over years. It's not complicated. It's just consistent.
+>
+> And that's what I teach inside the Collective — not the grind. The rhythm.
+>
+> If you want to see what that looks like for your business, come join us. It's free. Three hundred photographers working on exactly this. Link in bio.
+
+**Caption:**
+> People ask how I run both a photography business and a coaching community.
+>
+> Honest answer: it's not always elegant. But it works because of one thing — systems, not hustle.
+>
+> My photography business runs on a fortnightly newsletter, a simple content rhythm, and a client journey I've refined over years. It doesn't require me to be "on" all the time. It just requires consistency.
+>
+> That's exactly what I teach inside the Collective — not the grind. The rhythm.
+>
+> If you're a pet photographer who wants to build a business that doesn't depend on you showing up everywhere all the time — come join us. It's free. Link in bio.
+
+---
+
+### DAY 20 — Skool Community Post
+**Pillar:** Educate | **Buyer Stage:** Active Members
+
+**Post:**
+> Let's talk about active vs. passive marketing.
+>
+> **Passive marketing** = things that work while you sleep. SEO, Google listings, email automations, lead magnets, word of mouth systems.
+>
+> **Active marketing** = things you actively do. Social media posts, networking, direct outreach, stories, showing up.
+>
+> Most photographers are doing only one of these (usually active, and sporadically). The photographers with consistent bookings have both running at the same time.
+>
+> Quick exercise: map your current channels into two columns. Active and passive. What do you have? What's missing?
+>
+> Drop your lists below. Let's look at them together.
+
+---
+
+### DAY 21 — Instagram Single Image
+**Pillar:** Story + Legacy | **Buyer Stage:** Unaware → Problem-Aware
+
+**Caption:**
+> A client sent me this last week.
+>
+> She wrote to say she'd had to put her dog down — unexpectedly, the way it always is — and that the session we did together last year was the most important thing she'd ever done.
+>
+> "I look at those photos every single day," she said. "Thank you for existing."
+>
+> I sat with this message for a long time.
+>
+> Because when bookings are inconsistent, it's easy to treat marketing as optional. As something you'll get to when things slow down, or when you have more time, or when you feel more confident about your work.
+>
+> But what you're really doing is making it harder for the right person to find you.
+>
+> The client who needs what you do — who needs to book now, before it's too late — can't book with someone she can't find.
+>
+> That's why the business side of this matters. Not for the money. For the access.
+>
+> What would it mean to you to have that kind of impact more consistently?
+
+---
+
+## Week 4: "Here's the System"
+**Goal:** Drive enrolments in the Consistent Bookings Program 2026. Remove friction. Answer objections. Make the next step feel safe and obvious.
+
+---
+
+### DAY 22 — Email Newsletter
+**Pillar:** Conversion | **Buyer Stage:** Product-Aware → Conversion
+**Subject line:** `The Consistent Bookings Program is open — here's who it's for (and who it's not)`
+**Send day:** Tuesday
+
+**Body:**
+> I want to be straightforward with you about this.
+>
+> The Consistent Bookings Program 2026 is not for everyone. And I'd rather tell you that upfront than have you join and feel like it wasn't the right fit.
+>
+> **It's for you if:**
+> You're an established pet photographer — you have paying clients, you know your work is solid, but your bookings are inconsistent and you can't quite figure out why. You want to charge $1,000+ and attract clients who value artwork and experience. You're tired of piecing together advice from random podcasts and Facebook groups and you're ready for a structured system.
+>
+> **It's not for you if:**
+> You're just starting out and still building your portfolio. Or if you're looking for a course to add to your collection without a genuine commitment to implementing it. (No judgment — just honesty.)
+>
+> **What's inside:**
+> - The 3 Gaps diagnostic: identifying exactly which part of your business needs attention
+> - A simple, repeatable marketing rhythm you can maintain without burning out
+> - Messaging work that attracts your ideal client before they ever enquire
+> - The full client journey: from first touch to wall art on their wall
+> - Sales conversation frameworks that feel like service, not pushing
+> - Live coaching and community accountability throughout
+>
+> **The investment:** USD $529
+>
+> **[Full details and enrolment here →](https://www.inajphotography.com.au/the-consistent-bookings-program-2026)**
+>
+> Questions? Hit reply. I mean that.
+>
+> Ina
+
+---
+
+### DAY 23 — Instagram Reel
+**Pillar:** Conversion | **Buyer Stage:** Product-Aware
+
+**Hook:**
+> "If any of these sound familiar, the Consistent Bookings Program might be what you've been looking for."
+
+**Script:**
+> Your calendar is inconsistent — some months are fully booked, others are crickets and you don't know why.
+>
+> You're getting enquiries, but they're asking for "just digitals" or pushing back on your prices.
+>
+> You rely heavily on word of mouth and referrals — and when they slow down, so does everything else.
+>
+> You know you should be doing more marketing. You're just not sure what, or where to start.
+>
+> You've tried posting more on Instagram. Maybe even ran a promotion. It helped short-term but didn't fix the underlying problem.
+>
+> If two or more of those felt like you — the Consistent Bookings Program 2026 is open. It's a six-week structured program built specifically for pet photographers who want consistent bookings with clients who invest $1,000 or more.
+>
+> Link in bio. Come check if it's the right fit.
+
+**Caption:**
+> Consistent bookings with clients who invest $1,000+ — that's the goal.
+>
+> But if you're relying on word of mouth, posting when you feel like it, and running promotions when the calendar gets scary — you're going to stay stuck in the same cycle.
+>
+> The Consistent Bookings Program 2026 is a six-week structured program built specifically for pet photographers who want to change that.
+>
+> Not generic business advice. Not inspiration without a plan. An actual system — built for pet photography, tested in pet photography.
+>
+> If any of this feels familiar, it's worth a look. Link in bio.
+>
+> (And if you have questions — DM me. I'll give you a straight answer.)
+
+---
+
+### DAY 24 — Skool Community Post
+**Pillar:** Conversion | **Buyer Stage:** Active Members → Product-Aware
+
+**Post:**
+> For those of you who've been inside the Collective for a while and are wondering what "going deeper" looks like — this is for you.
+>
+> The Consistent Bookings Program 2026 is now open for enrolment.
+>
+> This is the structured, six-week version of what we do here in the Collective. If you've found value in the community posts, the coaching calls, the frameworks — this is what it looks like with personalised guidance, a clear progression, and live accountability built in.
+>
+> You don't have to join. The Collective stays free. Always.
+>
+> But if you've been feeling like you need more structure — more accountability — more support to actually implement — this is what that looks like.
+>
+> [Details here →](https://www.inajphotography.com.au/the-consistent-bookings-program-2026)
+>
+> Happy to answer any questions in the comments or via DM.
+
+---
+
+### DAY 25 — Instagram Carousel
+**Pillar:** Conversion (FAQ) | **Buyer Stage:** Product-Aware
+
+**Slide 1:**
+> Questions I always get about the Consistent Bookings Program
+> Answered honestly.
+
+**Slide 2:**
+> **"Is this for photographers just starting out?"**
+> No — and that's intentional. This program is for photographers who already have paying clients but can't crack consistency. If you're still building your portfolio, the free Collective is the right starting point.
+
+**Slide 3:**
+> **"Will I have time for this?"**
+> The program is designed for photographers juggling day jobs and families. The live calls are recorded. The workbooks are self-paced. You don't need unlimited time — you need a clear plan for the time you have.
+
+**Slide 4:**
+> **"How is this different from a generic business course?"**
+> Every single example, scenario, and framework is specific to pet photography. Digitals vs. artwork. In-person sales appointments. Session-to-wall-art client journeys. It's not adapted from generic advice — it's built from the inside.
+
+**Slide 5:**
+> **"What if it doesn't work for me?"**
+> I'd rather have this conversation before you join than after. Hit the link in bio, read the full details, and DM me with your specific situation. I'll give you an honest answer about whether it's the right fit.
+
+**Slide 6 (CTA):**
+> Still have questions?
+> DM me directly. Or head to the link in bio for the full breakdown.
+> Enrolment is open now.
+
+**Caption (carousel):**
+> I get a lot of DMs when I open the Consistent Bookings Program. So I'm answering the most common questions here — honestly, not salesy.
+>
+> Swipe through and see if it answers yours.
+>
+> If it doesn't? DM me. I genuinely mean that. I'd rather you make the right decision for where you're at than join when it's not the right fit.
+>
+> Full details in bio.
+
+---
+
+### DAY 26 — Email Newsletter
+**Pillar:** Conversion (Social Proof) | **Buyer Stage:** Product-Aware → Conversion
+**Subject line:** `Before you decide — read this`
+**Send day:** Tuesday
+
+**Body:**
+> Before I say anything else: here's what some photographers who've gone through this work had to say.
+>
+> ---
+>
+> *"I noticed that I worked less but generated the same revenue. This means I was working with more of my ideal clients."*
+>
+> *"I've gotten sales over $2,500 but my average was under $1K. That changed once I understood my messaging gap."*
+>
+> *"Every time I read her emails or posts, I see my exact problems explained clearly. I walk away with an action I can actually take."*
+>
+> *"I had a good year photography-wise — awards, great clients. But my bookings were so inconsistent. Working through the 3 Gaps framework was the moment things started to click."*
+>
+> ---
+>
+> These are not dramatic before-and-after stories. They're quiet, real shifts.
+>
+> A clearer message. A simpler system. More confidence in a sales conversation.
+>
+> That's what the Consistent Bookings Program is. Not magic. Not a shortcut. A structured path for photographers who already have the talent and just need the system.
+>
+> If you've been on the fence — [here's the link](https://www.inajphotography.com.au/the-consistent-bookings-program-2026).
+>
+> Enrolment closes this week.
+>
+> Ina
+>
+> P.S. Still unsure? Hit reply and tell me where you're stuck. I'll give you an honest answer.
+
+---
+
+### DAY 27 — Instagram Stories Series
+**Pillar:** Conversion | **Buyer Stage:** Product-Aware
+
+**Story 1:** Poll
+> "Have you looked at the Consistent Bookings Program yet?"
+> 👀 Yes, checking it out / 🤔 Not yet
+
+**Story 2:** (DM to those who said "Not yet")
+> "Hey! Just wanted to reach out personally — is there anything specific you'd like to know before you decide? Happy to answer honestly. No pressure at all."
+
+**Story 3:** Q&A answering real questions received this week
+> "Answering your questions about CBP 2026 — swipe through."
+
+**Story 4:**
+> "The most common question I got: 'Will this work if I'm not in Australia?'
+> Yes — completely. The program is global. We have photographers from the US, Canada, UK, and Europe in the Collective. The frameworks work wherever you are."
+
+**Story 5:**
+> "Enrolment closes this week. If it's not the right time — totally okay. If it is — link in bio."
+
+---
+
+### DAY 28 — Instagram Reel
+**Pillar:** Conversion | **Buyer Stage:** Product-Aware
+
+**Hook:**
+> "This is the last week to join the Consistent Bookings Program for this round."
+
+**Script:**
+> I'm not going to pressure you. That's not how I do this.
+>
+> But I do want to say one honest thing.
+>
+> If you've been watching this content for the past month. If something in the 3 Gaps framework clicked for you. If you saw a member result and thought "I know I'm capable of that" —
+>
+> That feeling is real information. Pay attention to it.
+>
+> Doors close this week. The next intake won't be for a while.
+>
+> If it feels like the right time — the link is in my bio.
+>
+> If it's not — that's genuinely okay. The Collective is here and it's free, and I'll keep showing up with content that's useful regardless.
+>
+> See you in there either way.
+
+**Caption:**
+> I'm not going to pressure you. That's not how I do this.
+>
+> But if you've been following along this month — and something clicked for you — I want you to pay attention to that feeling.
+>
+> The photographers who've been through the Consistent Bookings Program didn't join because they had everything figured out. They joined because they were tired of figuring it out alone.
+>
+> Doors close this week. Next intake won't be for a while.
+>
+> If it feels like the right time — link in bio.
+>
+> If it doesn't — the Collective is free and I'm not going anywhere. See you there.
+
+---
+
+## Days 29–30: "The Community Is the Point"
+
+---
+
+### DAY 29 — Skool Community Post
+**Pillar:** Community | **Buyer Stage:** Active Members
+
+**Post:**
+> Can we just take a moment.
+>
+> This month we talked about where bookings come from. We looked honestly at our marketing. We mapped our gaps. We shared wins and we shared struggles.
+>
+> And this community showed up the way it always does — with real answers, real questions, and genuine support for each other.
+>
+> That's rare. And I don't take it for granted.
+>
+> To anyone who joined the Collective this month: welcome. You found a good place.
+>
+> To anyone who's been here a while: thank you for being what makes this work.
+>
+> New members — introduce yourself below. Tell us where you're from, what kind of pet photography you do, and what your biggest challenge is right now. We want to know you.
+
+---
+
+### DAY 30 — Instagram Carousel + Email
+
+**Instagram Carousel:**
+
+**Slide 1:**
+> What consistent bookings actually looks like when you have a system
+> (90 days from now)
+
+**Slide 2:**
+> You know exactly where your last 5 clients came from.
+> And you know how to get more of them.
+
+**Slide 3:**
+> Your marketing runs on a simple weekly rhythm.
+> Not inspiration. Not panic. A plan.
+
+**Slide 4:**
+> Your enquiries have shifted.
+> Fewer "can I just get the digitals?" More "I love your wall art — how do I book?"
+
+**Slide 5:**
+> You hold your prices calmly.
+> Because your messaging has already done the work of pre-selling the value.
+
+**Slide 6:**
+> You have a community of photographers who get it.
+> Who share real numbers, ask real questions, and celebrate real wins.
+
+**Slide 7 (CTA):**
+> This is what the Pet Photographers Collective is working toward.
+> Free to join. 300 photographers already inside.
+> Link in bio.
+
+**Caption (carousel):**
+> This is what 90 days looks like when you stop winging it and start working a system.
+>
+> Not an overnight transformation. Not 10x anything. Just clarity — about where your clients come from, what your marketing does, and how to hold your prices without flinching.
+>
+> Swipe through to see what that actually looks like in practice.
+>
+> The Pet Photographers Collective is where we build this together. It's free. 300 photographers already inside doing exactly this work.
+>
+> Link in bio to join us. We'd love to have you.
+
+---
+
+**Email Newsletter:**
+**Subject line:** `What month 2 looks like`
+**Send day:** Tuesday
+
+**Body:**
+> We've spent a month together now.
+>
+> You've heard me talk about the 3 Gaps, about messaging that pre-sells, about the difference between busy and profitable, about why consistency beats inspiration every single time.
+>
+> I hope some of it clicked. I hope one or two things shifted.
+>
+> But I also know that reading isn't doing. And doing is the only thing that actually changes anything.
+>
+> So here's what I want for you going into next month:
+>
+> Pick ONE thing from this month's content. One framework. One habit. One action. And do it — imperfectly, this week.
+>
+> Not five things. Not a complete overhaul. One thing.
+>
+> And if you want to do it inside a community of photographers who are doing the same work — the Pet Photographers Collective is free, and it's full of people who will celebrate that imperfect action alongside you.
+>
+> [Come find your people →](https://www.skool.com/pet-photographers-collective)
+>
+> See you in there.
+>
+> Ina
+
+---
+
+## Implementation Notes
+
+### Content Batching Schedule
+| Week | Prep Day | Content Ready |
+|------|----------|---------------|
+| Week 1 | Day before launch | All 7 days scheduled |
+| Week 2 | Day 6 | Days 8–14 scheduled |
+| Week 3 | Day 13 | Days 15–21 scheduled |
+| Week 4 | Day 20 | Days 22–30 scheduled |
+
+### Engagement Commitments
+- Respond to every comment on conversion posts within 4 hours
+- DM everyone who comments a keyword (GAPS, STORY) within 2 hours
+- Reply to all email replies within 24 hours
+- Acknowledge every Skool community response personally
+
+### Repurposing Map
+| Original | Repurpose As |
+|----------|-------------|
+| Reel script (Day 1) | Email opening story |
+| Carousel (Day 4) | Skool post + story slides |
+| Email (Day 8, 3 Gaps) | Reel script + carousel |
+| Member wins (Day 16) | Social proof slides + email testimonials |
+| FAQ Carousel (Day 25) | Skool pinned post |
+
+### Metrics to Track
+- Instagram: saves, shares, comment keywords triggered, profile visits
+- Skool: new members per week, post engagement, DM conversions
+- Email: open rate, reply rate (aim for 5%+), unsubscribes
+- Program: enquiries attributed to each content piece, conversion rate from Collective to CBP
+
+### Voice Checklist (run before posting)
+- [ ] Uses pet-photography-specific language (not generic "creative business")
+- [ ] One clear action step (not five)
+- [ ] Respects their constraints (time-poor, often juggling day jobs or family)
+- [ ] Warm but not hollow — no "just believe in yourself" without a framework
+- [ ] Mirrors VoC language where possible ("consistent bookings", "getting leads", "digitals only")
+- [ ] CTA is a gentle invitation, not a pressure tactic
+
+---
+
+*Skills applied: `Claude-brand-voice-skill` (coaching-voice.md + platform-guide.md) + `ideal-client-lens` (all 5 checkpoints)*
+*Brand personality: Fireside (warm, grounded, credible) + Sunshine (encouraging, light, forward-moving)*


### PR DESCRIPTION
Creates a full content calendar targeting established pet photographers who struggle with consistent bookings. Strategy is aligned with:
- Claude-brand-voice-skill (coaching register: warm, direct, practical)
- ideal-client-lens (5 checkpoints applied to every content piece)
- Platform guide (Instagram Reels/Carousels/Stories, Skool, Email)

Content spans 4 buyer journey stages across 4 themed weeks:
- Week 1: "You're not alone" — awareness + pain point naming
- Week 2: "Here's what's actually going on" — 3 Gaps framework
- Week 3: "Here's what's possible" — social proof + transformation
- Week 4: "Here's the system" — Consistent Bookings Program conversion

Includes full reel scripts, captions, carousel slide copy, Skool community posts, and email newsletter bodies for all 30 days.

https://claude.ai/code/session_01SvrQTDziUhiLT87geeqsZ6