### PR TITLE
feat: add MCP server for dynamic agent discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,5 @@ integrations/aider/CONVENTIONS.md
 integrations/windsurf/.windsurfrules
 integrations/openclaw/*
 !integrations/openclaw/README.md
+mcp-server/node_modules/
+mcp-server/build/

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,0 +1,106 @@
+# 🔌 Agency Agents MCP Server
+
+An [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that exposes The Agency's 100+ AI agent prompts to any MCP-compatible client — Claude Desktop, Kiro CLI, VS Code, Cursor, and more.
+
+No installation scripts, no file copying. Just connect and use.
+
+## Quick Start
+
+```bash
+cd mcp-server
+npm install
+npm run build
+```
+
+### Claude Desktop
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "agency-agents": {
+      "command": "node",
+      "args": ["/path/to/agency-agents/mcp-server/build/index.js"]
+    }
+  }
+}
+```
+
+### Kiro CLI
+
+Add to `.kiro/settings/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "agency-agents": {
+      "command": "node",
+      "args": ["/path/to/agency-agents/mcp-server/build/index.js"]
+    }
+  }
+}
+```
+
+### VS Code / Cursor
+
+Add to `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "agency-agents": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["/path/to/agency-agents/mcp-server/build/index.js"]
+    }
+  }
+}
+```
+
+## Tools
+
+### `list_agents`
+
+List all available agents, optionally filtered by division.
+
+```
+list_agents()                          → all 106 agents
+list_agents(division: "engineering")   → 16 engineering agents
+list_agents(division: "design")        → 8 design agents
+```
+
+### `get_agent`
+
+Get the full prompt/content of a specific agent by name.
+
+```
+get_agent(name: "Frontend Developer")  → full agent prompt
+get_agent(name: "SRE")                → fuzzy match works
+```
+
+### `search_agents`
+
+Search agents by keyword across name, description, and content.
+
+```
+search_agents(query: "React")          → agents mentioning React
+search_agents(query: "security")       → security-related agents
+```
+
+## Divisions
+
+| Division | Agents |
+|----------|--------|
+| design | 8 |
+| engineering | 16 |
+| game-development | 19 |
+| marketing | 18 |
+| paid-media | 7 |
+| sales | 8 |
+| product | 4 |
+| project-management | 6 |
+| testing | 8 |
+| support | 6 |
+| spatial-computing | 6 |
+| specialized | 14 |

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@agency-agents/mcp-server",
+  "version": "1.0.0",
+  "description": "MCP server for The Agency - browse, search, and use AI agent prompts",
+  "type": "module",
+  "main": "build/index.js",
+  "bin": {
+    "agency-agents-mcp": "build/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "start": "node build/index.js"
+  },
+  "keywords": ["mcp", "ai-agents", "agency-agents"],
+  "license": "MIT",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.1",
+    "zod": "^3.25.23"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.3",
+    "@types/node": "^22.15.18"
+  }
+}

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+import { readFileSync, readdirSync, existsSync } from "fs";
+import { join, resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+// ---------------------------------------------------------------------------
+// Agent loading
+// ---------------------------------------------------------------------------
+
+interface Agent {
+  name: string;
+  description: string;
+  emoji: string;
+  division: string;
+  file: string;
+  body: string;
+}
+
+const DIVISIONS = [
+  "design", "engineering", "game-development", "marketing", "paid-media",
+  "sales", "product", "project-management", "testing", "support",
+  "spatial-computing", "specialized",
+];
+
+function parseAgent(filePath: string, division: string): Agent | null {
+  const content = readFileSync(filePath, "utf-8");
+  const match = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!match) return null;
+
+  const frontmatter = match[1];
+  const body = match[2].trim();
+
+  const get = (key: string) => {
+    const m = frontmatter.match(new RegExp(`^${key}:\\s*(.+)$`, "m"));
+    return m ? m[1].replace(/^["']|["']$/g, "") : "";
+  };
+
+  const name = get("name");
+  if (!name) return null;
+
+  return { name, description: get("description"), emoji: get("emoji"), division, file: filePath, body };
+}
+
+function loadAgents(repoRoot: string): Agent[] {
+  const agents: Agent[] = [];
+  for (const div of DIVISIONS) {
+    const dirPath = join(repoRoot, div);
+    if (!existsSync(dirPath)) continue;
+    for (const f of readdirSync(dirPath).filter(f => f.endsWith(".md")).sort()) {
+      const agent = parseAgent(join(dirPath, f), div);
+      if (agent) agents.push(agent);
+    }
+  }
+  return agents;
+}
+
+// ---------------------------------------------------------------------------
+// Resolve repo root (mcp-server lives inside the repo)
+// ---------------------------------------------------------------------------
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "../..");
+const agents = loadAgents(repoRoot);
+
+// ---------------------------------------------------------------------------
+// MCP Server
+// ---------------------------------------------------------------------------
+
+const server = new McpServer({ name: "agency-agents", version: "1.0.0" });
+
+// --- list_agents ---
+server.registerTool(
+  "list_agents",
+  {
+    description: "List all available agents. Optionally filter by division.",
+    inputSchema: z.object({
+      division: z.string().optional().describe("Filter by division name (e.g. 'engineering', 'design')"),
+    }),
+  },
+  async ({ division }) => {
+    let results = agents;
+    if (division) {
+      const d = division.toLowerCase();
+      results = agents.filter(a => a.division === d);
+    }
+    const text = results.length === 0
+      ? `No agents found${division ? ` in division '${division}'` : ""}.`
+      : results.map(a => `${a.emoji} ${a.name} [${a.division}] — ${a.description}`).join("\n");
+    return { content: [{ type: "text", text: `${results.length} agent(s):\n\n${text}` }] };
+  },
+);
+
+// --- get_agent ---
+server.registerTool(
+  "get_agent",
+  {
+    description: "Get the full prompt/content of a specific agent by name.",
+    inputSchema: z.object({
+      name: z.string().describe("Agent name (e.g. 'Frontend Developer', 'SRE')"),
+    }),
+  },
+  async ({ name }) => {
+    const q = name.toLowerCase();
+    const agent = agents.find(a => a.name.toLowerCase() === q)
+      || agents.find(a => a.name.toLowerCase().includes(q));
+    if (!agent) {
+      return { content: [{ type: "text", text: `Agent '${name}' not found. Use list_agents to see available agents.` }] };
+    }
+    return { content: [{ type: "text", text: `# ${agent.emoji} ${agent.name}\n**Division:** ${agent.division}\n**Description:** ${agent.description}\n\n${agent.body}` }] };
+  },
+);
+
+// --- search_agents ---
+server.registerTool(
+  "search_agents",
+  {
+    description: "Search agents by keyword in name, description, or content.",
+    inputSchema: z.object({
+      query: z.string().describe("Search keyword (e.g. 'React', 'security', 'API')"),
+    }),
+  },
+  async ({ query }) => {
+    const q = query.toLowerCase();
+    const results = agents.filter(a =>
+      a.name.toLowerCase().includes(q)
+      || a.description.toLowerCase().includes(q)
+      || a.body.toLowerCase().includes(q)
+    );
+    if (results.length === 0) {
+      return { content: [{ type: "text", text: `No agents found matching '${query}'.` }] };
+    }
+    const text = results.map(a => `${a.emoji} ${a.name} [${a.division}] — ${a.description}`).join("\n");
+    return { content: [{ type: "text", text: `${results.length} result(s) for '${query}':\n\n${text}` }] };
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Start
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error(`agency-agents MCP server running (${agents.length} agents loaded)`);
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/mcp-server/tsconfig.json
+++ b/mcp-server/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "build",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## What

Adds an MCP (Model Context Protocol) server that exposes all 106 agents dynamically — any MCP-compatible client can browse, search, and use agents without running install scripts or copying files.

## Why

Currently, using agents requires running `convert.sh` + `install.sh` and copying files to specific tool directories. An MCP server lets any compatible client (Claude Desktop, Kiro CLI, VS Code, Cursor) discover and use agents with zero setup beyond pointing to the server.

## Tools

| Tool | Description | Example |
|------|-------------|---------|
| `list_agents` | List all agents, filter by division | `list_agents(division: "engineering")` → 16 agents |
| `get_agent` | Get full agent prompt by name | `get_agent(name: "Frontend Developer")` → full prompt |
| `search_agents` | Keyword search across name/description/content | `search_agents(query: "React")` → 14 results |

## Setup

```bash
cd mcp-server && npm install && npm run build
```

Then add to any MCP client config:
```json
{
  "mcpServers": {
    "agency-agents": {
      "command": "node",
      "args": ["/path/to/agency-agents/mcp-server/build/index.js"]
    }
  }
}
```

## Test Results

```
list_agents()                        → 106 agent(s)
list_agents(division: "engineering") → 16 agent(s)
get_agent(name: "Frontend Developer") → full prompt with identity, mission, rules
search_agents(query: "React")        → 14 result(s)
search_agents(query: "security")     → matches across divisions
```

## Tech

- TypeScript + `@modelcontextprotocol/sdk` v1.x
- stdio transport (standard for local MCP servers)
- Reads agent .md files directly from repo (no pre-processing needed)
- 5 files, 299 lines total

## Files

```
mcp-server/
├── src/index.ts      # Server implementation (154 lines)
├── package.json
├── tsconfig.json
└── README.md         # Setup docs for Claude Desktop, Kiro, VS Code, Cursor
```