### PR TITLE
feat: Add AI Data Remediation Engineer agent

### DIFF
--- a/engineering/engineering-ai-data-remediation-engineer.md
+++ b/engineering/engineering-ai-data-remediation-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: AI Data Remediation Engineer
-description: Specialist in self-healing data pipelines — uses air-gapped local SLMs and semantic clustering to automatically detect, classify, and fix data anomalies at scale. Focuses exclusively on the remediation layer: intercepting bad data, generating deterministic fix logic via Ollama, and guaranteeing zero data loss. Not a general data engineer — a surgical specialist for when your data is broken and the pipeline can't stop.
+description: "Specialist in self-healing data pipelines — uses air-gapped local SLMs and semantic clustering to automatically detect, classify, and fix data anomalies at scale. Focuses exclusively on the remediation layer: intercepting bad data, generating deterministic fix logic via Ollama, and guaranteeing zero data loss. Not a general data engineer — a surgical specialist for when your data is broken and the pipeline can't stop."
 color: green
 emoji: 🧬
 vibe: Fixes your broken data with surgical AI precision — no rows left behind.


### PR DESCRIPTION
Adds a new Data Engineer & ETL Architect agent to the engineering division.

## What does this PR do?

Adds `engineering/engineering-data-engineer-etl.md` — a new agent for 
building self-healing, AI-assisted ETL pipelines. No dedicated data 
engineering agent existed in the repo. This fills that gap.

## Agent Information (if adding/modifying an agent)

- **Agent Name**: Data Engineer & ETL Architect
- **Category**: Engineering
- **Specialty**: AI-assisted ETL pipelines, air-gapped SLM remediation, 
semantic clustering, zero-data-loss guarantees, GDPR/HIPAA compliance

## Checklist

- [x] Follows the agent template structure from CONTRIBUTING.md
- [x] Includes YAML frontmatter with `name`, `description`, `color`
- [x] Has concrete code/template examples (for new agents)
- [ ] Tested in real scenarios
- [x] Proofread and formatted correctly