### PR TITLE
Add strategy directory to install/convert scripts and fix Claude Code…

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,14 @@ Born from a Reddit thread and months of iteration, **The Agency** is a growing c
 ### Option 1: Use with Claude Code (Recommended)
 
 ```bash
-# Copy agents to your Claude Code directory
-cp -r agency-agents/* ~/.claude/agents/
+# Install agents directly into your Claude Code agents directory
+./scripts/install.sh --tool claude-code --no-interactive
 
 # Now activate any agent in your Claude Code sessions:
 # "Hey Claude, activate Frontend Developer mode and help me build a React component"
 ```
+
+> **Note**: The install script flattens all agent `.md` files into `~/.claude/agents/` so Claude Code can discover and activate them. Running `cp -r` directly copies subdirectories instead, which may prevent agent discovery.
 
 ### Option 2: Use as Reference
 

--- a/scripts/convert.sh
+++ b/scripts/convert.sh
@@ -62,7 +62,7 @@ TODAY="$(date +%Y-%m-%d)"
 
 AGENT_DIRS=(
   academic design engineering game-development marketing paid-media sales product project-management
-  testing support spatial-computing specialized
+  testing support spatial-computing specialized strategy
 )
 
 # --- Usage ---

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -299,7 +299,7 @@ install_claude_code() {
   mkdir -p "$dest"
   local dir f first_line
   for dir in academic design engineering game-development marketing paid-media sales product project-management \
-              testing support spatial-computing specialized; do
+              testing support spatial-computing specialized strategy; do
     [[ -d "$REPO_ROOT/$dir" ]] || continue
     while IFS= read -r -d '' f; do
       first_line="$(head -1 "$f")"
@@ -318,7 +318,7 @@ install_copilot() {
   mkdir -p "$dest_github" "$dest_copilot"
   local dir f first_line
   for dir in academic design engineering game-development marketing paid-media sales product project-management \
-              testing support spatial-computing specialized; do
+              testing support spatial-computing specialized strategy; do
     [[ -d "$REPO_ROOT/$dir" ]] || continue
     while IFS= read -r -d '' f; do
       first_line="$(head -1 "$f")"


### PR DESCRIPTION
… quickstart

- Add `strategy` to directory loops in scripts/install.sh (claude-code and copilot installers)
- Add `strategy` to AGENT_DIRS in scripts/convert.sh for integration generation
- Update README Option 1 to use install.sh instead of cp -r, which copies subdirectories and may prevent Claude Code from discovering agents; add explanatory note

https://claude.ai/code/session_012ACkmAkW3rotsG2qc576ds

## What does this PR do?

<!-- Brief description of the change -->

## Agent Information (if adding/modifying an agent)

- **Agent Name**:
- **Category**:
- **Specialty**:

## Checklist

- [ ] Follows the agent template structure from CONTRIBUTING.md
- [ ] Includes YAML frontmatter with `name`, `description`, `color`
- [ ] Has concrete code/template examples (for new agents)
- [ ] Tested in real scenarios
- [ ] Proofread and formatted correctly
