### PR TITLE
Add CI workflow to validate agent file format

### DIFF
--- a/.github/workflows/lint-agents.yml
+++ b/.github/workflows/lint-agents.yml
@@ -12,6 +12,7 @@ on:
       - 'support/**'
       - 'spatial-computing/**'
       - 'specialized/**'
+      - 'strategy/**'
 
 jobs:
   lint:
@@ -28,7 +29,7 @@ jobs:
           FILES=$(git diff --name-only --diff-filter=ACMR origin/${{ github.base_ref }}...HEAD -- \
             'design/*.md' 'engineering/*.md' 'marketing/*.md' 'product/*.md' \
             'project-management/*.md' 'testing/*.md' 'support/*.md' \
-            'spatial-computing/*.md' 'specialized/*.md')
+            'spatial-computing/*.md' 'specialized/*.md' 'strategy/*.md')
           echo "files=$FILES" >> "$GITHUB_OUTPUT"
           if [ -z "$FILES" ]; then
             echo "No agent files changed."
@@ -39,6 +40,8 @@ jobs:
 
       - name: Run agent linter
         if: steps.changed.outputs.files != ''
+        env:
+          CHANGED_FILES: ${{ steps.changed.outputs.files }}
         run: |
           chmod +x scripts/lint-agents.sh
-          ./scripts/lint-agents.sh ${{ steps.changed.outputs.files }}
+          ./scripts/lint-agents.sh $CHANGED_FILES

--- a/scripts/lint-agents.sh
+++ b/scripts/lint-agents.sh
@@ -20,6 +20,7 @@ AGENT_DIRS=(
   support
   spatial-computing
   specialized
+  strategy
 )
 
 REQUIRED_FRONTMATTER=("name" "description" "color")
@@ -36,7 +37,7 @@ lint_file() {
   first_line=$(head -1 "$file")
   if [[ "$first_line" != "---" ]]; then
     echo "ERROR $file: missing frontmatter opening ---"
-    ((errors++))
+    errors=$((errors + 1))
     return
   fi
 
@@ -46,7 +47,7 @@ lint_file() {
 
   if [[ -z "$frontmatter" ]]; then
     echo "ERROR $file: empty or malformed frontmatter"
-    ((errors++))
+    errors=$((errors + 1))
     return
   fi
 
@@ -54,7 +55,7 @@ lint_file() {
   for field in "${REQUIRED_FRONTMATTER[@]}"; do
     if ! echo "$frontmatter" | grep -qE "^${field}:"; then
       echo "ERROR $file: missing frontmatter field '${field}'"
-      ((errors++))
+      errors=$((errors + 1))
     fi
   done
 
@@ -65,14 +66,14 @@ lint_file() {
   for section in "${RECOMMENDED_SECTIONS[@]}"; do
     if ! echo "$body" | grep -qi "$section"; then
       echo "WARN  $file: missing recommended section '${section}'"
-      ((warnings++))
+      warnings=$((warnings + 1))
     fi
   done
 
   # 4. Check file has meaningful content
   if [[ $(echo "$body" | wc -w) -lt 50 ]]; then
     echo "WARN  $file: body seems very short (< 50 words)"
-    ((warnings++))
+    warnings=$((warnings + 1))
   fi
 }
 


### PR DESCRIPTION
## Summary

- Adds a **lint script** (`scripts/lint-agents.sh`) that validates agent markdown files
- Adds a **GitHub Actions workflow** that runs the linter on PRs touching agent directories
- Checks required YAML frontmatter fields (`name`, `description`, `color`) as errors
- Checks recommended sections (`Identity`, `Core Mission`, `Critical Rules`) as warnings
- Only lints changed files in PRs to avoid blocking on pre-existing issues

## Why

Currently there's no automated validation for agent files. Some existing agents are missing frontmatter fields or standard sections. This CI prevents new contributions from introducing format issues while not breaking on legacy files.

## Checklist

- [x] Script tested locally against all 56 agent files
- [x] Existing valid agents pass cleanly
- [x] Only triggers on PR changes to agent directories
- [x] Errors vs warnings properly separated