### PR TITLE
fix: add post-install hint for Copilot agent path verification

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -330,6 +330,8 @@ install_copilot() {
   done
   ok "Copilot: $count agents -> $dest_github"
   ok "Copilot: $count agents -> $dest_copilot"
+  warn "Copilot: Verify VS Code setting 'chat.agentFilesLocations' includes your install path."
+  dim  "         Open Settings (Ctrl/Cmd+,) -> search 'chat.agentFilesLocations'"
 }
 
 install_antigravity() {


### PR DESCRIPTION
## What does this PR do?

Adds a post-install warning after Copilot agent installation, reminding users to verify their VS Code `chat.agentFilesLocations` setting includes the install path.

## Motivation

VS Code's default `chat.agentFilesLocations` may not include `~/.github/agents` or `~/.copilot/agents`, so agents installed by `install.sh --tool copilot` may not be detected. This is a minimal, non-invasive fix that guides users to the right setting.

Fixes #218
Relates to #185, Discussion #200

## Changes

- `scripts/install.sh`: add `warn` + `dim` hint after `install_copilot()` completes

## Output after install

```
[OK]  Copilot: 155 agents -> ~/.github/agents
[OK]  Copilot: 155 agents -> ~/.copilot/agents
[!!]  Copilot: Verify VS Code setting 'chat.agentFilesLocations' includes your install path.
         Open Settings (Ctrl/Cmd+,) -> search 'chat.agentFilesLocations'
```

## Checklist

- [x] Minimal change (2 lines added)
- [x] Tested locally
- [x] Follows existing warn/dim pattern used elsewhere in the script