### PR TITLE
fix: add academic/ and sales/ to lint-agents.sh and CI workflow

### DIFF
--- a/.github/workflows/lint-agents.yml
+++ b/.github/workflows/lint-agents.yml
@@ -3,6 +3,7 @@ name: Lint Agent Files
 on:
   pull_request:
     paths:
+      - 'academic/**'
       - 'design/**'
       - 'engineering/**'
       - 'game-development/**'
@@ -29,7 +30,7 @@ jobs:
         id: changed
         run: |
           FILES=$(git diff --name-only --diff-filter=ACMR origin/${{ github.base_ref }}...HEAD -- \
-            'design/**/*.md' 'engineering/**/*.md' 'game-development/**/*.md' 'marketing/**/*.md' 'paid-media/**/*.md' 'sales/**/*.md' 'product/**/*.md' \
+            'academic/**/*.md' 'design/**/*.md' 'engineering/**/*.md' 'game-development/**/*.md' 'marketing/**/*.md' 'paid-media/**/*.md' 'sales/**/*.md' 'product/**/*.md' \
             'project-management/**/*.md' 'testing/**/*.md' 'support/**/*.md' \
             'spatial-computing/**/*.md' 'specialized/**/*.md')
           {

--- a/scripts/lint-agents.sh
+++ b/scripts/lint-agents.sh
@@ -11,11 +11,13 @@
 set -euo pipefail
 
 AGENT_DIRS=(
+  academic
   design
   engineering
   game-development
   marketing
   paid-media
+  sales
   product
   project-management
   testing


### PR DESCRIPTION
## What does this PR do?

Adds the `academic/` and `sales/` directories to `scripts/lint-agents.sh` `AGENT_DIRS` and adds `academic/` to the `.github/workflows/lint-agents.yml` trigger paths and diff filter, so these directories are covered by both local full-scan linting and CI.

## Why

`academic/` was added in #219 with `convert.sh` and `install.sh` updates, but the linter and CI workflow were not updated — PRs touching `academic/` agents never trigger CI lint. `sales/` was already in CI but missing from `lint-agents.sh`, so local `./scripts/lint-agents.sh` (no args) silently skipped it.

Directory ordering in `AGENT_DIRS` now matches `convert.sh` and `install.sh`.

Fixes #242

## Checklist

- [x] Proofread and formatted correctly
- [x] Tested locally: `./scripts/lint-agents.sh` → 0 errors, 156 files scanned (previously missed academic/ and sales/)