### PR TITLE
feat: add Kiro CLI integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ integrations/windsurf/.windsurfrules
 integrations/openclaw/*
 integrations/qwen/agents/
 !integrations/openclaw/README.md
+integrations/kiro/skills/

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Each agent file contains:
 
 Browse the agents below and copy/adapt the ones you need!
 
-### Option 3: Use with Other Tools (Cursor, Aider, Windsurf, Gemini CLI, OpenCode)
+### Option 3: Use with Other Tools (Cursor, Aider, Windsurf, Gemini CLI, OpenCode, Kiro CLI)
 
 ```bash
 # Step 1 -- generate integration files for all supported tools
@@ -514,6 +514,7 @@ The Agency works natively with Claude Code, and ships conversion + install scrip
 - **[Windsurf](https://codeium.com/windsurf)** — single `.windsurfrules` → `./.windsurfrules`
 - **[OpenClaw](https://github.com/openclaw/openclaw)** — `SOUL.md` + `AGENTS.md` + `IDENTITY.md` per agent
 - **[Qwen Code](https://github.com/QwenLM/qwen-code)** — `.md` SubAgent files → `~/.qwen/agents/`
+- **[Kiro CLI](https://kiro.dev/cli/)** — `SKILL.md` per agent → `~/.kiro/skills/`
 
 ---
 
@@ -759,6 +760,23 @@ cd /your/project
 
 > 📚 [Qwen SubAgents Docs](https://qwenlm.github.io/qwen-code-docs/en/users/features/sub-agents/)
 
+</details>
+
+<details>
+<summary><strong>Kiro CLI</strong></summary>
+
+Each agent becomes a skill in `~/.kiro/skills/agency-<slug>/`.
+
+```bash
+./scripts/install.sh --tool kiro
+```
+
+Activate in Kiro CLI:
+```
+Use the agency-frontend-developer skill to review this component.
+```
+
+See [integrations/kiro/README.md](integrations/kiro/README.md) for details.
 </details>
 
 ---

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -14,6 +14,7 @@ supported agentic coding tools.
 - **[Cursor](#cursor)** — `.mdc` rule files in `cursor/`
 - **[Aider](#aider)** — `CONVENTIONS.md` in `aider/`
 - **[Windsurf](#windsurf)** — `.windsurfrules` in `windsurf/`
+- **[Kiro CLI](#kiro-cli)** — `SKILL.md` per agent in `kiro/`
 
 ## Quick Install
 
@@ -26,6 +27,7 @@ supported agentic coding tools.
 ./scripts/install.sh --tool copilot
 ./scripts/install.sh --tool openclaw
 ./scripts/install.sh --tool claude-code
+./scripts/install.sh --tool kiro
 
 # Gemini CLI needs generated integration files on a fresh clone
 ./scripts/convert.sh --tool gemini-cli
@@ -172,3 +174,16 @@ cd /your/project && /path/to/agency-agents/scripts/install.sh --tool windsurf
 ```
 
 See [windsurf/README.md](windsurf/README.md) for details.
+
+---
+
+## Kiro CLI
+
+Each agent becomes a `SKILL.md` skill file installed to `~/.kiro/skills/`.
+Skills are prefixed with `agency-` to avoid naming conflicts.
+
+```bash
+./scripts/install.sh --tool kiro
+```
+
+See [kiro/README.md](kiro/README.md) for details.

--- a/integrations/kiro/README.md
+++ b/integrations/kiro/README.md
@@ -1,0 +1,46 @@
+# Kiro CLI Integration
+
+Installs all Agency agents as Kiro CLI skills. Each agent is prefixed
+with `agency-` to avoid conflicts with existing skills.
+
+## Install
+
+```bash
+./scripts/install.sh --tool kiro
+```
+
+This copies files from `integrations/kiro/skills/` to
+`~/.kiro/skills/`.
+
+## Activate a Skill
+
+In Kiro CLI, skills are automatically available. Reference an agent by name:
+
+```
+Use the agency-frontend-developer skill to review this component.
+```
+
+Available slugs follow the pattern `agency-<agent-name>`, e.g.:
+- `agency-frontend-developer`
+- `agency-backend-architect`
+- `agency-reality-checker`
+- `agency-growth-hacker`
+
+## Regenerate
+
+After modifying agents, regenerate the skill files:
+
+```bash
+./scripts/convert.sh --tool kiro
+```
+
+## File Format
+
+Each skill is a `SKILL.md` file in `~/.kiro/skills/<skill-name>/`:
+
+```yaml
+---
+name: agency-frontend-developer
+description: Expert frontend developer specializing in...
+---
+```

--- a/scripts/convert.sh
+++ b/scripts/convert.sh
@@ -18,6 +18,7 @@
 #   windsurf     — Single .windsurfrules for Windsurf
 #   openclaw     — OpenClaw SOUL.md files (openclaw_workspace/<agent>/SOUL.md)
 #   qwen         — Qwen Code SubAgent files (~/.qwen/agents/*.md)
+#   kiro         — Kiro CLI skill files (~/.kiro/skills/)
 #   all          — All tools (default)
 #
 # Output is written to integrations/<tool>/ relative to the repo root.
@@ -373,6 +374,29 @@ HEREDOC
   fi
 }
 
+convert_kiro() {
+  local file="$1"
+  local name description slug outdir outfile body
+
+  name="$(get_field "name" "$file")"
+  description="$(get_field "description" "$file")"
+  slug="agency-$(slugify "$name")"
+  body="$(get_body "$file")"
+
+  outdir="$OUT_DIR/kiro/skills/$slug"
+  outfile="$outdir/SKILL.md"
+  mkdir -p "$outdir"
+
+  # Kiro CLI SKILL.md format: ~/.kiro/skills/<skill-name>/SKILL.md
+  cat > "$outfile" <<HEREDOC
+---
+name: ${slug}
+description: ${description}
+---
+${body}
+HEREDOC
+}
+
 # Aider and Windsurf are single-file formats — accumulate into temp files
 # then write at the end.
 AIDER_TMP="$(mktemp)"
@@ -470,6 +494,7 @@ run_conversions() {
         cursor)      convert_cursor      "$file" ;;
         openclaw)    convert_openclaw    "$file" ;;
         qwen)        convert_qwen        "$file" ;;
+        kiro)        convert_kiro        "$file" ;;
         aider)       accumulate_aider    "$file" ;;
         windsurf)    accumulate_windsurf "$file" ;;
       esac
@@ -500,7 +525,7 @@ main() {
     esac
   done
 
-  local valid_tools=("antigravity" "gemini-cli" "opencode" "cursor" "aider" "windsurf" "openclaw" "qwen" "all")
+  local valid_tools=("antigravity" "gemini-cli" "opencode" "cursor" "aider" "windsurf" "openclaw" "qwen" "kiro" "all")
   local valid=false
   for t in "${valid_tools[@]}"; do [[ "$t" == "$tool" ]] && valid=true && break; done
   if ! $valid; then
@@ -519,7 +544,7 @@ main() {
 
   local tools_to_run=()
   if [[ "$tool" == "all" ]]; then
-    tools_to_run=("antigravity" "gemini-cli" "opencode" "cursor" "aider" "windsurf" "openclaw" "qwen")
+    tools_to_run=("antigravity" "gemini-cli" "opencode" "cursor" "aider" "windsurf" "openclaw" "qwen" "kiro")
   else
     tools_to_run=("$tool")
   fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -20,6 +20,7 @@
 #   windsurf     -- Copy .windsurfrules to current directory
 #   openclaw     -- Copy workspaces to ~/.openclaw/agency-agents/
 #   qwen         -- Copy SubAgents to ~/.qwen/agents/ (user-wide) or .qwen/agents/ (project)
+#   kiro         -- Copy skills to ~/.kiro/skills/
 #   all          -- Install for all detected tools (default)
 #
 # Flags:
@@ -101,7 +102,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 INTEGRATIONS="$REPO_ROOT/integrations"
 
-ALL_TOOLS=(claude-code copilot antigravity gemini-cli opencode openclaw cursor aider windsurf qwen)
+ALL_TOOLS=(claude-code copilot antigravity gemini-cli opencode openclaw cursor aider windsurf qwen kiro)
 
 # ---------------------------------------------------------------------------
 # Usage
@@ -142,6 +143,7 @@ detect_aider()        { command -v aider >/dev/null 2>&1; }
 detect_openclaw()     { command -v openclaw >/dev/null 2>&1 || [[ -d "${HOME}/.openclaw" ]]; }
 detect_windsurf()     { command -v windsurf >/dev/null 2>&1 || [[ -d "${HOME}/.codeium" ]]; }
 detect_qwen()         { command -v qwen >/dev/null 2>&1 || [[ -d "${HOME}/.qwen" ]]; }
+detect_kiro()         { command -v kiro-cli >/dev/null 2>&1 || [[ -d "${HOME}/.kiro" ]]; }
 
 is_detected() {
   case "$1" in
@@ -155,6 +157,7 @@ is_detected() {
     aider)       detect_aider       ;;
     windsurf)    detect_windsurf    ;;
     qwen)        detect_qwen        ;;
+    kiro)        detect_kiro        ;;
     *)           return 1 ;;
   esac
 }
@@ -172,6 +175,7 @@ tool_label() {
     aider)       printf "%-14s  %s" "Aider"        "(CONVENTIONS.md)"        ;;
     windsurf)    printf "%-14s  %s" "Windsurf"     "(.windsurfrules)"        ;;
     qwen)        printf "%-14s  %s" "Qwen Code"    "(~/.qwen/agents)"        ;;
+    kiro)        printf "%-14s  %s" "Kiro CLI"     "(~/.kiro/skills)"        ;;
   esac
 }
 
@@ -468,6 +472,22 @@ install_qwen() {
   warn "Tip: Run '/agents manage' in Qwen Code to refresh, or restart session"
 }
 
+install_kiro() {
+  local src="$INTEGRATIONS/kiro/skills"
+  local dest="${HOME}/.kiro/skills"
+  local count=0
+  [[ -d "$src" ]] || { err "integrations/kiro missing. Run convert.sh first."; return 1; }
+  mkdir -p "$dest"
+  local d
+  while IFS= read -r -d '' d; do
+    local name; name="$(basename "$d")"
+    mkdir -p "$dest/$name"
+    cp "$d/SKILL.md" "$dest/$name/SKILL.md"
+    (( count++ )) || true
+  done < <(find "$src" -mindepth 1 -maxdepth 1 -type d -print0)
+  ok "Kiro CLI: $count skills -> $dest"
+}
+
 install_tool() {
   case "$1" in
     claude-code) install_claude_code ;;
@@ -480,6 +500,7 @@ install_tool() {
     aider)       install_aider       ;;
     windsurf)    install_windsurf    ;;
     qwen)        install_qwen        ;;
+    kiro)        install_kiro        ;;
   esac
 }
 


### PR DESCRIPTION
## What does this PR do?

Add Kiro CLI integration — converts all Agency agents into Kiro CLI skill files (`SKILL.md`) and installs them to `~/.kiro/skills/`.

This is a rebased version of #121 (by @kienbui1995), updated to resolve conflicts with the Qwen Code PR that landed since that PR was opened. All changes from the original PR are preserved; `qwen` and `kiro` entries are included side-by-side throughout.

## Changes

- `scripts/convert.sh` — add `convert_kiro()` (SKILL.md per agent), alongside existing `convert_qwen()`
- `scripts/install.sh` — add `detect_kiro()`, `install_kiro()`, interactive UI entry, alongside qwen equivalents
- `integrations/kiro/README.md` — tool-specific docs
- `integrations/README.md` — add Kiro CLI install line
- `README.md` — add Kiro CLI to Supported Tools list + `<details>` block
- `.gitignore` — exclude generated `integrations/kiro/skills/`

## Conflict resolution vs #121

The original PR conflicted because the Qwen Code PR landed after it was opened. All seven conflict sites in `install.sh`, six in `convert.sh`, and two in `README.md` were resolved by including both `qwen` and `kiro` entries in each location.

## Credit

Original implementation by @kienbui1995 in #121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)