### PR TITLE
docs: fix markdown table rendering in Product Division

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,6 @@ Building the right thing at the right time.
 | 🔍 [Trend Researcher](product/product-trend-researcher.md) | Market intelligence, competitive analysis | Market research, opportunity assessment, trend identification |
 | 💬 [Feedback Synthesizer](product/product-feedback-synthesizer.md) | User feedback analysis, insights extraction | Feedback analysis, user insights, product priorities |
 | 🧠 [Behavioral Nudge Engine](product/product-behavioral-nudge-engine.md) | Behavioral psychology, nudge design, engagement | Maximizing user motivation through behavioral science |
-
 | 🧭 [Product Manager](product/product-manager.md) | Full lifecycle product ownership | Discovery, PRDs, roadmap planning, GTM, outcome measurement |
 
 ### 🎬 Project Management Division


### PR DESCRIPTION
Fixed a markdown formatting issue in the README.md.
The `Product Manager` row wasn't rendering as part of the `Product Division` table due to an extra newline at line 187 that broke the markdown parser. This PR removes the line break to restore the table structure.
