### PR TITLE
docs: align displayed OpenClaw install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,7 +573,7 @@ The installer scans your system for installed tools, shows a checkbox UI, and le
   [x]  3)  [*]  Antigravity     (~/.gemini/antigravity)
   [ ]  4)  [ ]  Gemini CLI      (gemini extension)
   [ ]  5)  [ ]  OpenCode        (opencode.ai)
-[ ]  6)  [ ]  OpenClaw        (~/.openclaw/agency-agents)
+  [ ]  6)  [ ]  OpenClaw        (~/.openclaw/agency-agents)
   [x]  7)  [*]  Cursor          (.cursor/rules)
   [ ]  8)  [ ]  Aider           (CONVENTIONS.md)
   [ ]  9)  [ ]  Windsurf        (.windsurfrules)

--- a/README.md
+++ b/README.md
@@ -573,7 +573,7 @@ The installer scans your system for installed tools, shows a checkbox UI, and le
   [x]  3)  [*]  Antigravity     (~/.gemini/antigravity)
   [ ]  4)  [ ]  Gemini CLI      (gemini extension)
   [ ]  5)  [ ]  OpenCode        (opencode.ai)
-  [ ]  6)  [ ]  OpenClaw        (~/.openclaw)
+[ ]  6)  [ ]  OpenClaw        (~/.openclaw/agency-agents)
   [x]  7)  [*]  Cursor          (.cursor/rules)
   [ ]  8)  [ ]  Aider           (CONVENTIONS.md)
   [ ]  9)  [ ]  Windsurf        (.windsurfrules)


### PR DESCRIPTION
## Summary

- update the installer UI label for OpenClaw to `(~/.openclaw/agency-agents)`
- update the root README selection list to show the same path
- keep the public docs consistent with the existing integration guide, which already documents `~/.openclaw/agency-agents/`

## Validation

- static check confirmed both `README.md` and `scripts/install.sh` now show `(~/.openclaw/agency-agents)`
- static check confirmed neither file still contains the older `(~/.openclaw)` label