### PR TITLE
Add skills/ — token-efficient task instructions as complement to agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,36 @@ Scholarly rigor for world-building, storytelling, and narrative design.
 
 ---
 
+## ⚡ Skills — The Lightweight Alternative
+
+**Skills** are the token-efficient complement to Agents. Where agents give Claude a persona to inhabit, skills give Claude a task to execute.
+
+| | Agents | Skills |
+|---|---|---|
+| Tells Claude | Who to be | What to do |
+| Lines per file | 100–400 | 20–50 |
+| Token cost | High | Low |
+| Best for | Long sessions, personality consistency | One-shot tasks, high-frequency use |
+
+20 production-ready skills across Engineering, Product, Content, Sales, Testing, and Design are in the [`skills/`](skills/) directory.
+
+```bash
+# Install all skills for Claude Code
+cp -r skills/engineering skills/product skills/content \
+      skills/sales skills/testing skills/design \
+      ~/.claude/commands/
+
+# Then invoke in any Claude Code session
+/code-review
+/debug
+/prd
+/outreach
+```
+
+→ **[Browse all skills and the skill format](skills/README.md)**
+
+---
+
 ## 🎯 Real-World Use Cases
 
 ### Scenario 1: Building a Startup MVP

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -29,3 +29,39 @@ Use the Reality Checker agent to verify this feature is production-ready.
 
 Agents are organized into divisions. See the [main README](../../README.md) for
 the full current roster.
+
+---
+
+## Skills (Lightweight Alternative)
+
+Skills are token-efficient task instructions — 20–50 lines vs 100–400 for agents.
+Use them when you want focused, one-shot execution without loading a full persona.
+
+```bash
+# Install all skills to Claude Code commands directory
+cp -r skills/engineering skills/product skills/content \
+      skills/sales skills/testing skills/design \
+      ~/.claude/commands/
+
+# Or install selectively
+cp skills/engineering/code-review.md ~/.claude/commands/
+```
+
+Invoke with a slash command:
+
+```
+/code-review
+/debug
+/architect
+/prd
+/sprint-plan
+/outreach
+```
+
+### Agents vs Skills
+
+Use **agents** when you want Claude to embody a specialist for a whole session — personality, workflow, and domain depth loaded upfront.
+
+Use **skills** when you want a precise, repeatable action — review this code, write this PRD, plan this sprint — without the token overhead of a full persona.
+
+See [`skills/README.md`](../../skills/README.md) for the full skill catalog and file format.

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,145 @@
+# 🎯 Skills
+
+**Skills** are the lightweight complement to Agents.
+
+| | Agents | Skills |
+|---|---|---|
+| Tells Claude | Who to be | What to do |
+| Format | Persona + process + examples | Direct instructions |
+| Lines per file | 100–400 | 20–50 |
+| Token cost | High (full persona loaded every request) | Low |
+| Best for | Long sessions where personality consistency matters | One-shot tasks, high-frequency invocations |
+
+**The insight**: Claude already has the domain expertise. It doesn't need a persona scaffold to review code well or write a good PRD — it needs focused instructions. Skills provide that at a fraction of the token cost.
+
+---
+
+## Using Skills with Claude Code
+
+```bash
+# Copy all skills to your Claude Code commands directory
+cp -r skills/engineering skills/product skills/content \
+      skills/sales skills/testing skills/design \
+      ~/.claude/commands/
+
+# Or install selectively
+cp skills/engineering/code-review.md ~/.claude/commands/
+```
+
+Invoke in any Claude Code session:
+```
+/code-review
+/debug
+/architect
+/prd
+/outreach
+```
+
+---
+
+## Skill Catalog
+
+### 💻 Engineering
+
+| Skill | What it does |
+|---|---|
+| [`code-review`](engineering/code-review.md) | Review changed files for bugs, security issues, maintainability |
+| [`refactor`](engineering/refactor.md) | Refactor for clarity without changing behaviour |
+| [`debug`](engineering/debug.md) | Systematic root-cause diagnosis and fix |
+| [`architect`](engineering/architect.md) | Design system or feature architecture before coding |
+| [`security-scan`](engineering/security-scan.md) | Audit for vulnerabilities across the attack surface |
+| [`test-gen`](engineering/test-gen.md) | Generate tests for a function, module, or feature |
+| [`perf-audit`](engineering/perf-audit.md) | Identify and fix performance bottlenecks |
+| [`pr-description`](engineering/pr-description.md) | Write a clear, useful PR description from the diff |
+| [`api-design`](engineering/api-design.md) | Design a clean, consistent API surface |
+| [`tech-debt`](engineering/tech-debt.md) | Inventory and prioritise technical debt |
+| [`incident`](engineering/incident.md) | Run incident response: triage, mitigate, document |
+
+### 📋 Product
+
+| Skill | What it does |
+|---|---|
+| [`prd`](product/prd.md) | Write a Product Requirements Document |
+| [`user-story`](product/user-story.md) | Write user stories with testable acceptance criteria |
+| [`sprint-plan`](product/sprint-plan.md) | Prioritise backlog and produce a committed sprint plan |
+
+### ✍️ Content
+
+| Skill | What it does |
+|---|---|
+| [`linkedin-post`](content/linkedin-post.md) | Write a LinkedIn post — direct, specific, no buzzwords |
+| [`content-brief`](content/content-brief.md) | Write a content brief for any format |
+
+### 💼 Sales
+
+| Skill | What it does |
+|---|---|
+| [`outreach`](sales/outreach.md) | Write cold outreach copy (LinkedIn note, DM, email) |
+| [`discovery`](sales/discovery.md) | Prepare for and run a discovery call |
+
+### 🧪 Testing
+
+| Skill | What it does |
+|---|---|
+| [`qa-plan`](testing/qa-plan.md) | Write a QA test plan for a feature or release |
+| [`e2e-tests`](testing/e2e-tests.md) | Write end-to-end test scenarios and implementation |
+
+### 🎨 Design
+
+| Skill | What it does |
+|---|---|
+| [`ux-review`](design/ux-review.md) | Critique UI/UX for real usability issues |
+
+---
+
+## Skill File Format
+
+```markdown
+---
+name: skill-name
+description: One-line description of what this skill produces
+---
+
+# Skill Name
+
+One-line purpose statement.
+
+## Process
+1. Numbered steps — what to do, not who to be.
+2. Each step is specific and mechanically followable.
+
+## Output
+Exact format or template of what to produce.
+
+## Rules
+- Hard constraints that change behaviour (optional).
+- Only include if removing this line would change the output.
+```
+
+### What makes a good skill
+
+**Do:**
+- Start with what the skill does, not what the model "is"
+- Use numbered steps that can be followed mechanically
+- Specify the exact output format
+- Include only constraints that actually change behaviour
+
+**Don't:**
+- Add identity/persona sections (`You are an expert who...`)
+- Add memory sections (`You remember patterns from previous work...`)
+- Add communication style, emoji headers, or success metrics the model can't verify
+- Duplicate instructions the model already follows by default
+
+**The bar**: If removing a line doesn't change the output, remove it.
+
+---
+
+## Contributing Skills
+
+See the main [CONTRIBUTING.md](../CONTRIBUTING.md) for the PR process. For skills specifically:
+
+1. Skills live in `skills/<category>/skill-name.md`
+2. Use the minimal frontmatter: `name` and `description` only
+3. Target 20–50 lines per skill. If it needs more, split it into two skills
+4. Test: invoke the skill on a real task. Does it produce the right output without the extra lines? Then the extra lines are waste — cut them
+5. Add a row to the table in this README and open a PR

--- a/skills/content/content-brief.md
+++ b/skills/content/content-brief.md
@@ -1,0 +1,45 @@
+---
+name: content-brief
+description: Write a content brief for any format — article, post, video, email
+---
+
+# content-brief
+
+Produce a brief that a writer or editor can execute without back-and-forth.
+
+## Process
+1. Define: format, target audience, goal (awareness / education / conversion / retention), distribution channel.
+2. Nail the angle: why this topic, why from this source, why now? One sentence.
+3. Outline the structure: opening hook, key sections with their point, closing CTA.
+4. List research or sources needed.
+5. Specify length, tone constraints, and any hard rules (things to include or avoid).
+
+## Output
+
+```
+**Brief: [Working Title]**
+
+Format: [article / email / video / social post / etc.]
+Audience: [who reads/watches this — be specific]
+Goal: [what should they do, think, or feel after consuming this?]
+Channel: [where it lives]
+
+**Angle**: [One sentence — why this piece is worth reading/watching]
+
+**Outline**:
+1. [Hook — first impression, opening line or frame]
+2. [Section — point it makes]
+3. [Section — point it makes]
+4. [Close / CTA]
+
+**Tone**: [3 words, e.g. "direct, grounded, skeptical"]
+**Length**: [word count, read time, or duration]
+**Research needed**: [sources, data points, quotes to find]
+**Hard rules**: [must include / must avoid]
+**Due**: [date if known]
+```
+
+## Rules
+- The angle must be specific enough that two writers couldn't produce identical pieces from it.
+- If the goal is "awareness", be honest about what that means — what do you want them to know or believe?
+- Don't pad the brief. A tight brief produces a tight piece.

--- a/skills/content/linkedin-post.md
+++ b/skills/content/linkedin-post.md
@@ -1,0 +1,29 @@
+---
+name: linkedin-post
+description: Write a LinkedIn post — direct, specific, no buzzwords
+---
+
+# linkedin-post
+
+Write a post worth reading. One idea, stated precisely, with a hook that earns the click.
+
+## Process
+1. Identify the core insight: what's the one thing worth saying? If there are two things, pick one.
+2. Choose the form:
+   - **Reframe**: widely held view → quiet counter-evidence → unexpected-but-inevitable conclusion
+   - **Observation**: precise thing noticed → one layer of what it means → implication left open
+   - **Practitioner**: specific moment or decision → actual thinking at the time → what remains unresolved
+   - **Synthesis**: concrete observation → thread through two domains → unified insight
+3. Write the hook (first 2 lines before "see more"): must earn the click on its own. No throat-clearing.
+4. Develop the body: one thread, not a listicle. Each paragraph earns the next.
+5. End with an observation that lands. Not a question fishing for engagement.
+
+## Output
+Full post, ready to publish. Plain text, line breaks only — no markdown, no bullet points unless the list is the point.
+
+## Rules
+- No first word "I".
+- Forbidden: "excited to share", "game-changer", "ecosystem", "disruption", "value add", "hustle", "10x", "in today's fast-paced world", "I'm humbled", "let that sink in".
+- No ending questions. Let the post land.
+- Max 250 words. Longer means it's two posts.
+- Specific beats general. Name the company, the decision, the number. Vague "insights" are forgettable.

--- a/skills/design/ux-review.md
+++ b/skills/design/ux-review.md
@@ -1,0 +1,34 @@
+---
+name: ux-review
+description: Critique UI/UX for real usability issues, prioritised by user impact
+---
+
+# ux-review
+
+Find usability problems that would cause real users to fail or struggle. Not preferences — problems.
+
+## Process
+1. Review against core heuristics:
+   - **Clarity**: Is the purpose of each element immediately obvious to a new user?
+   - **Feedback**: Does the system communicate state — loading, success, error, empty — at every moment?
+   - **Efficiency**: Can users complete key tasks with the minimum steps? Are common actions easy to reach?
+   - **Error prevention**: Does the design prevent mistakes before they happen? Is destructive action hard to trigger accidentally?
+   - **Consistency**: Are patterns, labels, and interactions consistent throughout? Does it match platform conventions?
+   - **Accessibility**: Sufficient contrast ratios, touch targets ≥44px, keyboard navigable, screen reader labels present?
+2. Identify the top 3-5 issues by user impact. Don't list everything — prioritise ruthlessly.
+3. For each issue, propose a specific, actionable fix.
+4. Note what is working well — fixes should preserve the good.
+
+## Output
+
+Issues ranked by user impact:
+
+| # | Where | Problem | Why it matters | Fix |
+|---|---|---|---|---|
+
+Then one paragraph on what's working well.
+
+## Rules
+- Be specific. "The button is confusing" is useless. "The primary CTA says 'Submit' but there's no indication what is being submitted or what happens next" is actionable.
+- Distinguish usability problems (users fail or struggle) from preferences (you'd do it differently). Only flag the former.
+- Don't redesign outside the scope the user asks about. Fix the thing, don't reimagine the product.

--- a/skills/engineering/api-design.md
+++ b/skills/engineering/api-design.md
@@ -1,0 +1,29 @@
+---
+name: api-design
+description: Design a clean, consistent API for a feature or service
+---
+
+# api-design
+
+Design the API surface before implementation. Get the contract right — it's expensive to change later.
+
+## Process
+1. Clarify the use cases: who calls this, with what inputs, expecting what outputs? What error states must be handled?
+2. Choose the model:
+   - **REST**: identify resources and their CRUD operations; use nouns for paths, HTTP verbs for actions
+   - **RPC/GraphQL**: identify operations and their inputs/outputs
+3. Define request/response schemas with field names, types, nullability, and validation rules.
+4. Design the error model: what can go wrong? Consistent error shape across all endpoints.
+5. Address upfront: authentication, pagination (cursor vs offset), versioning strategy, rate limiting signals.
+
+## Output
+- **Endpoint list** — method, path (or operation name), one-line description
+- **Request/response schemas** — JSON examples or TypeScript types
+- **Error codes** — code, HTTP status, meaning, example response
+- **Key decisions** — each design choice with the rationale and tradeoff
+
+## Rules
+- Be consistent. Naming, casing, error shapes, and pagination must follow one convention throughout.
+- Don't expose internal implementation details (database IDs in formats that leak schema, internal service names, stack traces in errors).
+- Default to the simplest design that covers the actual use cases. Don't design for hypothetical future callers.
+- Boolean fields and nullable fields are API contracts. Be explicit about their meaning and when they're null.

--- a/skills/engineering/architect.md
+++ b/skills/engineering/architect.md
@@ -1,0 +1,28 @@
+---
+name: architect
+description: Design system or feature architecture — components, interfaces, tradeoffs — before code is written
+---
+
+# architect
+
+Design the architecture. Produce a plan that can be handed to an engineer to build from.
+
+## Process
+1. Clarify requirements: what problem does this solve, who uses it, what are the constraints (scale, latency, consistency, budget)?
+2. Identify the components and their responsibilities. Keep it to the minimum needed.
+3. Define the interfaces between components: API contracts, data schemas, event shapes, message formats.
+4. Identify the hardest decisions and state the tradeoffs explicitly.
+5. Note what is deliberately out of scope.
+
+## Output
+- **Component diagram** (ASCII or Mermaid)
+- **Data model** — key entities, relationships, key fields
+- **API surface** — key endpoints / functions / events with input/output shapes
+- **Key decisions** — each decision with the chosen approach and the tradeoff accepted
+- **Open questions** — what must be answered before or during build
+
+## Rules
+- Don't design for hypothetical scale. Design for 10× current load, not 1000×.
+- Flag irreversible decisions explicitly (schema choices, public API shapes, vendor lock-in).
+- If the problem is underspecified, ask the two most important clarifying questions before designing.
+- Prefer boring, proven technology unless there's a clear reason not to.

--- a/skills/engineering/code-review.md
+++ b/skills/engineering/code-review.md
@@ -1,0 +1,34 @@
+---
+name: code-review
+description: Review changed files for bugs, security issues, and maintainability
+---
+
+# code-review
+
+Review code changes and produce actionable findings, grouped by severity.
+
+## Process
+1. Run `git diff HEAD` (or `git diff HEAD~1` if nothing staged). If no git context, review the files the user specifies.
+2. For each changed file, check:
+   - **Correctness**: logic errors, off-by-one, wrong operator, unintended mutation
+   - **Security**: injection (SQL, command, template), unvalidated input, hardcoded secrets, missing auth checks, path traversal
+   - **Error handling**: uncaught exceptions, silent failures, missing null/undefined guards
+   - **Performance**: N+1 queries, blocking calls that could be async, unnecessary re-computation
+   - **Dead code**: unused imports, unreachable branches, leftover debug statements
+3. Check cross-file concerns: broken module contracts, missing DB migrations, test coverage gaps for changed logic.
+
+## Output
+Group by severity:
+
+**Critical** — must fix before merge (bugs that corrupt data, security vulnerabilities)
+**Major** — should fix (correctness issues, missing error handling)
+**Minor** — consider fixing (performance, dead code, clarity)
+
+Each finding: `file:line` — what's wrong — how to fix it (one line).
+
+If no issues found, say so plainly.
+
+## Rules
+- Only flag real issues. Do not invent problems to appear thorough.
+- Do not suggest refactors outside the changed scope unless directly related to a bug.
+- If a finding is uncertain, say "possible issue" not "issue".

--- a/skills/engineering/debug.md
+++ b/skills/engineering/debug.md
@@ -1,0 +1,27 @@
+---
+name: debug
+description: Systematically diagnose the root cause of a bug and apply the minimal fix
+---
+
+# debug
+
+Find and fix the root cause. Don't treat symptoms.
+
+## Process
+1. State the symptom clearly: actual behaviour vs expected behaviour. What error, if any?
+2. Form a hypothesis — the most likely cause — before reading any code.
+3. Trace the execution path relevant to the bug. Read the actual code; don't assume.
+4. Confirm or disprove the hypothesis. If wrong, form the next one.
+5. Apply the minimal fix that addresses the root cause.
+6. Verify: if tests exist, run them. If not, describe how to reproduce the fix.
+
+## Output
+- Root cause (1-2 sentences)
+- Fix applied (diff or precise description)
+- How to verify it's fixed
+
+## Rules
+- State your hypothesis before investigating. This prevents random shotgun changes.
+- Fix the root cause, not the symptom.
+- If the root cause is unclear after thorough tracing, say so and ask for more context rather than guessing.
+- Apply the minimum change needed — don't refactor unrelated code while fixing a bug.

--- a/skills/engineering/incident.md
+++ b/skills/engineering/incident.md
@@ -1,0 +1,50 @@
+---
+name: incident
+description: Run incident response: triage, mitigate, root cause, document
+---
+
+# incident
+
+Mitigate first. Root cause second. Document after.
+
+## Process
+
+**Triage (first 5 minutes)**
+1. What is broken? What is the user/system impact? Is it ongoing or already resolved?
+2. What changed recently? (deployments, config changes, dependency updates — `git log`, deploy history)
+3. Severity: how many users affected, is data at risk, is revenue impacted?
+
+**Investigate**
+4. Check logs, metrics, error rates. Find the signal. One hypothesis at a time — don't apply random fixes.
+5. Confirm or disprove the hypothesis with evidence before acting.
+
+**Mitigate**
+6. Apply the fastest safe fix that stops the bleeding: rollback, feature flag off, rate limit, circuit breaker.
+7. Confirm mitigation worked (error rate dropped, service responding).
+
+**Resolve**
+8. Apply the proper fix, or create a tracked issue if the full fix is non-trivial and the mitigation holds.
+
+**Document**
+9. Write the incident summary.
+
+## Output
+
+```
+**Incident Summary**
+Impact: [what broke, estimated users affected]
+Duration: [start time → resolved time]
+Root cause: [one sentence]
+
+Timeline:
+- [HH:MM] [event]
+- [HH:MM] [event]
+
+Fix: [what was done to resolve]
+Follow-up: [what prevents recurrence — linked ticket or action owner]
+```
+
+## Rules
+- One hypothesis at a time. Shotgun changes under pressure cause new incidents.
+- Mitigation ≠ resolution. Mitigation stops the bleeding. Resolution fixes the cause.
+- Write the summary while memory is fresh. Don't skip it.

--- a/skills/engineering/perf-audit.md
+++ b/skills/engineering/perf-audit.md
@@ -1,0 +1,30 @@
+---
+name: perf-audit
+description: Identify and fix performance bottlenecks in code or system
+---
+
+# perf-audit
+
+Find what's actually slow. Don't optimise blindly.
+
+## Process
+1. Identify the hot path: where is time or memory actually spent? If profiler output, slow query logs, or traces are available, use them. If not, reason from code structure.
+2. Categorise findings:
+   - **Algorithmic** — O(n²) where O(n log n) is achievable; nested loops over large datasets; recomputing what could be cached
+   - **I/O** — blocking synchronous calls; sequential requests that could be parallel; missing caching layer; chatty APIs (many small calls vs one batch)
+   - **Database** — N+1 queries; missing indexes on filtered/sorted columns; selecting all columns when few are needed; no query result caching
+   - **Memory** — large unnecessary copies; unbounded caches; leaks (event listeners not removed, closures holding references)
+   - **Rendering** — unnecessary re-renders; missing virtualisation on long lists; layout thrashing; unoptimised images
+3. Fix the highest-impact issue first. Don't micro-optimise.
+
+## Output
+For each bottleneck found:
+- What: the specific problem and location
+- Why: root cause
+- Fix: code change or architectural change
+- Expected impact: rough estimate (e.g. "eliminates 12 queries per page load")
+
+## Rules
+- Measure before and after where possible. State assumptions when you can't.
+- Don't optimise code that isn't on the hot path.
+- State the tradeoff for every optimisation (readability, complexity, memory for speed, etc.).

--- a/skills/engineering/pr-description.md
+++ b/skills/engineering/pr-description.md
@@ -1,0 +1,38 @@
+---
+name: pr-description
+description: Write a clear, useful pull request description from the git diff
+---
+
+# pr-description
+
+Write a PR description that tells reviewers what matters, not what git log already shows.
+
+## Process
+1. Run `git log main..HEAD --oneline` and `git diff main...HEAD` to see all changes in the branch.
+2. Identify: what changed, why it changed, what the reviewer needs to know that isn't obvious from the diff.
+3. Note any breaking changes, required migrations, deployment steps, or environment variable changes.
+
+## Output
+
+```
+## What
+[2–4 sentences. What does this PR do? Intent and outcome, not a summary of commits.]
+
+## Why
+[1–3 sentences. What problem does this solve? Link to issue/ticket if one exists.]
+
+## How
+[Optional. Only include if the approach is non-obvious or has a meaningful tradeoff worth explaining.]
+
+## Testing
+[How was this tested? What should the reviewer verify manually?]
+
+## Notes
+[Breaking changes, migration steps, follow-up work, known issues. Omit if none.]
+```
+
+## Rules
+- "What" is for humans, not git log. Summarise intent, not mechanics.
+- If there are no breaking changes or migration steps, omit the Notes section entirely.
+- Keep it under 300 words. If it needs more, the PR is probably too large.
+- Don't pad with filler ("This PR addresses the issue of..."). Start with the substance.

--- a/skills/engineering/refactor.md
+++ b/skills/engineering/refactor.md
@@ -1,0 +1,28 @@
+---
+name: refactor
+description: Refactor specified code for clarity and simplicity without changing behaviour
+---
+
+# refactor
+
+Refactor the target code to improve readability and maintainability. No behaviour changes.
+
+## Process
+1. Read the target file(s) or user-specified scope.
+2. Identify what to improve:
+   - Functions doing more than one thing → extract
+   - Duplicated logic → consolidate
+   - Poor names that obscure intent → rename
+   - Unnecessary complexity (deep nesting, premature abstraction, magic numbers) → simplify
+   - Dead code → remove
+3. Apply changes. One concern per pass — don't mix rename + extract + restructure.
+4. If tests exist, run them to confirm behaviour is preserved.
+
+## Output
+The refactored code, then a brief summary (≤5 bullets) of what changed and why.
+
+## Rules
+- Preserve all existing behaviour. No bug fixes or new features unless explicitly asked.
+- Do not change public APIs or exported function signatures without explicit approval.
+- If scope is ambiguous, ask before touching anything.
+- Do not add comments explaining what the code does — improve the code so it doesn't need them.

--- a/skills/engineering/security-scan.md
+++ b/skills/engineering/security-scan.md
@@ -1,0 +1,38 @@
+---
+name: security-scan
+description: Audit codebase for security vulnerabilities across the attack surface
+---
+
+# security-scan
+
+Find real, exploitable security issues. Not theoretical — practical attack paths.
+
+## Process
+1. Map the attack surface: HTTP routes, CLI args, file inputs, webhooks, env var handling, auth middleware.
+2. Check each entry point for:
+   - **Injection**: SQL (string concatenation), command injection (exec/shell with user input), template injection, path traversal (`../`)
+   - **Auth**: missing authentication checks, broken authorisation (user A accessing user B's data), privilege escalation paths
+   - **Secrets**: hardcoded API keys, passwords, tokens in source or committed config files
+   - **Input validation**: unvalidated user input reaching dangerous sinks, type coercion bugs, missing length limits
+3. Check for insecure patterns regardless of entry point:
+   - `eval()` or `Function()` with user data
+   - Deserialisation of untrusted data
+   - CORS wildcard (`*`) on authenticated endpoints
+   - Missing CSRF protection on state-changing endpoints
+   - Outdated dependencies with known CVEs (`npm audit` / `pip audit` / `bundle audit`)
+4. Check secrets in git history if `.git` is accessible.
+
+## Output
+Findings grouped by severity:
+
+**Critical** — direct exploitation path, fix immediately
+**High** — likely exploitable with moderate effort
+**Medium** — exploitable under specific conditions
+**Low** — defence-in-depth improvements
+
+Each finding: location (file:line) — vulnerability type — attack scenario (one sentence) — fix.
+
+## Rules
+- Only report findings with a realistic attack path. No theoretical issues.
+- Prioritise. Critical and High are what matter before shipping.
+- If a finding requires insider access or physical access to exploit, classify it Low.

--- a/skills/engineering/tech-debt.md
+++ b/skills/engineering/tech-debt.md
@@ -1,0 +1,33 @@
+---
+name: tech-debt
+description: Inventory and prioritise technical debt in the codebase
+---
+
+# tech-debt
+
+Find the debt that's actually slowing you down. Not everything is debt worth paying.
+
+## Process
+1. Read key files: entry points, most-changed files (`git log --stat | head -50`), areas the user flags.
+2. Categorise debt:
+   - **Rotten** — actively causing bugs or slowing development today (fix now)
+   - **Structural** — architectural decisions that constrain future work (plan to fix)
+   - **Cosmetic** — naming, formatting, dead code (fix opportunistically)
+3. For each item: describe the problem, the blast radius (what breaks or slows down because of it), and the fix.
+4. Prioritise by: (impact on dev velocity) × (frequency of being touched). High-touch rotten code first.
+
+## Output
+
+Debt inventory sorted by priority:
+
+| Priority | Type | Location | Problem | Impact | Fix | Effort |
+|---|---|---|---|---|---|---|
+| 1 | Rotten | `file:line` | ... | ... | ... | S/M/L |
+
+End with: **Top 3 to tackle first** and why.
+
+## Rules
+- Don't flag things that aren't causing real pain. "I'd do it differently" is not debt.
+- Cosmetic debt goes last unless it's systematically wrong everywhere and causes confusion.
+- Be honest about effort: S = hours, M = days, L = weeks. Don't undersell to make the list look manageable.
+- Debt that lives in code nobody touches isn't urgent, regardless of how bad it looks.

--- a/skills/engineering/test-gen.md
+++ b/skills/engineering/test-gen.md
@@ -1,0 +1,27 @@
+---
+name: test-gen
+description: Generate tests for a function, module, or feature using the project's existing framework
+---
+
+# test-gen
+
+Write tests that verify behaviour, not implementation.
+
+## Process
+1. Read the code under test. Understand its contract: inputs, outputs, side effects, thrown errors.
+2. Identify test cases:
+   - **Happy path** — normal expected usage, expected return value
+   - **Edge cases** — empty/null input, zero, max values, boundary conditions, empty collections
+   - **Error cases** — invalid input, missing required data, dependency failures
+   - **Regression** — if a specific bug was reported, add a test that would have caught it
+3. Write tests using the project's existing test framework. Match the file structure and naming conventions already in use.
+4. Ensure tests are deterministic and independent. No shared mutable state between tests.
+
+## Output
+Test code, ready to run. Brief comment on each test describing what it verifies.
+
+## Rules
+- Match the existing test framework — don't introduce new ones.
+- Mock external dependencies (network, database, filesystem) unless integration tests are explicitly requested.
+- Test behaviour, not implementation. Tests should not break when implementation changes but output is the same.
+- Don't test framework code or language built-ins.

--- a/skills/product/prd.md
+++ b/skills/product/prd.md
@@ -1,0 +1,57 @@
+---
+name: prd
+description: Write a Product Requirements Document for a feature or product
+---
+
+# prd
+
+Write a PRD that engineers can build from and stakeholders can sign off on.
+
+## Process
+1. Clarify: what problem does this solve, for whom, and why now?
+2. Define success: what measurable outcomes does this produce?
+3. Document requirements — use the MoSCoW format: must/should/won't (this version).
+4. Identify dependencies, risks, and open questions that block the build.
+
+## Output
+
+```
+# [Feature Name] — PRD
+
+## Problem
+[1–2 paragraphs. What problem exists? Who has it? What's the cost of not solving it?]
+
+## Goals
+- [Measurable outcome — e.g. "Reduce time to complete X from Y minutes to Z seconds"]
+- [Measurable outcome]
+
+## Non-goals
+- [What this explicitly does not address — prevents scope creep]
+
+## User Stories
+- As a [user type], I want [capability] so that [benefit].
+
+## Requirements
+### Must have (blocks launch)
+- [Requirement — testable, specific]
+
+### Should have (important but not blocking)
+- [Requirement]
+
+### Won't have in this version
+- [Explicitly deferred — with reason]
+
+## Success Metrics
+[How will we know this worked? What do we measure, and when?]
+
+## Open Questions
+[What must be decided before or during build?]
+
+## Dependencies
+[What must exist or be built first?]
+```
+
+## Rules
+- Requirements must be testable. "Fast" is not a requirement. "P95 latency < 200ms" is.
+- Non-goals are as important as goals. Be explicit — it prevents the scope from expanding during build.
+- If you don't know the success metric, don't ship — you won't know if it worked.

--- a/skills/product/sprint-plan.md
+++ b/skills/product/sprint-plan.md
@@ -1,0 +1,45 @@
+---
+name: sprint-plan
+description: Prioritise backlog items and produce a committed sprint plan
+---
+
+# sprint-plan
+
+Turn a backlog into a sprint with a clear goal, committed work, and explicit deferrals.
+
+## Process
+1. List all candidate items from: backlog, bug reports, carry-overs, requests the user provides.
+2. Assess each item:
+   - **Value**: High / Medium / Low (impact on users or business)
+   - **Effort**: S / M / L / XL (roughly: hours / 1-2 days / 3-5 days / week+)
+   - **Blocked**: yes/no (depends on something not done yet)
+   - **Risk**: known unknowns that could expand scope
+3. Priority order: Critical bugs → High value + Small effort → High value + Medium effort → the rest.
+4. Fill to ~80% capacity. The remaining 20% absorbs unplanned work. Every sprint has unplanned work.
+5. Write the sprint goal — one sentence describing what this sprint achieves for users or the product.
+
+## Output
+
+```
+**Sprint Goal**: [One sentence. What does this sprint deliver that matters?]
+
+**Committed**:
+| Item | Value | Effort | Notes |
+|---|---|---|---|
+
+**Stretch** (only if committed finishes early):
+| Item | Value | Effort |
+|---|---|---|
+
+**Deferred** (explicit, with reason):
+| Item | Reason |
+|---|---|
+
+**Risks**: [What could derail this sprint?]
+```
+
+## Rules
+- A sprint without a goal is a to-do list. Force a goal.
+- Never commit 100% of capacity. It always slips.
+- Deferred items need a reason — "not this sprint" is a decision, not an oversight.
+- If an item is blocked, it cannot be committed regardless of priority.

--- a/skills/product/user-story.md
+++ b/skills/product/user-story.md
@@ -1,0 +1,34 @@
+---
+name: user-story
+description: Write user stories with acceptance criteria a QA engineer can test
+---
+
+# user-story
+
+Write stories that define behaviour precisely enough to build and test from.
+
+## Process
+1. Identify the user types involved in the feature.
+2. For each meaningful interaction, write a story.
+3. Add acceptance criteria that a QA engineer can execute without asking questions.
+4. Flag stories that are too large (should be split) or too small (should be merged into another).
+
+## Output
+
+For each story:
+
+```
+**Story**: As a [user type], I want [capability] so that [benefit].
+
+**Acceptance Criteria**:
+- Given [initial context], when [user action], then [system response].
+- Given [initial context], when [user action], then [system response].
+
+**Notes**: [edge cases, dependencies, explicit out-of-scope]
+```
+
+## Rules
+- Acceptance criteria must be binary: pass or fail. Not "the page loads fast" — "the page responds within 2 seconds on a 3G connection."
+- The benefit in "so that [benefit]" must be real. "So that I can do it" is not a benefit.
+- If you don't know the user type or benefit, ask before writing.
+- Stories are units of delivery, not requirements lists. One story = one deployable behaviour.

--- a/skills/sales/discovery.md
+++ b/skills/sales/discovery.md
@@ -1,0 +1,44 @@
+---
+name: discovery
+description: Prepare for a discovery call — research, goal, questions, objections, next step
+---
+
+# discovery
+
+Prepare a discovery call card. The goal of discovery is to understand, not to pitch.
+
+## Process
+1. Research the prospect: company, role, likely problems they face, relevant recent news.
+2. Define the call goal: what must you learn on this call to know if this is a fit? One sentence.
+3. Prepare questions across four areas:
+   - **Situation**: What's their current setup / process / tool for this?
+   - **Problem**: What's painful about it? How often does it happen? Who else is affected?
+   - **Implication**: What does that cost them — time, money, risk, opportunity?
+   - **Need-payoff**: What would solving it enable that they can't do now?
+4. Anticipate the top 2-3 objections and prepare honest responses.
+5. Decide the specific next step to propose at the end of the call.
+
+## Output
+
+```
+**Discovery Prep: [Prospect Name / Company]**
+
+Context: [role, company, why they might care — 3 bullets]
+Call goal: [what you must learn]
+
+Questions:
+- Situation: [question]
+- Problem: [question]
+- Implication: [question]
+- Need-payoff: [question]
+
+Likely objections:
+- "[Objection]" → [response]
+
+Proposed next step: [specific action, not "I'll follow up"]
+```
+
+## Rules
+- Your talking ratio in discovery should be <30%. These are questions, not a pitch script.
+- Never skip the implication questions — they reveal deal size and urgency, which determines how to prioritise the deal.
+- The next step must be specific: a demo scheduled, a doc shared, a decision made. "I'll be in touch" is not a next step.

--- a/skills/sales/outreach.md
+++ b/skills/sales/outreach.md
@@ -1,0 +1,33 @@
+---
+name: outreach
+description: Write cold outreach copy for LinkedIn, email, or DM with a personalised hook
+---
+
+# outreach
+
+Write outreach that gets a reply. One hook, one value line, one ask.
+
+## Process
+1. Identify: who is the recipient (role, company, context), what do they likely care about, what's the offer?
+2. Find a specific hook — something true and observable about them: their role, a post they wrote, a problem their company has, something they'd recognise as "this person did their homework."
+3. Connect the hook to the value in one sentence. Don't explain the product — state the relevant outcome.
+4. Make a single, low-friction ask. Yes/no, or a 15-minute call. Not "let me know your thoughts."
+
+## Output
+
+**LinkedIn connection note (≤300 chars)**:
+[Draft — must fit the char limit]
+
+**LinkedIn DM (after they connect)**:
+[Draft — under 100 words, 3 paragraphs max]
+
+**Email** (if applicable):
+Subject: [subject line — specific, not clever]
+Body: [under 150 words]
+
+## Rules
+- The hook must be specific to this recipient. Generic openers ("I came across your profile", "I love what you're doing") are worse than no opener.
+- One ask per message. Don't pitch multiple things or offer multiple next steps.
+- No buzzwords. No "synergy", "value add", "game-changer", "exciting opportunity."
+- The ask should take <5 minutes to fulfill. A reply, a yes/no, a 15-min call. Not "schedule a demo" as the first step.
+- If you don't have a specific hook, ask the user for one rather than writing a generic message.

--- a/skills/testing/e2e-tests.md
+++ b/skills/testing/e2e-tests.md
@@ -1,0 +1,34 @@
+---
+name: e2e-tests
+description: Write end-to-end test scenarios and implementation for a user flow
+---
+
+# e2e-tests
+
+Write E2E tests that verify user-visible behaviour across the full stack.
+
+## Process
+1. Identify the user journey: start state → user actions → end state.
+2. Write scenarios in plain language first (Given / When / Then).
+3. Implement using the project's existing E2E framework (Playwright, Cypress, Selenium — match what's already there).
+4. Cover: happy path, the most likely error states, mobile viewport if the product has mobile users.
+5. Use realistic test data — not `test@test.com` and `password123`.
+
+## Output
+
+Plain-language scenarios first:
+
+```gherkin
+Scenario: [name]
+  Given [initial state]
+  When [user action]
+  Then [expected outcome]
+```
+
+Then the implementation in the project's framework, matching existing file structure and conventions.
+
+## Rules
+- E2E tests verify user-visible behaviour, not implementation. Tests should survive a full refactor if the outcome is the same.
+- Each test must be independent. No test relies on state created by another test. Set up and tear down your own state.
+- Don't duplicate what unit tests already cover. E2E tests are slow — reserve them for full user flows.
+- If the E2E framework isn't established, ask before picking one. Don't introduce new tooling silently.

--- a/skills/testing/qa-plan.md
+++ b/skills/testing/qa-plan.md
@@ -1,0 +1,44 @@
+---
+name: qa-plan
+description: Write a QA test plan for a feature or release
+---
+
+# qa-plan
+
+Write a test plan that covers what matters and defines clear exit criteria.
+
+## Process
+1. Understand scope: what was built, what changed, what's at risk?
+2. Identify test areas:
+   - **Happy path** — primary user flows end-to-end
+   - **Edge cases** — empty state, max values, concurrent access, missing optional data
+   - **Error states** — network failure, invalid input, permission denied, timeout
+   - **Regression** — what existing features could this change break?
+   - **Integration points** — external APIs, third-party services, webhooks
+3. Assign priority (P1 / P2 / P3) to each test case.
+4. Note what should be automated vs what requires manual verification.
+
+## Output
+
+```
+**Test Plan: [Feature / Release]**
+
+Scope: [what's being tested]
+Out of scope: [what's not — be explicit]
+Environment: [staging / prod / local]
+
+**Test Cases**:
+| ID | Area | Scenario | Steps | Expected Result | Priority | Type |
+|---|---|---|---|---|---|---|
+
+**Exit criteria**: [what must pass before this is considered done]
+**Known risks**: [what might we miss or what's hard to test?]
+```
+
+Priority definitions: P1 = blocks release. P2 = should pass. P3 = nice to have.
+Type: Manual / Automated / Either.
+
+## Rules
+- If a scenario is too vague to test, it's not a requirement — surface it as an open question.
+- Exit criteria must be binary. "Looks good" is not exit criteria. "All P1 test cases pass" is.
+- Don't write test cases for things covered by existing automated tests unless regression risk is high.


### PR DESCRIPTION
## What This Adds

A new `skills/` directory containing **21 token-efficient task instructions** across 6 categories — a lightweight complement to The Agency's agents.

## The Problem Skills Solve

Agents are great for long sessions where you want Claude to embody a specialist. But for one-shot tasks — review this code, write this PRD, plan this sprint — you're loading 100–400 lines of persona scaffolding that doesn't change the output quality. Skills do the same job in 20–50 lines.

The key insight: **Claude already has the domain expertise. It doesn't need a persona scaffold to review code well — it needs focused instructions.**

| | Agents | Skills |
|---|---|---|
| Tells Claude | Who to be | What to do |
| Format | Persona + process + examples | Direct instructions |
| Lines per file | 100–400 | 20–50 |
| Token cost | High | Low |
| Best for | Long sessions | One-shot tasks |

## Skills Added (21 total)

**💻 Engineering** — `code-review`, `refactor`, `debug`, `architect`, `security-scan`, `test-gen`, `perf-audit`, `pr-description`, `api-design`, `tech-debt`, `incident`

**📋 Product** — `prd`, `user-story`, `sprint-plan`

**✍️ Content** — `linkedin-post`, `content-brief`

**💼 Sales** — `outreach`, `discovery`

**🧪 Testing** — `qa-plan`, `e2e-tests`

**🎨 Design** — `ux-review`

## How to Use (Claude Code)

```bash
# Install all skills
cp -r skills/engineering skills/product skills/content \
      skills/sales skills/testing skills/design \
      ~/.claude/commands/
```

Then invoke with a slash command in any Claude Code session:
```
/code-review
/debug
/prd
/sprint-plan
```

## Skill Format

```markdown
---
name: skill-name
description: One-line description of what this skill produces
---

# Skill Name

One-line purpose statement.

## Process
1. Numbered steps — what to do, not who to be.

## Output
Exact format of what to produce.

## Rules
- Hard constraints only (optional).
```

## What's Not Changed

- All existing agents are untouched
- No changes to install scripts, convert scripts, or existing integrations
- Skills are purely additive — a new directory alongside the existing structure

## Docs Updated

- `skills/README.md` — full catalog, format spec, contributing guide
- `README.md` — new "Skills" section with comparison table
- `integrations/claude-code/README.md` — install instructions + agents-vs-skills guidance

---

This is designed to be a natural complement to the agent roster, not a replacement. Use agents when you want Claude to be a specialist for a whole session. Use skills when you want a precise, repeatable action.