### PR TITLE
CI: run agent lint on academic changes; expand default lint directories

### DIFF
--- a/.github/workflows/lint-agents.yml
+++ b/.github/workflows/lint-agents.yml
@@ -3,18 +3,19 @@ name: Lint Agent Files
 on:
   pull_request:
     paths:
-      - 'design/**'
-      - 'engineering/**'
-      - 'game-development/**'
-      - 'marketing/**'
-      - 'paid-media/**'
-      - 'sales/**'
-      - 'product/**'
-      - 'project-management/**'
-      - 'testing/**'
-      - 'support/**'
-      - 'spatial-computing/**'
-      - 'specialized/**'
+      - "academic/**"
+      - "design/**"
+      - "engineering/**"
+      - "game-development/**"
+      - "marketing/**"
+      - "paid-media/**"
+      - "sales/**"
+      - "product/**"
+      - "project-management/**"
+      - "testing/**"
+      - "support/**"
+      - "spatial-computing/**"
+      - "specialized/**"
 
 jobs:
   lint:
@@ -29,7 +30,7 @@ jobs:
         id: changed
         run: |
           FILES=$(git diff --name-only --diff-filter=ACMR origin/${{ github.base_ref }}...HEAD -- \
-            'design/**/*.md' 'engineering/**/*.md' 'game-development/**/*.md' 'marketing/**/*.md' 'paid-media/**/*.md' 'sales/**/*.md' 'product/**/*.md' \
+            'academic/**/*.md' 'design/**/*.md' 'engineering/**/*.md' 'game-development/**/*.md' 'marketing/**/*.md' 'paid-media/**/*.md' 'sales/**/*.md' 'product/**/*.md' \
             'project-management/**/*.md' 'testing/**/*.md' 'support/**/*.md' \
             'spatial-computing/**/*.md' 'specialized/**/*.md')
           {

--- a/scripts/lint-agents.sh
+++ b/scripts/lint-agents.sh
@@ -10,12 +10,15 @@
 
 set -euo pipefail
 
+# Keep in sync with AGENT_DIRS in scripts/convert.sh
 AGENT_DIRS=(
+  academic
   design
   engineering
   game-development
   marketing
   paid-media
+  sales
   product
   project-management
   testing
@@ -32,6 +35,12 @@ warnings=0
 
 lint_file() {
   local file="$1"
+
+  if [[ ! -f "$file" ]]; then
+    echo "ERROR $file: not a file or does not exist"
+    errors=$((errors + 1))
+    return
+  fi
 
   # 1. Check frontmatter delimiters
   local first_line
@@ -71,8 +80,10 @@ lint_file() {
     fi
   done
 
-  # 4. Check file has meaningful content
-  if [[ $(echo "$body" | wc -w) -lt 50 ]]; then
+  # 4. Check file has meaningful content (awk strips wc's leading whitespace on macOS/BSD)
+  local word_count
+  word_count=$(echo "$body" | wc -w | awk '{print $1}')
+  if [[ "${word_count:-0}" -lt 50 ]]; then
     echo "WARN  $file: body seems very short (< 50 words)"
     warnings=$((warnings + 1))
   fi


### PR DESCRIPTION
## What does this PR do?

This PR aligns lint-agents.sh with convert.sh by scanning academic/ and sales/, adds academic/** to the PR lint workflow’s paths and diff globs, and hardens the linter with explicit missing-file errors and a portable word-count check.

## Agent Information (if adding/modifying an agent)

- **Agent Name**: N/A (tooling only)
- **Category**: N/A
- **Specialty**: N/A

## Checklist

- [ ] Follows the agent template structure from CONTRIBUTING.md
- [ ] Includes YAML frontmatter with `name`, `description`, `color`
- [ ] Has concrete code/template examples (for new agents)
- [x] Tested in real scenarios
- [x] Proofread and formatted correctly