### PR TITLE
fix: correct README scenario section ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ Scholarly rigor for world-building, storytelling, and narrative design.
 
 ---
 
-### Scenario 5: Paid Media Account Takeover
+### Scenario 4: Paid Media Account Takeover
 
 **Your Team**:
 
@@ -400,7 +400,7 @@ Scholarly rigor for world-building, storytelling, and narrative design.
 
 ---
 
-### Scenario 4: Full Agency Product Discovery
+### Scenario 5: Full Agency Product Discovery
 
 **Your Team**: All 8 divisions working in parallel on a single mission.
 


### PR DESCRIPTION
## Summary
- Scenario 5 (Paid Media Account Takeover) was listed before Scenario 4 (Full Agency Product Discovery), breaking sequential order
- Swapped the section numbers so they read 1, 2, 3, 4, 5

## Test plan
- [x] Verify `grep -n '### Scenario' README.md` shows correct 1-5 ordering

Fixes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)