### PR TITLE
fix(install): warn about vscode copilot agent path setting (#185)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -547,6 +547,12 @@ main() {
   box_bot
   printf "\n"
   dim "  Run ./scripts/convert.sh to regenerate after adding or editing agents."
+  
+  if [[ " ${SELECTED_TOOLS[*]} " =~ " copilot " ]]; then
+    printf "\n"
+    warn "Copilot: Ensure VS Code 'chat.agentFilesLocations' includes ~/.github/agents"
+    dim  "         See: https://code.visualstudio.com/docs/copilot/customization/custom-agents#_custom-agent-file-locations"
+  fi
   printf "\n"
 }
 


### PR DESCRIPTION
Fixes #185 by adding a post-install warning about the `chat.agentFilesLocations` setting for VS Code Copilot agents.