### PR TITLE
docs: add Qwen integration guide

### DIFF
--- a/integrations/README.md
+++ b/integrations/README.md
@@ -15,6 +15,7 @@ supported agentic coding tools.
 - **[Aider](#aider)** — `CONVENTIONS.md` in `aider/`
 - **[Windsurf](#windsurf)** — `.windsurfrules` in `windsurf/`
 - **[Kimi Code](#kimi-code)** — YAML agent specs in `kimi/`
+- **[Qwen Code](#qwen-code)** — project-scoped `.md` SubAgents in `.qwen/agents/`
 
 ## Quick Install
 
@@ -31,6 +32,10 @@ supported agentic coding tools.
 # Gemini CLI needs generated integration files on a fresh clone
 ./scripts/convert.sh --tool gemini-cli
 ./scripts/install.sh --tool gemini-cli
+
+# Qwen Code also needs generated SubAgent files on a fresh clone
+./scripts/convert.sh --tool qwen
+./scripts/install.sh --tool qwen
 ```
 
 If you install OpenClaw and the gateway is already running, restart it after installation:
@@ -39,7 +44,8 @@ If you install OpenClaw and the gateway is already running, restart it after ins
 openclaw gateway restart
 ```
 
-For project-scoped tools such as OpenCode, Cursor, Aider, and Windsurf, run
+For project-scoped tools such as OpenCode, Cursor, Aider, Windsurf, and Qwen
+Code, run
 the installer from your target project root as shown in the tool-specific
 sections below.
 
@@ -212,3 +218,23 @@ kimi --agent-file ~/.config/kimi/agents/frontend-developer/agent.yaml \
 ```
 
 See [kimi/README.md](kimi/README.md) for details.
+
+---
+
+## Qwen Code
+
+Each agent becomes a project-scoped `.md` SubAgent file in `.qwen/agents/`.
+
+From a fresh clone, generate the Qwen files first:
+
+```bash
+./scripts/convert.sh --tool qwen
+```
+
+Then install them from your project root:
+
+```bash
+cd /your/project && /path/to/agency-agents/scripts/install.sh --tool qwen
+```
+
+See [qwen/README.md](qwen/README.md) for details.

--- a/integrations/qwen/README.md
+++ b/integrations/qwen/README.md
@@ -1,0 +1,43 @@
+# Qwen Code Integration
+
+Qwen Code uses project-scoped `.md` SubAgent files in `.qwen/agents/`.
+
+The generated files come from `scripts/convert.sh --tool qwen`, which writes one
+SubAgent Markdown file per agency agent into `integrations/qwen/agents/`.
+
+## Generate
+
+From the repository root:
+
+```bash
+./scripts/convert.sh --tool qwen
+```
+
+## Install
+
+Run the installer from your target project root:
+
+```bash
+cd /your/project && /path/to/agency-agents/scripts/install.sh --tool qwen
+```
+
+This copies the generated SubAgent files into:
+
+```text
+.qwen/agents/
+```
+
+## Refresh in Qwen Code
+
+After installation:
+
+- run `/agents manage` in Qwen Code to refresh the agent list, or
+- restart the current Qwen Code session
+
+## Notes
+
+- Qwen Code is project-scoped, not home-scoped
+- The generated Qwen files use minimal frontmatter: `name`, `description`, and
+  optional `tools`
+- If you update agents in this repo, regenerate the Qwen output before
+  reinstalling


### PR DESCRIPTION
## Summary

- add Qwen Code to the integrations index and quick-install section
- add a dedicated `integrations/qwen/README.md` that matches the existing `convert_qwen` / `install_qwen` behavior
- keep the patch independent from the open authoring and OpenClaw path-label PRs in the same repo

## Validation

- static check confirmed:
  - `integrations/README.md` now has a Qwen index entry, quick-install commands, and a dedicated section
  - `integrations/qwen/README.md` points to project-scoped `.qwen/agents/`
  - the docs match the existing `scripts/install.sh` and `scripts/convert.sh` Qwen paths