### PR TITLE
fix: stop linting strategy docs as agent files

### DIFF
--- a/.github/workflows/lint-agents.yml
+++ b/.github/workflows/lint-agents.yml
@@ -14,7 +14,6 @@ on:
       - 'support/**'
       - 'spatial-computing/**'
       - 'specialized/**'
-      - 'strategy/**'
 
 jobs:
   lint:
@@ -31,7 +30,7 @@ jobs:
           FILES=$(git diff --name-only --diff-filter=ACMR origin/${{ github.base_ref }}...HEAD -- \
             'design/**/*.md' 'engineering/**/*.md' 'game-development/**/*.md' 'marketing/**/*.md' 'paid-media/**/*.md' 'product/**/*.md' \
             'project-management/**/*.md' 'testing/**/*.md' 'support/**/*.md' \
-            'spatial-computing/**/*.md' 'specialized/**/*.md' 'strategy/**/*.md')
+            'spatial-computing/**/*.md' 'specialized/**/*.md')
           {
             echo "files<<ENDOFLIST"
             echo "$FILES"


### PR DESCRIPTION
## What does this PR do?

  Removes `strategy/**` from the `lint-agents.yml` workflow trigger and changed-files filter so the agent linter only
  runs on actual agent files.

  ## Why

  The workflow runs `scripts/lint-agents.sh`, which validates agent frontmatter and agent-specific structure. Files
  under `strategy/` are documentation, playbooks, and runbooks rather than agent files, so including them in this
  workflow creates a CI scope mismatch.

  ## Agent Information (if adding/modifying an agent)

  N/A — this PR does not add or modify any agent files.

  ## Checklist

  - [x] Proofread and formatted correctly

  ## Verification

  - Confirmed the change is limited to `.github/workflows/lint-agents.yml`
  - Confirmed `strategy/**` was removed from both the workflow trigger and changed-files filter