### PR TITLE
fix: add missing dirs to lint/CI and generate opencode agents

### DIFF
--- a/.github/workflows/lint-agents.yml
+++ b/.github/workflows/lint-agents.yml
@@ -3,6 +3,7 @@ name: Lint Agent Files
 on:
   pull_request:
     paths:
+      - 'academic/**'
       - 'design/**'
       - 'engineering/**'
       - 'game-development/**'
@@ -11,6 +12,7 @@ on:
       - 'sales/**'
       - 'product/**'
       - 'project-management/**'
+      - 'strategy/**'
       - 'testing/**'
       - 'support/**'
       - 'spatial-computing/**'
@@ -29,8 +31,8 @@ jobs:
         id: changed
         run: |
           FILES=$(git diff --name-only --diff-filter=ACMR origin/${{ github.base_ref }}...HEAD -- \
-            'design/**/*.md' 'engineering/**/*.md' 'game-development/**/*.md' 'marketing/**/*.md' 'paid-media/**/*.md' 'sales/**/*.md' 'product/**/*.md' \
-            'project-management/**/*.md' 'testing/**/*.md' 'support/**/*.md' \
+            'academic/**/*.md' 'design/**/*.md' 'engineering/**/*.md' 'game-development/**/*.md' 'marketing/**/*.md' 'paid-media/**/*.md' 'sales/**/*.md' 'product/**/*.md' \
+            'project-management/**/*.md' 'strategy/**/*.md' 'testing/**/*.md' 'support/**/*.md' \
             'spatial-computing/**/*.md' 'specialized/**/*.md')
           {
             echo "files<<ENDOFLIST"

--- a/scripts/lint-agents.sh
+++ b/scripts/lint-agents.sh
@@ -11,6 +11,7 @@
 set -euo pipefail
 
 AGENT_DIRS=(
+  academic
   design
   engineering
   game-development
@@ -18,10 +19,12 @@ AGENT_DIRS=(
   paid-media
   product
   project-management
+  sales
   testing
   support
   spatial-computing
   specialized
+  strategy
 )
 
 REQUIRED_FRONTMATTER=("name" "description" "color")


### PR DESCRIPTION
## Summary
- Add `academic`, `sales`, `strategy` to `AGENT_DIRS` array in `scripts/lint-agents.sh`
- Add `academic/**` and `strategy/**` paths to CI workflow triggers and git diff filter in `.github/workflows/lint-agents.yml`
- Ran `./scripts/convert.sh --tool opencode` to regenerate opencode integration files (all were already up to date)

Closes #242, #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)