### PR TITLE
docs: add API key setup instruction to Accounts Payable Agent

### DIFF
--- a/specialized/accounts-payable-agent.md
+++ b/specialized/accounts-payable-agent.md
@@ -54,6 +54,8 @@ This agent uses [AgenticBTC](https://agenticbtc.io) for payment execution — a 
 npm install agenticbtc-mcp
 ```
 
+Get your API key at [agenticbtc.io](https://agenticbtc.io) → Dashboard → API Keys
+
 Configure in Claude Desktop's `claude_desktop_config.json`:
 ```json
 {


### PR DESCRIPTION
## What This Changes

Adds a clear, explicit line in the **Setup** section of `specialized/accounts-payable-agent.md` directing users to obtain their AgenticBTC API key before configuring the MCP server.

## Why

The existing Setup section shows the `claude_desktop_config.json` block with `AGENTICBTC_API_KEY: "your_agent_api_key"` but doesn't tell users *where* to get that key. This one-liner closes that gap so users know exactly where to go.

## Change

Added between the `npm install` step and the config block:

```
Get your API key at [agenticbtc.io](https://agenticbtc.io) → Dashboard → API Keys
```