### PR TITLE
feat: generate README agent index from source files

### DIFF
--- a/.github/workflows/check-agent-index.yml
+++ b/.github/workflows/check-agent-index.yml
@@ -1,0 +1,33 @@
+name: Check Agent Index
+
+on:
+  pull_request:
+    paths:
+      - 'engineering/**'
+      - 'design/**'
+      - 'paid-media/**'
+      - 'sales/**'
+      - 'marketing/**'
+      - 'product/**'
+      - 'project-management/**'
+      - 'testing/**'
+      - 'support/**'
+      - 'spatial-computing/**'
+      - 'specialized/**'
+      - 'game-development/**'
+      - 'academic/**'
+      - 'README.md'
+      - 'CONTRIBUTING.md'
+      - 'scripts/generate-readme-agent-index.sh'
+
+jobs:
+  check:
+    name: Verify README agent index is up to date
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check agent index
+        run: |
+          chmod +x scripts/generate-readme-agent-index.sh
+          ./scripts/generate-readme-agent-index.sh --check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -271,6 +271,7 @@ We love ambitious ideas — a [Discussion](https://github.com/msitarzewski/agenc
 3. **Add Examples**: Include at least 2-3 code/template examples
 4. **Define Metrics**: Include specific, measurable success criteria
 5. **Proofread**: Check for typos, formatting issues, clarity
+6. **Regenerate the Agent Index**: If you added or renamed an agent, run `./scripts/generate-readme-agent-index.sh` to update README.md
 
 ### Submitting Your PR
 

--- a/README.md
+++ b/README.md
@@ -810,6 +810,216 @@ When you add new agents or edit existing ones, regenerate all integration files:
 
 ---
 
+## 📇 Agent Index
+
+An auto-generated index of every agent in the repository. To regenerate, run `./scripts/generate-readme-agent-index.sh`.
+
+<!-- BEGIN GENERATED AGENT INDEX -->
+
+### Engineering
+
+- [AI Data Remediation Engineer](engineering/engineering-ai-data-remediation-engineer.md)
+- [AI Engineer](engineering/engineering-ai-engineer.md)
+- [Autonomous Optimization Architect](engineering/engineering-autonomous-optimization-architect.md)
+- [Backend Architect](engineering/engineering-backend-architect.md)
+- [CMS Developer](engineering/engineering-cms-developer.md)
+- [Code Reviewer](engineering/engineering-code-reviewer.md)
+- [Data Engineer](engineering/engineering-data-engineer.md)
+- [Database Optimizer](engineering/engineering-database-optimizer.md)
+- [DevOps Automator](engineering/engineering-devops-automator.md)
+- [Email Intelligence Engineer](engineering/engineering-email-intelligence-engineer.md)
+- [Embedded Firmware Engineer](engineering/engineering-embedded-firmware-engineer.md)
+- [Feishu Integration Developer](engineering/engineering-feishu-integration-developer.md)
+- [Filament Optimization Specialist](engineering/engineering-filament-optimization-specialist.md)
+- [Frontend Developer](engineering/engineering-frontend-developer.md)
+- [Git Workflow Master](engineering/engineering-git-workflow-master.md)
+- [Incident Response Commander](engineering/engineering-incident-response-commander.md)
+- [Mobile App Builder](engineering/engineering-mobile-app-builder.md)
+- [Rapid Prototyper](engineering/engineering-rapid-prototyper.md)
+- [Security Engineer](engineering/engineering-security-engineer.md)
+- [Senior Developer](engineering/engineering-senior-developer.md)
+- [Software Architect](engineering/engineering-software-architect.md)
+- [Solidity Smart Contract Engineer](engineering/engineering-solidity-smart-contract-engineer.md)
+- [SRE (Site Reliability Engineer)](engineering/engineering-sre.md)
+- [Technical Writer](engineering/engineering-technical-writer.md)
+- [Threat Detection Engineer](engineering/engineering-threat-detection-engineer.md)
+- [WeChat Mini Program Developer](engineering/engineering-wechat-mini-program-developer.md)
+
+### Design
+
+- [Brand Guardian](design/design-brand-guardian.md)
+- [Image Prompt Engineer](design/design-image-prompt-engineer.md)
+- [Inclusive Visuals Specialist](design/design-inclusive-visuals-specialist.md)
+- [UI Designer](design/design-ui-designer.md)
+- [UX Architect](design/design-ux-architect.md)
+- [UX Researcher](design/design-ux-researcher.md)
+- [Visual Storyteller](design/design-visual-storyteller.md)
+- [Whimsy Injector](design/design-whimsy-injector.md)
+
+### Paid Media
+
+- [Paid Media Auditor](paid-media/paid-media-auditor.md)
+- [Ad Creative Strategist](paid-media/paid-media-creative-strategist.md)
+- [Paid Social Strategist](paid-media/paid-media-paid-social-strategist.md)
+- [PPC Campaign Strategist](paid-media/paid-media-ppc-strategist.md)
+- [Programmatic & Display Buyer](paid-media/paid-media-programmatic-buyer.md)
+- [Search Query Analyst](paid-media/paid-media-search-query-analyst.md)
+- [Tracking & Measurement Specialist](paid-media/paid-media-tracking-specialist.md)
+
+### Sales
+
+- [Account Strategist](sales/sales-account-strategist.md)
+- [Sales Coach](sales/sales-coach.md)
+- [Deal Strategist](sales/sales-deal-strategist.md)
+- [Discovery Coach](sales/sales-discovery-coach.md)
+- [Sales Engineer](sales/sales-engineer.md)
+- [Outbound Strategist](sales/sales-outbound-strategist.md)
+- [Pipeline Analyst](sales/sales-pipeline-analyst.md)
+- [Proposal Strategist](sales/sales-proposal-strategist.md)
+
+### Marketing
+
+- [AI Citation Strategist](marketing/marketing-ai-citation-strategist.md)
+- [App Store Optimizer](marketing/marketing-app-store-optimizer.md)
+- [Baidu SEO Specialist](marketing/marketing-baidu-seo-specialist.md)
+- [Bilibili Content Strategist](marketing/marketing-bilibili-content-strategist.md)
+- [Book Co-Author](marketing/marketing-book-co-author.md)
+- [Carousel Growth Engine](marketing/marketing-carousel-growth-engine.md)
+- [China E-Commerce Operator](marketing/marketing-china-ecommerce-operator.md)
+- [China Market Localization Strategist](marketing/marketing-china-market-localization-strategist.md)
+- [Content Creator](marketing/marketing-content-creator.md)
+- [Cross-Border E-Commerce Specialist](marketing/marketing-cross-border-ecommerce.md)
+- [Douyin Strategist](marketing/marketing-douyin-strategist.md)
+- [Growth Hacker](marketing/marketing-growth-hacker.md)
+- [Instagram Curator](marketing/marketing-instagram-curator.md)
+- [Kuaishou Strategist](marketing/marketing-kuaishou-strategist.md)
+- [LinkedIn Content Creator](marketing/marketing-linkedin-content-creator.md)
+- [Livestream Commerce Coach](marketing/marketing-livestream-commerce-coach.md)
+- [Podcast Strategist](marketing/marketing-podcast-strategist.md)
+- [Private Domain Operator](marketing/marketing-private-domain-operator.md)
+- [Reddit Community Builder](marketing/marketing-reddit-community-builder.md)
+- [SEO Specialist](marketing/marketing-seo-specialist.md)
+- [Short-Video Editing Coach](marketing/marketing-short-video-editing-coach.md)
+- [Social Media Strategist](marketing/marketing-social-media-strategist.md)
+- [TikTok Strategist](marketing/marketing-tiktok-strategist.md)
+- [Twitter Engager](marketing/marketing-twitter-engager.md)
+- [Video Optimization Specialist](marketing/marketing-video-optimization-specialist.md)
+- [WeChat Official Account Manager](marketing/marketing-wechat-official-account.md)
+- [Weibo Strategist](marketing/marketing-weibo-strategist.md)
+- [Xiaohongshu Specialist](marketing/marketing-xiaohongshu-specialist.md)
+- [Zhihu Strategist](marketing/marketing-zhihu-strategist.md)
+
+### Product
+
+- [Behavioral Nudge Engine](product/product-behavioral-nudge-engine.md)
+- [Feedback Synthesizer](product/product-feedback-synthesizer.md)
+- [Product Manager](product/product-manager.md)
+- [Sprint Prioritizer](product/product-sprint-prioritizer.md)
+- [Trend Researcher](product/product-trend-researcher.md)
+
+### Project Management
+
+- [Experiment Tracker](project-management/project-management-experiment-tracker.md)
+- [Jira Workflow Steward](project-management/project-management-jira-workflow-steward.md)
+- [Project Shepherd](project-management/project-management-project-shepherd.md)
+- [Studio Operations](project-management/project-management-studio-operations.md)
+- [Studio Producer](project-management/project-management-studio-producer.md)
+- [Senior Project Manager](project-management/project-manager-senior.md)
+
+### Testing
+
+- [Accessibility Auditor](testing/testing-accessibility-auditor.md)
+- [API Tester](testing/testing-api-tester.md)
+- [Evidence Collector](testing/testing-evidence-collector.md)
+- [Performance Benchmarker](testing/testing-performance-benchmarker.md)
+- [Reality Checker](testing/testing-reality-checker.md)
+- [Test Results Analyzer](testing/testing-test-results-analyzer.md)
+- [Tool Evaluator](testing/testing-tool-evaluator.md)
+- [Workflow Optimizer](testing/testing-workflow-optimizer.md)
+
+### Support
+
+- [Analytics Reporter](support/support-analytics-reporter.md)
+- [Executive Summary Generator](support/support-executive-summary-generator.md)
+- [Finance Tracker](support/support-finance-tracker.md)
+- [Infrastructure Maintainer](support/support-infrastructure-maintainer.md)
+- [Legal Compliance Checker](support/support-legal-compliance-checker.md)
+- [Support Responder](support/support-support-responder.md)
+
+### Spatial Computing
+
+- [macOS Spatial/Metal Engineer](spatial-computing/macos-spatial-metal-engineer.md)
+- [Terminal Integration Specialist](spatial-computing/terminal-integration-specialist.md)
+- [visionOS Spatial Engineer](spatial-computing/visionos-spatial-engineer.md)
+- [XR Cockpit Interaction Specialist](spatial-computing/xr-cockpit-interaction-specialist.md)
+- [XR Immersive Developer](spatial-computing/xr-immersive-developer.md)
+- [XR Interface Architect](spatial-computing/xr-interface-architect.md)
+
+### Specialized
+
+- [Accounts Payable Agent](specialized/accounts-payable-agent.md)
+- [Agentic Identity & Trust Architect](specialized/agentic-identity-trust.md)
+- [Agents Orchestrator](specialized/agents-orchestrator.md)
+- [Automation Governance Architect](specialized/automation-governance-architect.md)
+- [Blockchain Security Auditor](specialized/blockchain-security-auditor.md)
+- [Compliance Auditor](specialized/compliance-auditor.md)
+- [Corporate Training Designer](specialized/corporate-training-designer.md)
+- [Data Consolidation Agent](specialized/data-consolidation-agent.md)
+- [Government Digital Presales Consultant](specialized/government-digital-presales-consultant.md)
+- [Healthcare Marketing Compliance Specialist](specialized/healthcare-marketing-compliance.md)
+- [Identity Graph Operator](specialized/identity-graph-operator.md)
+- [LSP/Index Engineer](specialized/lsp-index-engineer.md)
+- [Recruitment Specialist](specialized/recruitment-specialist.md)
+- [Report Distribution Agent](specialized/report-distribution-agent.md)
+- [Sales Data Extraction Agent](specialized/sales-data-extraction-agent.md)
+- [Civil Engineer](specialized/specialized-civil-engineer.md)
+- [Cultural Intelligence Strategist](specialized/specialized-cultural-intelligence-strategist.md)
+- [Developer Advocate](specialized/specialized-developer-advocate.md)
+- [Document Generator](specialized/specialized-document-generator.md)
+- [French Consulting Market Navigator](specialized/specialized-french-consulting-market.md)
+- [Korean Business Navigator](specialized/specialized-korean-business-navigator.md)
+- [MCP Builder](specialized/specialized-mcp-builder.md)
+- [Model QA Specialist](specialized/specialized-model-qa.md)
+- [Salesforce Architect](specialized/specialized-salesforce-architect.md)
+- [Workflow Architect](specialized/specialized-workflow-architect.md)
+- [Study Abroad Advisor](specialized/study-abroad-advisor.md)
+- [Supply Chain Strategist](specialized/supply-chain-strategist.md)
+- [ZK Steward](specialized/zk-steward.md)
+
+### Game Development
+
+- [Blender Add-on Engineer](game-development/blender/blender-addon-engineer.md)
+- [Game Audio Engineer](game-development/game-audio-engineer.md)
+- [Game Designer](game-development/game-designer.md)
+- [Godot Gameplay Scripter](game-development/godot/godot-gameplay-scripter.md)
+- [Godot Multiplayer Engineer](game-development/godot/godot-multiplayer-engineer.md)
+- [Godot Shader Developer](game-development/godot/godot-shader-developer.md)
+- [Level Designer](game-development/level-designer.md)
+- [Narrative Designer](game-development/narrative-designer.md)
+- [Roblox Avatar Creator](game-development/roblox-studio/roblox-avatar-creator.md)
+- [Roblox Experience Designer](game-development/roblox-studio/roblox-experience-designer.md)
+- [Roblox Systems Scripter](game-development/roblox-studio/roblox-systems-scripter.md)
+- [Technical Artist](game-development/technical-artist.md)
+- [Unity Architect](game-development/unity/unity-architect.md)
+- [Unity Editor Tool Developer](game-development/unity/unity-editor-tool-developer.md)
+- [Unity Multiplayer Engineer](game-development/unity/unity-multiplayer-engineer.md)
+- [Unity Shader Graph Artist](game-development/unity/unity-shader-graph-artist.md)
+- [Unreal Multiplayer Architect](game-development/unreal-engine/unreal-multiplayer-architect.md)
+- [Unreal Systems Engineer](game-development/unreal-engine/unreal-systems-engineer.md)
+- [Unreal Technical Artist](game-development/unreal-engine/unreal-technical-artist.md)
+- [Unreal World Builder](game-development/unreal-engine/unreal-world-builder.md)
+
+### Academic
+
+- [Anthropologist](academic/academic-anthropologist.md)
+- [Geographer](academic/academic-geographer.md)
+- [Historian](academic/academic-historian.md)
+- [Narratologist](academic/academic-narratologist.md)
+- [Psychologist](academic/academic-psychologist.md)
+<!-- END GENERATED AGENT INDEX -->
+
+---
+
 ## 🗺️ Roadmap
 
 - [ ] Interactive agent selector web tool

--- a/scripts/generate-readme-agent-index.sh
+++ b/scripts/generate-readme-agent-index.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# Generates the "Agent Index" section in README.md from agent markdown files.
+# Usage:
+#   ./scripts/generate-readme-agent-index.sh          # update README in-place
+#   ./scripts/generate-readme-agent-index.sh --check   # exit non-zero if out of date
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+README="$REPO_ROOT/README.md"
+
+BEGIN_MARKER="<!-- BEGIN GENERATED AGENT INDEX -->"
+END_MARKER="<!-- END GENERATED AGENT INDEX -->"
+
+# Directories in display order
+CATEGORIES=(
+  engineering
+  design
+  paid-media
+  sales
+  marketing
+  product
+  project-management
+  testing
+  support
+  spatial-computing
+  specialized
+  game-development
+  academic
+)
+
+# Map directory name to human-readable heading (Bash 3.2 compatible)
+category_heading() {
+  case "$1" in
+    engineering)        echo "Engineering" ;;
+    design)             echo "Design" ;;
+    paid-media)         echo "Paid Media" ;;
+    sales)              echo "Sales" ;;
+    marketing)          echo "Marketing" ;;
+    product)            echo "Product" ;;
+    project-management) echo "Project Management" ;;
+    testing)            echo "Testing" ;;
+    support)            echo "Support" ;;
+    spatial-computing)  echo "Spatial Computing" ;;
+    specialized)        echo "Specialized" ;;
+    game-development)   echo "Game Development" ;;
+    academic)           echo "Academic" ;;
+    *)                  echo "$1" ;;
+  esac
+}
+
+generate_index() {
+  local output=""
+
+  for category in "${CATEGORIES[@]}"; do
+    local dir="$REPO_ROOT/$category"
+    [[ -d "$dir" ]] || continue
+
+    local heading
+    heading="$(category_heading "$category")"
+    local entries=""
+
+    while IFS= read -r filepath; do
+      local basename
+      basename="$(basename "$filepath")"
+      [[ "$basename" == "README.md" ]] && continue
+
+      # Only include files that start with YAML frontmatter
+      local first_line
+      first_line="$(head -1 "$filepath")"
+      [[ "$first_line" == "---" ]] || continue
+
+      # Extract name from frontmatter
+      local name
+      name="$(awk 'NR==1{next} /^---$/{exit} /^name:/{sub(/^name:[[:space:]]*/, ""); print}' "$filepath")"
+      [[ -z "$name" ]] && continue
+
+      local relpath="${filepath#"$REPO_ROOT/"}"
+      entries+="- [${name}](${relpath})"$'\n'
+    done < <(find "$dir" -name '*.md' -type f | sort)
+
+    if [[ -n "$entries" ]]; then
+      output+=$'\n'"### ${heading}"$'\n'
+      output+=$'\n'"${entries}"
+    fi
+  done
+
+  printf '%s' "$output"
+}
+
+# Build the new generated block
+new_block="$(generate_index)"
+
+if [[ "$*" == *"--check"* ]]; then
+  # Extract existing block from README
+  existing="$(awk -v begin="$BEGIN_MARKER" -v end="$END_MARKER" '
+    index($0, begin) { found=1; next }
+    index($0, end)   { found=0; next }
+    found            { print }
+  ' "$README")"
+
+  if [[ "$existing" == "$new_block" ]]; then
+    echo "Agent index is up to date."
+    exit 0
+  else
+    echo "ERROR: Agent index in README.md is out of date."
+    echo "Run ./scripts/generate-readme-agent-index.sh to regenerate."
+    diff <(echo "$existing") <(echo "$new_block") || true
+    exit 1
+  fi
+fi
+
+# Replace content between markers in-place using temp files so multiline
+# generated content works on Bash 3.2 and malformed existing blocks can be
+# overwritten cleanly.
+tmp_readme="$(mktemp)"
+tmp_block="$(mktemp)"
+
+printf '%s\n' "$new_block" > "$tmp_block"
+
+awk -v begin="$BEGIN_MARKER" '
+  { print }
+  index($0, begin) { exit }
+' "$README" > "$tmp_readme"
+
+cat "$tmp_block" >> "$tmp_readme"
+printf '%s\n' "$END_MARKER" >> "$tmp_readme"
+
+awk -v end="$END_MARKER" '
+  index($0, end) { found=1; next }
+  found          { print }
+' "$README" >> "$tmp_readme"
+
+mv "$tmp_readme" "$README"
+rm -f "$tmp_block"
+
+echo "Agent index in README.md updated."


### PR DESCRIPTION
## What does this PR do?

Adds an auto-generated `Agent Index` section to `README.md`, sourced from the repository’s agent markdown files.

This reduces drift between the source agent definitions and the top-level documentation, and adds CI verification so future changes keep the index in sync.

This keeps the existing roster tables untouched and adds a separate generated index for a low-risk discoverability improvement.

## Changes

- add `scripts/generate-readme-agent-index.sh`
- add generated `Agent Index` section to `README.md`
- add workflow to verify the generated index on pull requests
- update `CONTRIBUTING.md` with the regeneration step

## Why

The repository now contains a large and growing number of agents across many divisions. Keeping a discoverable index in sync by hand is error-prone. This PR makes that maintenance automatic and reviewable.

## Agent Information (if adding/modifying an agent)

- **Agent Name**: N/A
- **Category**: docs / tooling
- **Specialty**: README generation and CI verification

## Checklist

- [x] Follows the repository’s shell-script style
- [x] Keeps the generated section scoped to README markers
- [x] Includes CI verification
- [x] Proofread and formatted correctly
