### PR TITLE
fix: add post-install guidance for VS Code agent paths

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -330,6 +330,10 @@ install_copilot() {
   done
   ok "Copilot: $count agents -> $dest_github"
   ok "Copilot: $count agents -> $dest_copilot"
+  dim "Tip: if agents don't appear in VS Code Copilot Chat, add these paths"
+  dim "     to \"chat.agentFilesLocations\" in your VS Code settings.json:"
+  dim "       \"$dest_github\""
+  dim "       \"$dest_copilot\""
 }
 
 install_antigravity() {


### PR DESCRIPTION
## Summary
- After installing copilot agents, the install script now displays a post-install reminder to add `~/.github/agents` and `~/.copilot/agents` to the `chat.agentFilesLocations` setting in VS Code's `settings.json`
- The message only appears when copilot is among the selected/installed tools
- Prevents user confusion when installed agents aren't discovered by VS Code

Fixes #185
Fixes #218

## Test plan
- [ ] Run `./scripts/install.sh --tool copilot --no-interactive` and verify the VS Code setup message appears after the "Done" box
- [ ] Run `./scripts/install.sh --tool claude-code --no-interactive` and verify the VS Code message does NOT appear
- [ ] Run `./scripts/install.sh --no-interactive` with copilot detected and verify the message appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)