### PR TITLE
Update README stats to reflect actual agent count

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,8 +291,8 @@ Each agent is designed with:
 
 ## 📊 Stats
 
-- 🎭 **55+ Specialized Agents** across 9 divisions
-- 📝 **10,000+ lines** of personality, process, and code examples
+- 🎭 **56 Specialized Agents** across 9 divisions
+- 📝 **13,500+ lines** of personality, process, and code examples
 - ⏱️ **Months of iteration** from real-world usage
 - 🌟 **Battle-tested** in production environments
 - 💬 **50+ requests** in first 12 hours on Reddit


### PR DESCRIPTION
## What does this PR do?

Updates the Stats section in README.md with accurate numbers:

- Agent count: **55+** → **56** (actual count of agent files across all 9 divisions)
- Line count: **10,000+** → **13,500+** (actual line count across all agent files)

## Checklist

- [x] Verified counts by scanning all agent directories
- [x] Only README.md changed