### PR TITLE
fix: rename 'Data Analytics Reporter' to 'Analytics Reporter'

### DIFF
--- a/strategy/QUICKSTART.md
+++ b/strategy/QUICKSTART.md
@@ -176,7 +176,7 @@ Feedback Synthesizer│ Studio Operations   │ Test Results Analyzer
 ────────────────────┼─────────────────────┼──────────────────────
 SUPPORT             │ SPATIAL             │ SPECIALIZED
 Support Responder   │ XR Interface Arch.  │ Agents Orchestrator
-Analytics Reporter  │ macOS Spatial/Metal │ Data Analytics Reporter
+Analytics Reporter  │ macOS Spatial/Metal │ Analytics Reporter
 Finance Tracker     │ XR Immersive Dev    │ LSP/Index Engineer
 Infra Maintainer    │ XR Cockpit Spec.    │ Sales Data Extraction
 Legal Compliance    │ visionOS Spatial    │ Data Consolidation

--- a/strategy/nexus-strategy.md
+++ b/strategy/nexus-strategy.md
@@ -66,7 +66,7 @@ Individual agents are powerful. But without coordination, they produce:
 | **Testing** | Evidence Collector, Reality Checker, Test Results Analyzer, Performance Benchmarker, API Tester, Tool Evaluator, Workflow Optimizer | Verify quality through evidence-based assessment |
 | **Support** | Support Responder, Analytics Reporter, Finance Tracker, Infrastructure Maintainer, Legal Compliance Checker, Executive Summary Generator | Sustain operations, compliance, and business intelligence |
 | **Spatial Computing** | XR Interface Architect, macOS Spatial/Metal Engineer, XR Immersive Developer, XR Cockpit Interaction Specialist, visionOS Spatial Engineer, Terminal Integration Specialist | Build immersive and spatial computing experiences |
-| **Specialized** | Agents Orchestrator, Data Analytics Reporter, LSP/Index Engineer, Sales Data Extraction Agent, Data Consolidation Agent, Report Distribution Agent | Cross-cutting coordination, deep analytics, and code intelligence |
+| **Specialized** | Agents Orchestrator, Analytics Reporter, LSP/Index Engineer, Sales Data Extraction Agent, Data Consolidation Agent, Report Distribution Agent | Cross-cutting coordination, deep analytics, and code intelligence |
 
 ---
 
@@ -321,7 +321,7 @@ This is the heart of NEXUS. The Agents Orchestrator manages a **task-by-task qua
 | Backend API | Backend Architect | API Tester | Performance Benchmarker |
 | Database | Backend Architect | API Tester | Analytics Reporter |
 | Mobile | Mobile App Builder | Evidence Collector | UX Researcher |
-| AI/ML Feature | AI Engineer | Test Results Analyzer | Data Analytics Reporter |
+| AI/ML Feature | AI Engineer | Test Results Analyzer | Analytics Reporter |
 | Infrastructure | DevOps Automator | Performance Benchmarker | Infrastructure Maintainer |
 | Premium Polish | Senior Developer | Evidence Collector | Visual Storyteller |
 | Rapid Prototype | Rapid Prototyper | Evidence Collector | Experiment Tracker |
@@ -1019,7 +1019,7 @@ Use the NEXUS QA Feedback Loop Protocol format
 | Agent | Superpower | Activation Trigger |
 |-------|-----------|-------------------|
 | Agents Orchestrator | Multi-agent pipeline management | Any multi-agent workflow |
-| Data Analytics Reporter | Business intelligence, deep analytics | Deep data analysis |
+| Analytics Reporter | Business intelligence, deep analytics | Deep data analysis |
 | LSP/Index Engineer | Language Server Protocol, code intelligence | Code intelligence systems |
 | Sales Data Extraction Agent | Excel monitoring, sales metric extraction | Sales data ingestion |
 | Data Consolidation Agent | Sales data aggregation, dashboard reports | Territory and rep reporting |

--- a/strategy/playbooks/phase-3-build.md
+++ b/strategy/playbooks/phase-3-build.md
@@ -72,7 +72,7 @@ FOR EACH task IN sprint_backlog (ordered by RICE score):
 | Visual Storyteller | Visual narrative content needed | Content requires visual assets |
 | Brand Guardian | Brand consistency concern | QA finds brand deviation |
 | XR Interface Architect | Spatial interaction design needed | XR feature requires UX guidance |
-| Data Analytics Reporter | Deep data analysis needed | Feature requires analytics integration |
+| Analytics Reporter | Deep data analysis needed | Feature requires analytics integration |
 
 ## Parallel Build Tracks
 

--- a/strategy/playbooks/phase-6-operate.md
+++ b/strategy/playbooks/phase-6-operate.md
@@ -76,7 +76,7 @@ Sustained operations with continuous improvement. The product is live — now ma
 MEASURE (Analytics Reporter)
     │
     ▼
-ANALYZE (Feedback Synthesizer + Data Analytics Reporter)
+ANALYZE (Feedback Synthesizer + Analytics Reporter)
     │
     ▼
 PLAN (Sprint Prioritizer + Studio Producer)


### PR DESCRIPTION
## Summary
- Renamed all occurrences of "Data Analytics Reporter" to "Analytics Reporter" across 4 strategy files
- Files changed: `strategy/nexus-strategy.md`, `strategy/QUICKSTART.md`, `strategy/playbooks/phase-3-build.md`, `strategy/playbooks/phase-6-operate.md`

Fixes #291

## Test plan
- [x] Verified with grep that zero occurrences of "Data Analytics Reporter" remain in the repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)