### PR TITLE
fix: sync agent directories in lint scripts and CI workflow

### DIFF
--- a/.github/workflows/lint-agents.yml
+++ b/.github/workflows/lint-agents.yml
@@ -3,6 +3,7 @@ name: Lint Agent Files
 on:
   pull_request:
     paths:
+      - 'academic/**'
       - 'design/**'
       - 'engineering/**'
       - 'game-development/**'
@@ -29,7 +30,7 @@ jobs:
         id: changed
         run: |
           FILES=$(git diff --name-only --diff-filter=ACMR origin/${{ github.base_ref }}...HEAD -- \
-            'design/**/*.md' 'engineering/**/*.md' 'game-development/**/*.md' 'marketing/**/*.md' 'paid-media/**/*.md' 'sales/**/*.md' 'product/**/*.md' \
+            'academic/**/*.md' 'design/**/*.md' 'engineering/**/*.md' 'game-development/**/*.md' 'marketing/**/*.md' 'paid-media/**/*.md' 'sales/**/*.md' 'product/**/*.md' \
             'project-management/**/*.md' 'testing/**/*.md' 'support/**/*.md' \
             'spatial-computing/**/*.md' 'specialized/**/*.md')
           {

--- a/scripts/lint-agents.sh
+++ b/scripts/lint-agents.sh
@@ -11,6 +11,7 @@
 set -euo pipefail
 
 AGENT_DIRS=(
+  academic
   design
   engineering
   game-development
@@ -18,6 +19,7 @@ AGENT_DIRS=(
   paid-media
   product
   project-management
+  sales
   testing
   support
   spatial-computing


### PR DESCRIPTION
## Summary

Fixes issue #242 - lint-agents.sh and CI workflow missing academic/ and sales/ directories

## Changes

1. **scripts/lint-agents.sh**: Added  and  to AGENT_DIRS array so local linting includes these directories

2. **.github/workflows/lint-agents.yml**: 
   - Added  to the paths trigger list
   - Added  to the git diff glob for changed file detection

## Why

-  was added in PR #219 with convert.sh and install.sh updates, but lint-agents.sh and lint-agents.yml were not updated
-  was covered by CI but missing from lint-agents.sh AGENT_DIRS

This ensures all agent directories are consistently covered by both local and CI linting.