### PR TITLE
fix: clarify opencode README requires convert.sh before manual copy

### DIFF
--- a/integrations/opencode/README.md
+++ b/integrations/opencode/README.md
@@ -48,12 +48,20 @@ color: "#00FFFF"
 ## Project vs Global
 
 Agents in `.opencode/agents/` are **project-scoped**. To make them available
-globally across all projects, copy them to your OpenCode config directory:
+globally across all projects, first generate the agent files (they are not
+checked into the repo), then copy them to your OpenCode config directory:
 
 ```bash
+# Generate agent files first (required — the agents/ dir is not committed)
+./scripts/convert.sh --tool opencode
+
+# Then copy to global config
 mkdir -p ~/.config/opencode/agents
 cp integrations/opencode/agents/*.md ~/.config/opencode/agents/
 ```
+
+> **Note:** The recommended approach is `./scripts/install.sh --tool opencode`,
+> which handles both generation and installation automatically.
 
 ## Regenerate
 


### PR DESCRIPTION
## Summary
- Adds a note in the opencode README explaining that `integrations/opencode/agents/` does not exist until agent files are generated
- Documents two options: using `install.sh --tool opencode` (recommended) or running `convert.sh --tool opencode` before the manual `cp` command

Fixes #245

## Test plan
- [ ] Verify the README renders correctly on GitHub
- [ ] Confirm `install.sh --tool opencode` works end-to-end
- [ ] Confirm `convert.sh --tool opencode` generates the `integrations/opencode/agents/` directory before manual copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)