### PR TITLE
Fix opencode global install docs to use install.sh --path

### DIFF
--- a/integrations/opencode/README.md
+++ b/integrations/opencode/README.md
@@ -48,9 +48,11 @@ color: "#00FFFF"
 ## Project vs Global
 
 Agents in `.opencode/agents/` are **project-scoped**. To make them available
-globally across all projects, use the install script with `--path`:
+globally across all projects, first generate the agent files, then install
+with `--path`:
 
 ```bash
+./scripts/convert.sh --tool opencode
 ./scripts/install.sh --tool opencode --path ~/.config/opencode/agents
 ```
 

--- a/integrations/opencode/README.md
+++ b/integrations/opencode/README.md
@@ -48,11 +48,10 @@ color: "#00FFFF"
 ## Project vs Global
 
 Agents in `.opencode/agents/` are **project-scoped**. To make them available
-globally across all projects, copy them to your OpenCode config directory:
+globally across all projects, use the install script with `--path`:
 
 ```bash
-mkdir -p ~/.config/opencode/agents
-cp integrations/opencode/agents/*.md ~/.config/opencode/agents/
+./scripts/install.sh --tool opencode --path ~/.config/opencode/agents
 ```
 
 ## Regenerate


### PR DESCRIPTION
## Summary
- Fixes the opencode README's "Project vs Global" section which told users to `cp integrations/opencode/agents/*.md` — those files are gitignored and don't exist in the repo
- Replaces with `./scripts/install.sh --tool opencode --path ~/.config/opencode/agents` which handles conversion and copying

Closes #245

## Test plan
- [ ] Verify `./scripts/install.sh --tool opencode --path ~/.config/opencode/agents` works for global install