### PR TITLE
fix: correct README scenario section ordering (4 before 5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ Scholarly rigor for world-building, storytelling, and narrative design.
 
 ---
 
-### Scenario 5: Paid Media Account Takeover
+### Scenario 4: Paid Media Account Takeover
 
 **Your Team**:
 
@@ -400,7 +400,7 @@ Scholarly rigor for world-building, storytelling, and narrative design.
 
 ---
 
-### Scenario 4: Full Agency Product Discovery
+### Scenario 5: Full Agency Product Discovery
 
 **Your Team**: All 8 divisions working in parallel on a single mission.
 


### PR DESCRIPTION
## Summary
- Swapped Scenario 4 and Scenario 5 headings in README.md so they appear in correct numerical order

## Details
Scenario 5 ("Paid Media Account Takeover") appeared before Scenario 4 ("Full Agency Product Discovery"). This fix renumbers them so sections appear in proper sequential order.

Fixes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)