### PR TITLE
docs: add Built with Agency Agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,16 @@ See the **[Nexus Spatial Discovery Exercise](examples/nexus-spatial-discovery.md
 
 ---
 
+## 🛠️ Built with Agency Agents
+
+Projects and tools that use Agency Agents as their agent source:
+
+- **[AgentCrow](https://github.com/jee599/agentcrow)** — Auto agent router for Claude Code. Wraps Agency Agents into an npm package with auto-decomposition, fuzzy matching, and one-line setup (`npm i -g agentcrow && agentcrow init`). 144 agents, 118 tests, 12 language READMEs.
+
+> Built something with Agency Agents? Open a PR to add it here!
+
+---
+
 ## 🤝 Contributing
 
 We welcome contributions! Here's how you can help:


### PR DESCRIPTION
## Summary

Adding a "Built with Agency Agents" section to the README, starting with AgentCrow.

AgentCrow wraps Agency Agents into an npm package (`agentcrow`) that provides:
- Auto prompt decomposition → agent matching → subagent dispatch
- One-line setup: `npm i -g agentcrow && agentcrow init`
- 9 hand-crafted builtin agents + all Agency Agents
- Fuzzy matching with tag-based scoring
- 118 tests, 12 language READMEs

This section also encourages other projects to add themselves, creating a nice ecosystem reference.