### PR TITLE
fix: install all agent categories for copilot

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -285,7 +285,7 @@ install_copilot() {
   local count=0
   mkdir -p "$dest"
   local dir f first_line
-  for dir in design engineering marketing product project-management \
+  for dir in design engineering game-development marketing paid-media product project-management \
               testing support spatial-computing specialized; do
     [[ -d "$REPO_ROOT/$dir" ]] || continue
     while IFS= read -r -d '' f; do
@@ -293,7 +293,7 @@ install_copilot() {
       [[ "$first_line" == "---" ]] || continue
       cp "$f" "$dest/"
       (( count++ )) || true
-    done < <(find "$REPO_ROOT/$dir" -maxdepth 1 -name "*.md" -type f -print0)
+    done < <(find "$REPO_ROOT/$dir" -name "*.md" -type f -print0)
   done
   ok "Copilot: $count agents -> $dest"
 }


### PR DESCRIPTION
## What does this PR do?

  Updates `install_copilot()` so the Copilot installer includes all current agent categories and recursively installs
  nested agent files.

  ## Why

  The existing Copilot installer was narrower than the rest of the repository:

  - it did not include the `paid-media` directory at all
  - it scanned only top-level Markdown files, so nested categories like `game-development/unity`, `game-development/
  unreal-engine`, `game-development/godot`, and `game-development/roblox-studio` were skipped

  That meant the Copilot install path did not reflect the full on-disk agent roster.

  ## Agent Information (if adding/modifying an agent)

  N/A — this PR does not add or modify any agent files.

  ## Checklist

  - [x] Proofread and formatted correctly

  ## Changes

  - added `game-development` and `paid-media` to the Copilot installer directory list
  - changed the Copilot installer file search to recurse through nested directories

  ## Verification

  - confirmed the change is limited to `scripts/install.sh`
  - confirmed the previous installer scope excluded nested `game-development` agents and the entire `paid-media`
  category
  - confirmed the updated logic now matches the full agent directory layout more closely