### PR TITLE
Add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Ensure consistent line endings across platforms
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.sh text eol=lf


### PR DESCRIPTION
## What does this PR do?

Adds a `.gitattributes` file that enforces LF line endings for all markdown, YAML, and shell files.

## Why

While fixing #39 I found that `agentic-identity-trust.md` had Windows CRLF line endings, which broke frontmatter parsing. This `.gitattributes` prevents the issue from recurring — Git will automatically normalize line endings on commit regardless of the contributor's OS.

## Checklist

- [x] Single file addition, no other changes
- [x] Covers all relevant file types (`.md`, `.yml`, `.yaml`, `.sh`)