### PR TITLE
refactor: sync agent directory lists across all scripts

### DIFF
--- a/scripts/convert.sh
+++ b/scripts/convert.sh
@@ -61,8 +61,8 @@ OUT_DIR="$REPO_ROOT/integrations"
 TODAY="$(date +%Y-%m-%d)"
 
 AGENT_DIRS=(
-  academic design engineering game-development marketing paid-media sales product project-management
-  testing support spatial-computing specialized
+  academic design engineering game-development marketing paid-media product project-management
+  sales spatial-computing specialized strategy support testing
 )
 
 # --- Usage ---

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -103,6 +103,12 @@ INTEGRATIONS="$REPO_ROOT/integrations"
 
 ALL_TOOLS=(claude-code copilot antigravity gemini-cli opencode openclaw cursor aider windsurf qwen)
 
+# Standard agent category directories (keep sorted, sync with convert.sh / lint-agents.sh)
+AGENT_DIRS=(
+  academic design engineering game-development marketing paid-media product project-management
+  sales spatial-computing specialized strategy support testing
+)
+
 # ---------------------------------------------------------------------------
 # Usage
 # ---------------------------------------------------------------------------
@@ -298,8 +304,7 @@ install_claude_code() {
   local count=0
   mkdir -p "$dest"
   local dir f first_line
-  for dir in academic design engineering game-development marketing paid-media sales product project-management \
-              testing support spatial-computing specialized; do
+  for dir in "${AGENT_DIRS[@]}"; do
     [[ -d "$REPO_ROOT/$dir" ]] || continue
     while IFS= read -r -d '' f; do
       first_line="$(head -1 "$f")"
@@ -317,8 +322,7 @@ install_copilot() {
   local count=0
   mkdir -p "$dest_github" "$dest_copilot"
   local dir f first_line
-  for dir in academic design engineering game-development marketing paid-media sales product project-management \
-              testing support spatial-computing specialized; do
+  for dir in "${AGENT_DIRS[@]}"; do
     [[ -d "$REPO_ROOT/$dir" ]] || continue
     while IFS= read -r -d '' f; do
       first_line="$(head -1 "$f")"

--- a/scripts/lint-agents.sh
+++ b/scripts/lint-agents.sh
@@ -11,6 +11,7 @@
 set -euo pipefail
 
 AGENT_DIRS=(
+  academic
   design
   engineering
   game-development
@@ -18,10 +19,12 @@ AGENT_DIRS=(
   paid-media
   product
   project-management
-  testing
-  support
+  sales
   spatial-computing
   specialized
+  strategy
+  support
+  testing
 )
 
 REQUIRED_FRONTMATTER=("name" "description" "color")


### PR DESCRIPTION
## Summary

The three shell scripts each maintained their own hardcoded list of agent category directories, which had drifted out of sync. This caused some agent categories to be silently skipped during linting, conversion, or installation.

## Problem

| Directory | `convert.sh` | `install.sh` | `lint-agents.sh` |
|-----------|:---:|:---:|:---:|
| `academic/` | ✅ | ✅ | ❌ **missing** |
| `sales/` | ✅ | ✅ | ❌ **missing** |
| `strategy/` | ❌ **missing** | ❌ **missing** | ❌ **missing** |

This means:
- **`lint-agents.sh`** never linted agents in `academic/`, `sales/`, or `strategy/`
- **`convert.sh`** never converted agents in `strategy/`
- **`install.sh`** never installed agents from `strategy/`

## Changes

### 1. Add missing directories to all three scripts
All scripts now include the same 14 directories, sorted alphabetically:
```
academic design engineering game-development marketing paid-media
product project-management sales spatial-computing specialized
strategy support testing
```

### 2. Extract shared `AGENT_DIRS` constant in `install.sh`
Previously, `install_claude_code()` and `install_copilot()` each had their own identical inline directory list. Now both reference a single `AGENT_DIRS` array, matching the pattern already used by `convert.sh` and `lint-agents.sh`.

### 3. Sort entries alphabetically
Makes it trivial to spot missing entries when new directories are added.

## Files Changed

| File | Change |
|------|--------|
| `scripts/lint-agents.sh` | Added `academic`, `sales`, `strategy`; sorted entries |
| `scripts/convert.sh` | Added `strategy`; sorted entries |
| `scripts/install.sh` | Extracted `AGENT_DIRS` constant; added `strategy`; replaced 2 inline loops |

## Impact

- **3 files changed, 15 insertions, 8 deletions**
- **Zero breaking changes** — only adds previously-skipped directories
- Agents in `academic/`, `sales/`, and `strategy/` will now be properly linted, converted, and installed
- Future directory additions only need updating in one place per script (the `AGENT_DIRS` array)

## Testing

```bash
# Verify lint now picks up all dirs
./scripts/lint-agents.sh

# Verify convert processes strategy/
./scripts/convert.sh --tool cursor
ls integrations/cursor/rules/ | grep strategy

# Verify install uses shared constant
grep -n 'AGENT_DIRS' scripts/install.sh
```