### PR TITLE
Update zh-CN translation count (100 translated + 9 originals)

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,7 +621,7 @@ Community-maintained translations and regional adaptations. These are independen
 
 | Language | Maintainer | Link | Notes |
 |----------|-----------|------|-------|
-| 🇨🇳 简体中文 (zh-CN) | [@jnMetaCode](https://github.com/jnMetaCode) | [agency-agents-zh](https://github.com/jnMetaCode/agency-agents-zh) | 26 translated agents + 4 China-market agents |
+| 🇨🇳 简体中文 (zh-CN) | [@jnMetaCode](https://github.com/jnMetaCode) | [agency-agents-zh](https://github.com/jnMetaCode/agency-agents-zh) | 100 translated agents + 9 China-market originals |
 
 Want to add a translation? Open an issue and we'll link it here.
 


### PR DESCRIPTION
## Summary
- Updates the Community Translations table to reflect current zh-CN coverage
- Was: `26 translated agents + 4 China-market agents`
- Now: `100 translated agents + 9 China-market originals`

The [agency-agents-zh](https://github.com/jnMetaCode/agency-agents-zh) repo now has full coverage of all upstream agents plus 9 China-market originals (Douyin, Xiaohongshu, WeChat, Bilibili, Kuaishou, Baidu SEO, E-Commerce, WeChat Mini Program, Prompt Engineer).