### PR TITLE
Fix convert.sh single-file output cross-contamination

### DIFF
--- a/scripts/convert.sh
+++ b/scripts/convert.sh
@@ -456,16 +456,6 @@ run_conversions() {
   echo "$count"
 }
 
-write_single_file_outputs() {
-  # Aider
-  mkdir -p "$OUT_DIR/aider"
-  cp "$AIDER_TMP" "$OUT_DIR/aider/CONVENTIONS.md"
-
-  # Windsurf
-  mkdir -p "$OUT_DIR/windsurf"
-  cp "$WINDSURF_TMP" "$OUT_DIR/windsurf/.windsurfrules"
-}
-
 # --- Entry point ---
 
 main() {
@@ -524,9 +514,14 @@ HEREDOC
   done
 
   # Write single-file outputs after accumulation
-  if [[ "$tool" == "all" || "$tool" == "aider" || "$tool" == "windsurf" ]]; then
-    write_single_file_outputs
+  if [[ "$tool" == "all" || "$tool" == "aider" ]]; then
+    mkdir -p "$OUT_DIR/aider"
+    cp "$AIDER_TMP" "$OUT_DIR/aider/CONVENTIONS.md"
     info "Wrote integrations/aider/CONVENTIONS.md"
+  fi
+  if [[ "$tool" == "all" || "$tool" == "windsurf" ]]; then
+    mkdir -p "$OUT_DIR/windsurf"
+    cp "$WINDSURF_TMP" "$OUT_DIR/windsurf/.windsurfrules"
     info "Wrote integrations/windsurf/.windsurfrules"
   fi
 


### PR DESCRIPTION
## Summary
- `convert.sh --tool aider` was also writing Windsurf output (and vice versa) because `write_single_file_outputs()` dumped all formats unconditionally
- Each single-file format now gates on its own `--tool` flag before writing
- Removes the now-unnecessary `write_single_file_outputs()` function
- Also cleans up the path for incoming Codex integration (#175) to follow the same per-tool pattern

## Test plan
- [x] `./scripts/convert.sh --tool aider` — only writes `integrations/aider/CONVENTIONS.md`
- [x] `./scripts/convert.sh --tool windsurf` — only writes `integrations/windsurf/.windsurfrules`
- [x] No cross-contamination in output messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)