### PR TITLE
fix: add academic/ and sales/ to lint script and CI paths

### DIFF
--- a/.github/workflows/lint-agents.yml
+++ b/.github/workflows/lint-agents.yml
@@ -3,6 +3,7 @@ name: Lint Agent Files
 on:
   pull_request:
     paths:
+      - 'academic/**'
       - 'design/**'
       - 'engineering/**'
       - 'game-development/**'
@@ -29,7 +30,7 @@ jobs:
         id: changed
         run: |
           FILES=$(git diff --name-only --diff-filter=ACMR origin/${{ github.base_ref }}...HEAD -- \
-            'design/**/*.md' 'engineering/**/*.md' 'game-development/**/*.md' 'marketing/**/*.md' 'paid-media/**/*.md' 'sales/**/*.md' 'product/**/*.md' \
+            'academic/**/*.md' 'design/**/*.md' 'engineering/**/*.md' 'game-development/**/*.md' 'marketing/**/*.md' 'paid-media/**/*.md' 'sales/**/*.md' 'product/**/*.md' \
             'project-management/**/*.md' 'testing/**/*.md' 'support/**/*.md' \
             'spatial-computing/**/*.md' 'specialized/**/*.md')
           {

--- a/scripts/lint-agents.sh
+++ b/scripts/lint-agents.sh
@@ -11,6 +11,7 @@
 set -euo pipefail
 
 AGENT_DIRS=(
+  academic
   design
   engineering
   game-development
@@ -18,6 +19,7 @@ AGENT_DIRS=(
   paid-media
   product
   project-management
+  sales
   testing
   support
   spatial-computing


### PR DESCRIPTION
## Summary

- Added `academic` and `sales` to the `AGENT_DIRS` array in `scripts/lint-agents.sh` so the linter scans those directories
- Added `'academic/**'` to the CI workflow `paths:` trigger so PRs touching academic agents trigger the lint job
- Added `'academic/**/*.md'` to the `git diff` glob so changed academic files are passed to the linter

Note: `sales/` was already present in the CI workflow paths and git diff glob, but was missing from the lint script's `AGENT_DIRS` array.

Fixes #242

## Test plan

- [ ] Verify `./scripts/lint-agents.sh` picks up files in `academic/` and `sales/`
- [ ] Verify CI triggers on PRs modifying `academic/**` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)