### PR TITLE
Fix Gemini CLI installer preflight on fresh clones

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,8 +582,10 @@ See [integrations/antigravity/README.md](integrations/antigravity/README.md) for
 <summary><strong>Gemini CLI</strong></summary>
 
 Installs as a Gemini CLI extension with one skill per agent plus a manifest.
+On a fresh clone, generate the Gemini extension files before running the installer.
 
 ```bash
+./scripts/convert.sh --tool gemini-cli
 ./scripts/install.sh --tool gemini-cli
 ```
 

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -23,10 +23,13 @@ supported agentic coding tools.
 
 # Install a specific home-scoped tool
 ./scripts/install.sh --tool antigravity
-./scripts/install.sh --tool gemini-cli
 ./scripts/install.sh --tool copilot
 ./scripts/install.sh --tool openclaw
 ./scripts/install.sh --tool claude-code
+
+# Gemini CLI needs generated integration files on a fresh clone
+./scripts/convert.sh --tool gemini-cli
+./scripts/install.sh --tool gemini-cli
 ```
 
 For project-scoped tools such as OpenCode, Cursor, Aider, and Windsurf, run
@@ -88,8 +91,11 @@ See [antigravity/README.md](antigravity/README.md) for details.
 
 Agents are packaged as a Gemini CLI extension with individual skill files.
 The extension is installed to `~/.gemini/extensions/agency-agents/`.
+Because the Gemini manifest and skill folders are generated artifacts, run
+`./scripts/convert.sh --tool gemini-cli` before installing from a fresh clone.
 
 ```bash
+./scripts/convert.sh --tool gemini-cli
 ./scripts/install.sh --tool gemini-cli
 ```
 

--- a/integrations/gemini-cli/README.md
+++ b/integrations/gemini-cli/README.md
@@ -6,6 +6,10 @@ installs to `~/.gemini/extensions/agency-agents/`.
 ## Install
 
 ```bash
+# Generate the Gemini CLI integration files first
+./scripts/convert.sh --tool gemini-cli
+
+# Then install the extension
 ./scripts/install.sh --tool gemini-cli
 ```
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -325,16 +325,20 @@ install_gemini_cli() {
   local src="$INTEGRATIONS/gemini-cli"
   local dest="${HOME}/.gemini/extensions/agency-agents"
   local count=0
-  [[ -d "$src" ]] || { err "integrations/gemini-cli missing. Run convert.sh first."; return 1; }
+  local manifest="$src/gemini-extension.json"
+  local skills_dir="$src/skills"
+  [[ -d "$src" ]] || { err "integrations/gemini-cli missing. Run ./scripts/convert.sh --tool gemini-cli first."; return 1; }
+  [[ -f "$manifest" ]] || { err "integrations/gemini-cli/gemini-extension.json missing. Run ./scripts/convert.sh --tool gemini-cli first."; return 1; }
+  [[ -d "$skills_dir" ]] || { err "integrations/gemini-cli/skills missing. Run ./scripts/convert.sh --tool gemini-cli first."; return 1; }
   mkdir -p "$dest/skills"
-  cp "$src/gemini-extension.json" "$dest/gemini-extension.json"
+  cp "$manifest" "$dest/gemini-extension.json"
   local d
   while IFS= read -r -d '' d; do
     local name; name="$(basename "$d")"
     mkdir -p "$dest/skills/$name"
     cp "$d/SKILL.md" "$dest/skills/$name/SKILL.md"
     (( count++ )) || true
-  done < <(find "$src/skills" -mindepth 1 -maxdepth 1 -type d -print0)
+  done < <(find "$skills_dir" -mindepth 1 -maxdepth 1 -type d -print0)
   ok "Gemini CLI: $count skills -> $dest"
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes the Gemini CLI installer so a fresh clone fails with a clear preflight message instead of a raw `cp: ... No such file or directory` error when the generated extension artifacts are missing.

### Changes
- check for `integrations/gemini-cli/gemini-extension.json` before copying it
- check for `integrations/gemini-cli/skills/` before copying generated skills
- point both failures to `./scripts/convert.sh --tool gemini-cli`
- update `README.md`, `integrations/README.md`, and `integrations/gemini-cli/README.md` to document the required convert step on fresh clones

### Verification
- reproduced the current failure on a clean upstream clone (`cp: ... gemini-extension.json: No such file or directory`)
- ran `bash -n scripts/install.sh`
- verified the patched installer now fails with a clear message when generated Gemini files are missing
- ran `./scripts/convert.sh --tool gemini-cli`
- verified `./scripts/install.sh --tool gemini-cli` succeeds against a temporary `HOME` and installs the manifest + 142 generated skills

Closes #165.
