### PR TITLE
fix: convert agent colors to valid opencode format

### DIFF
--- a/design/design-brand-guardian.md
+++ b/design/design-brand-guardian.md
@@ -1,7 +1,7 @@
 ---
 name: Brand Guardian
 description: Expert brand strategist and guardian specializing in brand identity development, consistency maintenance, and strategic brand positioning
-color: blue
+color: "#3B82F6"
 ---
 
 # Brand Guardian Agent Personality

--- a/design/design-image-prompt-engineer.md
+++ b/design/design-image-prompt-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: Image Prompt Engineer
 description: Expert photography prompt engineer specializing in crafting detailed, evocative prompts for AI image generation. Masters the art of translating visual concepts into precise language that produces stunning, professional-quality photography through generative AI tools.
-color: amber
+color: "#F59E0B"
 ---
 
 # Image Prompt Engineer Agent

--- a/design/design-ui-designer.md
+++ b/design/design-ui-designer.md
@@ -1,7 +1,7 @@
 ---
 name: UI Designer
 description: Expert UI designer specializing in visual design systems, component libraries, and pixel-perfect interface creation. Creates beautiful, consistent, accessible user interfaces that enhance UX and reflect brand identity
-color: purple
+color: "#8B5CF6"
 ---
 
 # UI Designer Agent Personality

--- a/design/design-ux-architect.md
+++ b/design/design-ux-architect.md
@@ -1,7 +1,7 @@
 ---
 name: UX Architect
 description: Technical architecture and UX specialist who provides developers with solid foundations, CSS systems, and clear implementation guidance
-color: purple
+color: "#8B5CF6"
 ---
 
 # ArchitectUX Agent Personality

--- a/design/design-ux-researcher.md
+++ b/design/design-ux-researcher.md
@@ -1,7 +1,7 @@
 ---
 name: UX Researcher
 description: Expert user experience researcher specializing in user behavior analysis, usability testing, and data-driven design insights. Provides actionable research findings that improve product usability and user satisfaction
-color: green
+color: "#10B981"
 ---
 
 # UX Researcher Agent Personality

--- a/design/design-visual-storyteller.md
+++ b/design/design-visual-storyteller.md
@@ -1,7 +1,7 @@
 ---
 name: Visual Storyteller
 description: Expert visual communication specialist focused on creating compelling visual narratives, multimedia content, and brand storytelling through design. Specializes in transforming complex information into engaging visual stories that connect with audiences and drive emotional engagement.
-color: purple
+color: "#8B5CF6"
 ---
 
 # Visual Storyteller Agent

--- a/design/design-whimsy-injector.md
+++ b/design/design-whimsy-injector.md
@@ -1,7 +1,7 @@
 ---
 name: Whimsy Injector
 description: Expert creative specialist focused on adding personality, delight, and playful elements to brand experiences. Creates memorable, joyful interactions that differentiate brands through unexpected moments of whimsy
-color: pink
+color: "#EC4899"
 ---
 
 # Whimsy Injector Agent Personality

--- a/engineering/engineering-ai-engineer.md
+++ b/engineering/engineering-ai-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: AI Engineer
 description: Expert AI/ML engineer specializing in machine learning model development, deployment, and integration into production systems. Focused on building intelligent features, data pipelines, and AI-powered applications with emphasis on practical, scalable solutions.
-color: blue
+color: "#3B82F6"
 ---
 
 # AI Engineer Agent

--- a/engineering/engineering-backend-architect.md
+++ b/engineering/engineering-backend-architect.md
@@ -1,7 +1,7 @@
 ---
 name: Backend Architect
 description: Senior backend architect specializing in scalable system design, database architecture, API development, and cloud infrastructure. Builds robust, secure, performant server-side applications and microservices
-color: blue
+color: "#3B82F6"
 ---
 
 # Backend Architect Agent Personality

--- a/engineering/engineering-data-engineer.md
+++ b/engineering/engineering-data-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: Data Engineer
 description: Expert data engineer specializing in building reliable data pipelines, lakehouse architectures, and scalable data infrastructure. Masters ETL/ELT, Apache Spark, dbt, streaming systems, and cloud data platforms to turn raw data into trusted, analytics-ready assets.
-color: orange
+color: "#F97316"
 ---
 
 # Data Engineer Agent

--- a/engineering/engineering-devops-automator.md
+++ b/engineering/engineering-devops-automator.md
@@ -1,7 +1,7 @@
 ---
 name: DevOps Automator
 description: Expert DevOps engineer specializing in infrastructure automation, CI/CD pipeline development, and cloud operations
-color: orange
+color: "#F97316"
 ---
 
 # DevOps Automator Agent Personality

--- a/engineering/engineering-embedded-firmware-engineer.md
+++ b/engineering/engineering-embedded-firmware-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: Embedded Firmware Engineer
 description: Specialist in bare-metal and RTOS firmware - ESP32/ESP-IDF, PlatformIO, Arduino, ARM Cortex-M, STM32 HAL/LL, Nordic nRF5/nRF Connect SDK, FreeRTOS, Zephyr
-color: orange
+color: "#F97316"
 ---
 
 # Embedded Firmware Engineer

--- a/engineering/engineering-frontend-developer.md
+++ b/engineering/engineering-frontend-developer.md
@@ -1,7 +1,7 @@
 ---
 name: Frontend Developer
 description: Expert frontend developer specializing in modern web technologies, React/Vue/Angular frameworks, UI implementation, and performance optimization
-color: cyan
+color: "#06B6D4"
 ---
 
 # Frontend Developer Agent Personality

--- a/engineering/engineering-mobile-app-builder.md
+++ b/engineering/engineering-mobile-app-builder.md
@@ -1,7 +1,7 @@
 ---
 name: Mobile App Builder
 description: Specialized mobile application developer with expertise in native iOS/Android development and cross-platform frameworks
-color: purple
+color: "#8B5CF6"
 ---
 
 # Mobile App Builder Agent Personality

--- a/engineering/engineering-rapid-prototyper.md
+++ b/engineering/engineering-rapid-prototyper.md
@@ -1,7 +1,7 @@
 ---
 name: Rapid Prototyper
 description: Specialized in ultra-fast proof-of-concept development and MVP creation using efficient tools and frameworks
-color: green
+color: "#10B981"
 ---
 
 # Rapid Prototyper Agent Personality

--- a/engineering/engineering-security-engineer.md
+++ b/engineering/engineering-security-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: Security Engineer
 description: Expert application security engineer specializing in threat modeling, vulnerability assessment, secure code review, and security architecture design for modern web and cloud-native applications.
-color: red
+color: "#EF4444"
 ---
 
 # Security Engineer Agent

--- a/engineering/engineering-senior-developer.md
+++ b/engineering/engineering-senior-developer.md
@@ -1,7 +1,7 @@
 ---
 name: Senior Developer
 description: Premium implementation specialist - Masters Laravel/Livewire/FluxUI, advanced CSS, Three.js integration
-color: green
+color: "#10B981"
 ---
 
 # Developer Agent Personality

--- a/engineering/engineering-technical-writer.md
+++ b/engineering/engineering-technical-writer.md
@@ -1,7 +1,7 @@
 ---
 name: Technical Writer
 description: Expert technical writer specializing in developer documentation, API references, README files, and tutorials. Transforms complex engineering concepts into clear, accurate, and engaging docs that developers actually read and use.
-color: teal
+color: "#14B8A6"
 ---
 
 # Technical Writer Agent

--- a/marketing/marketing-app-store-optimizer.md
+++ b/marketing/marketing-app-store-optimizer.md
@@ -1,7 +1,7 @@
 ---
 name: App Store Optimizer
 description: Expert app store marketing specialist focused on App Store Optimization (ASO), conversion rate optimization, and app discoverability
-color: blue
+color: "#3B82F6"
 ---
 
 # App Store Optimizer Agent Personality

--- a/marketing/marketing-content-creator.md
+++ b/marketing/marketing-content-creator.md
@@ -2,7 +2,7 @@
 name: Content Creator
 description: Expert content strategist and creator for multi-platform campaigns. Develops editorial calendars, creates compelling copy, manages brand storytelling, and optimizes content for engagement across all digital channels.
 tools: WebFetch, WebSearch, Read, Write, Edit
-color: teal
+color: "#14B8A6"
 ---
 
 # Marketing Content Creator Agent

--- a/marketing/marketing-growth-hacker.md
+++ b/marketing/marketing-growth-hacker.md
@@ -2,7 +2,7 @@
 name: Growth Hacker
 description: Expert growth strategist specializing in rapid user acquisition through data-driven experimentation. Develops viral loops, optimizes conversion funnels, and finds scalable growth channels for exponential business growth.
 tools: WebFetch, WebSearch, Read, Write, Edit
-color: green
+color: "#10B981"
 ---
 
 # Marketing Growth Hacker Agent

--- a/marketing/marketing-social-media-strategist.md
+++ b/marketing/marketing-social-media-strategist.md
@@ -2,7 +2,7 @@
 name: Social Media Strategist
 description: Expert social media strategist for LinkedIn, Twitter, and professional platforms. Creates cross-platform campaigns, builds communities, manages real-time engagement, and develops thought leadership strategies.
 tools: WebFetch, WebSearch, Read, Write, Edit
-color: blue
+color: "#3B82F6"
 ---
 
 # Social Media Strategist Agent

--- a/product/product-feedback-synthesizer.md
+++ b/product/product-feedback-synthesizer.md
@@ -1,7 +1,7 @@
 ---
 name: Feedback Synthesizer
 description: Expert in collecting, analyzing, and synthesizing user feedback from multiple channels to extract actionable product insights. Transforms qualitative feedback into quantitative priorities and strategic recommendations.
-color: blue
+color: "#3B82F6"
 tools: WebFetch, WebSearch, Read, Write, Edit
 ---
 

--- a/product/product-sprint-prioritizer.md
+++ b/product/product-sprint-prioritizer.md
@@ -1,7 +1,7 @@
 ---
 name: Sprint Prioritizer
 description: Expert product manager specializing in agile sprint planning, feature prioritization, and resource allocation. Focused on maximizing team velocity and business value delivery through data-driven prioritization frameworks.
-color: green
+color: "#10B981"
 tools: WebFetch, WebSearch, Read, Write, Edit
 ---
 

--- a/product/product-trend-researcher.md
+++ b/product/product-trend-researcher.md
@@ -1,7 +1,7 @@
 ---
 name: Trend Researcher
 description: Expert market intelligence analyst specializing in identifying emerging trends, competitive analysis, and opportunity assessment. Focused on providing actionable insights that drive product strategy and innovation decisions.
-color: purple
+color: "#8B5CF6"
 tools: WebFetch, WebSearch, Read, Write, Edit
 ---
 

--- a/project-management/project-management-experiment-tracker.md
+++ b/project-management/project-management-experiment-tracker.md
@@ -1,7 +1,7 @@
 ---
 name: Experiment Tracker
 description: Expert project manager specializing in experiment design, execution tracking, and data-driven decision making. Focused on managing A/B tests, feature experiments, and hypothesis validation through systematic experimentation and rigorous analysis.
-color: purple
+color: "#8B5CF6"
 ---
 
 # Experiment Tracker Agent Personality

--- a/project-management/project-management-project-shepherd.md
+++ b/project-management/project-management-project-shepherd.md
@@ -1,7 +1,7 @@
 ---
 name: Project Shepherd
 description: Expert project manager specializing in cross-functional project coordination, timeline management, and stakeholder alignment. Focused on shepherding projects from conception to completion while managing resources, risks, and communications across multiple teams and departments.
-color: blue
+color: "#3B82F6"
 ---
 
 # Project Shepherd Agent Personality

--- a/project-management/project-management-studio-operations.md
+++ b/project-management/project-management-studio-operations.md
@@ -1,7 +1,7 @@
 ---
 name: Studio Operations
 description: Expert operations manager specializing in day-to-day studio efficiency, process optimization, and resource coordination. Focused on ensuring smooth operations, maintaining productivity standards, and supporting all teams with the tools and processes needed for success.
-color: green
+color: "#10B981"
 ---
 
 # Studio Operations Agent Personality

--- a/project-management/project-management-studio-producer.md
+++ b/project-management/project-management-studio-producer.md
@@ -1,7 +1,7 @@
 ---
 name: Studio Producer
 description: Senior strategic leader specializing in high-level creative and technical project orchestration, resource allocation, and multi-project portfolio management. Focused on aligning creative vision with business objectives while managing complex cross-functional initiatives and ensuring optimal studio operations.
-color: gold
+color: "#EAB308"
 ---
 
 # Studio Producer Agent Personality

--- a/project-management/project-manager-senior.md
+++ b/project-management/project-manager-senior.md
@@ -1,7 +1,7 @@
 ---
 name: Senior Project Manager
 description: Converts specs to tasks and remembers previous projects. Focused on realistic scope, no background processes, exact spec requirements
-color: blue
+color: "#3B82F6"
 ---
 
 # Project Manager Agent Personality

--- a/spatial-computing/macos-spatial-metal-engineer.md
+++ b/spatial-computing/macos-spatial-metal-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: macOS Spatial/Metal Engineer
 description: Native Swift and Metal specialist building high-performance 3D rendering systems and spatial computing experiences for macOS and Vision Pro
-color: metallic-blue
+color: "#6B7280"
 ---
 
 # macOS Spatial/Metal Engineer Agent Personality

--- a/spatial-computing/terminal-integration-specialist.md
+++ b/spatial-computing/terminal-integration-specialist.md
@@ -1,7 +1,7 @@
 ---
 name: Terminal Integration Specialist
 description: Terminal emulation, text rendering optimization, and SwiftTerm integration for modern Swift applications
-color: green
+color: "#10B981"
 ---
 
 # Terminal Integration Specialist

--- a/spatial-computing/visionos-spatial-engineer.md
+++ b/spatial-computing/visionos-spatial-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: visionOS Spatial Engineer
 description: Native visionOS spatial computing, SwiftUI volumetric interfaces, and Liquid Glass design implementation
-color: indigo
+color: "#6366F1"
 ---
 
 # visionOS Spatial Engineer

--- a/spatial-computing/xr-cockpit-interaction-specialist.md
+++ b/spatial-computing/xr-cockpit-interaction-specialist.md
@@ -1,7 +1,7 @@
 ---
 name: XR Cockpit Interaction Specialist
 description: Specialist in designing and developing immersive cockpit-based control systems for XR environments
-color: orange
+color: "#F97316"
 ---
 
 # XR Cockpit Interaction Specialist Agent Personality

--- a/spatial-computing/xr-immersive-developer.md
+++ b/spatial-computing/xr-immersive-developer.md
@@ -1,7 +1,7 @@
 ---
 name: XR Immersive Developer
 description: Expert WebXR and immersive technology developer with specialization in browser-based AR/VR/XR applications
-color: neon-cyan
+color: "#06B6D4"
 ---
 
 # XR Immersive Developer Agent Personality

--- a/spatial-computing/xr-interface-architect.md
+++ b/spatial-computing/xr-interface-architect.md
@@ -1,7 +1,7 @@
 ---
 name: XR Interface Architect
 description: Spatial interaction designer and interface strategist for immersive AR/VR/XR environments
-color: neon-green
+color: "#22C55E"
 ---
 
 # XR Interface Architect Agent Personality

--- a/specialized/accounts-payable-agent.md
+++ b/specialized/accounts-payable-agent.md
@@ -1,7 +1,7 @@
 ---
 name: Accounts Payable Agent
 description: Autonomous payment processing specialist that executes vendor payments, contractor invoices, and recurring bills across any payment rail — crypto, fiat, stablecoins. Integrates with AI agent workflows via MCP.
-color: green
+color: "#10B981"
 ---
 
 # Accounts Payable Agent Personality

--- a/specialized/agents-orchestrator.md
+++ b/specialized/agents-orchestrator.md
@@ -1,7 +1,7 @@
 ---
 name: Agents Orchestrator
 description: Autonomous pipeline manager that orchestrates the entire development workflow. You are the leader of this process.
-color: cyan
+color: "#06B6D4"
 ---
 
 # AgentsOrchestrator Agent Personality

--- a/specialized/compliance-auditor.md
+++ b/specialized/compliance-auditor.md
@@ -1,7 +1,7 @@
 ---
 name: Compliance Auditor
 description: Expert technical compliance auditor specializing in SOC 2, ISO 27001, HIPAA, and PCI-DSS audits — from readiness assessment through evidence collection to certification.
-color: orange
+color: "#F97316"
 ---
 
 # Compliance Auditor Agent

--- a/specialized/data-analytics-reporter.md
+++ b/specialized/data-analytics-reporter.md
@@ -2,7 +2,7 @@
 name: Data Analytics Reporter
 description: Expert data analyst transforming raw data into actionable business insights. Creates dashboards, performs statistical analysis, tracks KPIs, and provides strategic decision support through data visualization and reporting.
 tools: WebFetch, WebSearch, Read, Write, Edit
-color: indigo
+color: "#6366F1"
 ---
 
 # Data Analytics Reporter Agent

--- a/specialized/lsp-index-engineer.md
+++ b/specialized/lsp-index-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: LSP/Index Engineer
 description: Language Server Protocol specialist building unified code intelligence systems through LSP client orchestration and semantic indexing
-color: orange
+color: "#F97316"
 ---
 
 # LSP/Index Engineer Agent Personality

--- a/specialized/specialized-developer-advocate.md
+++ b/specialized/specialized-developer-advocate.md
@@ -1,7 +1,7 @@
 ---
 name: Developer Advocate
 description: Expert developer advocate specializing in building developer communities, creating compelling technical content, optimizing developer experience (DX), and driving platform adoption through authentic engineering engagement. Bridges product and engineering teams with external developers.
-color: purple
+color: "#8B5CF6"
 ---
 
 # Developer Advocate Agent

--- a/specialized/zk-steward.md
+++ b/specialized/zk-steward.md
@@ -1,7 +1,7 @@
 ---
 name: ZK Steward
 description: Knowledge-base steward in the spirit of Niklas Luhmann's Zettelkasten. Default perspective: Luhmann; switches to domain experts (Feynman, Munger, Ogilvy, etc.) by task. Enforces atomic notes, connectivity, and validation loops. Use for knowledge-base building, note linking, complex task breakdown, and cross-domain decision support.
-color: teal
+color: "#14B8A6"
 ---
 
 # ZK Steward Agent

--- a/support/support-analytics-reporter.md
+++ b/support/support-analytics-reporter.md
@@ -1,7 +1,7 @@
 ---
 name: Analytics Reporter
 description: Expert data analyst transforming raw data into actionable business insights. Creates dashboards, performs statistical analysis, tracks KPIs, and provides strategic decision support through data visualization and reporting.
-color: teal
+color: "#14B8A6"
 ---
 
 # Analytics Reporter Agent Personality

--- a/support/support-executive-summary-generator.md
+++ b/support/support-executive-summary-generator.md
@@ -1,7 +1,7 @@
 ---
 name: Executive Summary Generator
 description: Consultant-grade AI specialist trained to think and communicate like a senior strategy consultant. Transforms complex business inputs into concise, actionable executive summaries using McKinsey SCQA, BCG Pyramid Principle, and Bain frameworks for C-suite decision-makers.
-color: purple
+color: "#8B5CF6"
 ---
 
 # Executive Summary Generator Agent Personality

--- a/support/support-finance-tracker.md
+++ b/support/support-finance-tracker.md
@@ -1,7 +1,7 @@
 ---
 name: Finance Tracker
 description: Expert financial analyst and controller specializing in financial planning, budget management, and business performance analysis. Maintains financial health, optimizes cash flow, and provides strategic financial insights for business growth.
-color: green
+color: "#10B981"
 ---
 
 # Finance Tracker Agent Personality

--- a/support/support-infrastructure-maintainer.md
+++ b/support/support-infrastructure-maintainer.md
@@ -1,7 +1,7 @@
 ---
 name: Infrastructure Maintainer
 description: Expert infrastructure specialist focused on system reliability, performance optimization, and technical operations management. Maintains robust, scalable infrastructure supporting business operations with security, performance, and cost efficiency.
-color: orange
+color: "#F97316"
 ---
 
 # Infrastructure Maintainer Agent Personality

--- a/support/support-legal-compliance-checker.md
+++ b/support/support-legal-compliance-checker.md
@@ -1,7 +1,7 @@
 ---
 name: Legal Compliance Checker
 description: Expert legal and compliance specialist ensuring business operations, data handling, and content creation comply with relevant laws, regulations, and industry standards across multiple jurisdictions.
-color: red
+color: "#EF4444"
 ---
 
 # Legal Compliance Checker Agent Personality

--- a/support/support-support-responder.md
+++ b/support/support-support-responder.md
@@ -1,7 +1,7 @@
 ---
 name: Support Responder
 description: Expert customer support specialist delivering exceptional customer service, issue resolution, and user experience optimization. Specializes in multi-channel support, proactive customer care, and turning support interactions into positive brand experiences.
-color: blue
+color: "#3B82F6"
 ---
 
 # Support Responder Agent Personality

--- a/testing/testing-api-tester.md
+++ b/testing/testing-api-tester.md
@@ -1,7 +1,7 @@
 ---
 name: API Tester
 description: Expert API testing specialist focused on comprehensive API validation, performance testing, and quality assurance across all systems and third-party integrations
-color: purple
+color: "#8B5CF6"
 ---
 
 # API Tester Agent Personality

--- a/testing/testing-evidence-collector.md
+++ b/testing/testing-evidence-collector.md
@@ -1,7 +1,7 @@
 ---
 name: Evidence Collector
 description: Screenshot-obsessed, fantasy-allergic QA specialist - Default to finding 3-5 issues, requires visual proof for everything
-color: orange
+color: "#F97316"
 ---
 
 # QA Agent Personality

--- a/testing/testing-performance-benchmarker.md
+++ b/testing/testing-performance-benchmarker.md
@@ -1,7 +1,7 @@
 ---
 name: Performance Benchmarker
 description: Expert performance testing and optimization specialist focused on measuring, analyzing, and improving system performance across all applications and infrastructure
-color: orange
+color: "#F97316"
 ---
 
 # Performance Benchmarker Agent Personality

--- a/testing/testing-reality-checker.md
+++ b/testing/testing-reality-checker.md
@@ -1,7 +1,7 @@
 ---
 name: Reality Checker
 description: Stops fantasy approvals, evidence-based certification - Default to "NEEDS WORK", requires overwhelming proof for production readiness
-color: red
+color: "#EF4444"
 ---
 
 # Integration Agent Personality

--- a/testing/testing-test-results-analyzer.md
+++ b/testing/testing-test-results-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: Test Results Analyzer
 description: Expert test analysis specialist focused on comprehensive test result evaluation, quality metrics analysis, and actionable insight generation from testing activities
-color: indigo
+color: "#6366F1"
 ---
 
 # Test Results Analyzer Agent Personality

--- a/testing/testing-tool-evaluator.md
+++ b/testing/testing-tool-evaluator.md
@@ -1,7 +1,7 @@
 ---
 name: Tool Evaluator
 description: Expert technology assessment specialist focused on evaluating, testing, and recommending tools, software, and platforms for business use and productivity optimization
-color: teal
+color: "#14B8A6"
 ---
 
 # Tool Evaluator Agent Personality

--- a/testing/testing-workflow-optimizer.md
+++ b/testing/testing-workflow-optimizer.md
@@ -1,7 +1,7 @@
 ---
 name: Workflow Optimizer
 description: Expert process improvement specialist focused on analyzing, optimizing, and automating workflows across all business functions for maximum productivity and efficiency
-color: green
+color: "#10B981"
 ---
 
 # Workflow Optimizer Agent Personality


### PR DESCRIPTION
## Summary

Converts agent colors to valid OpenCode format (56 agents fixed).

OpenCode requires agent colors to be either:
- 6-character hex codes (e.g., `#FF5733`)  
- Or specific theme names (`primary`, `secondary`, `accent`, `success`, `warning`, `error`, `info`)

Named colors like `purple`, `teal`, `amber`, `cyan`, etc. are not valid.

## Changes

All invalid named colors converted to hex equivalents:
- `green` -> `#10B981`
- `blue` -> `#3B82F6`
- `purple` -> `#8B5CF6`
- `teal` -> `#14B8A6`
- `orange` -> `#F97316`
- `red` -> `#EF4444`
- `amber` -> `#F59E0B`
- `indigo` -> `#6366F1`
- `gold` -> `#EAB308`
- `pink` -> `#EC4899`
- `cyan` -> `#06B6D4`
- `neon-cyan` -> `#06B6D4`
- `neon-green` -> `#22C55E`
- `metallic-blue` -> `#6B7280`

## Testing

Verified with `opencode providers list` - no more color validation errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)