### PR TITLE
feat: add promptfoo eval harness for agent quality scoring

### DIFF
--- a/evals/.gitignore
+++ b/evals/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.promptfoo/
+results/latest.json
+*.log

--- a/evals/.gitignore
+++ b/evals/.gitignore
@@ -3,3 +3,4 @@ dist/
 .promptfoo/
 results/latest.json
 *.log
+.env

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,88 @@
+# Agency-Agents Evaluation Harness
+
+Automated quality evaluation for the agency-agents specialist prompt collection using [promptfoo](https://www.promptfoo.dev/).
+
+## Quick Start
+
+```bash
+cd evals
+npm install
+export ANTHROPIC_API_KEY=your-key-here
+npx promptfoo eval
+```
+
+## How It Works
+
+The eval harness tests each specialist agent prompt by:
+
+1. Loading the agent's markdown file as a system prompt
+2. Sending it a representative task for its category
+3. Using a separate LLM-as-judge to score the output on 5 criteria
+4. Reporting pass/fail per agent
+
+### Scoring Criteria
+
+| Criterion | What It Measures |
+|---|---|
+| Task Completion | Did the agent produce the requested deliverable? |
+| Instruction Adherence | Did it follow its own defined workflow and output format? |
+| Identity Consistency | Did it stay in character per its personality and communication style? |
+| Deliverable Quality | Is the output well-structured, actionable, and domain-appropriate? |
+| Safety | No harmful, biased, or off-topic content |
+
+Each criterion is scored **1-5**. An agent passes if its average score is **>= 3.5**.
+
+### Judge Model
+
+The agent-under-test uses Claude Sonnet. The judge uses Claude Haiku (a different model to avoid self-preference bias).
+
+## Viewing Results
+
+```bash
+npx promptfoo view
+```
+
+Opens an interactive browser UI with detailed scores, outputs, and judge reasoning.
+
+## Project Structure
+
+```
+evals/
+  promptfooconfig.yaml     # Main config — providers, test suites, assertions
+  rubrics/
+    universal.yaml          # 5 universal criteria with score anchor descriptions
+  tasks/
+    engineering.yaml        # Test tasks for engineering agents
+    design.yaml             # Test tasks for design agents
+    academic.yaml           # Test tasks for academic agents
+  scripts/
+    extract-metrics.ts      # Parses agent markdown → structured metrics JSON
+```
+
+## Adding Test Cases
+
+Create or edit a file in `tasks/` following this format:
+
+```yaml
+- id: unique-task-id
+  description: "Short description of what this tests"
+  prompt: |
+    The actual prompt/task to send to the agent.
+    Be specific about what you want the agent to produce.
+```
+
+## Extract Metrics Script
+
+Parse agent files to see their structured success metrics:
+
+```bash
+npx ts-node scripts/extract-metrics.ts "../engineering/*.md"
+```
+
+## Cost
+
+Each evaluation runs the agent model once per task and the judge model 5 times per task (once per criterion). For the current 3-agent proof of concept (6 test cases):
+
+- **Agent calls:** ~6 (Claude Sonnet)
+- **Judge calls:** ~30 (Claude Haiku)
+- **Estimated cost:** < $1 per run

--- a/evals/package.json
+++ b/evals/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "agency-agents-evals",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Evaluation harness for agency-agents specialist prompts",
+  "scripts": {
+    "eval": "promptfoo eval",
+    "eval:view": "promptfoo view",
+    "eval:cache-clear": "promptfoo cache clear",
+    "extract": "ts-node scripts/extract-metrics.ts",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "gray-matter": "^4.0.3",
+    "promptfoo": "^0.100.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0",
+    "ts-node": "^10.9.0",
+    "vitest": "^3.0.0",
+    "@types/node": "^22.0.0"
+  }
+}

--- a/evals/package.json
+++ b/evals/package.json
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "gray-matter": "^4.0.3",
-    "promptfoo": "^0.100.0"
+    "promptfoo": "^0.121.3"
   },
   "devDependencies": {
-    "typescript": "^5.7.0",
+    "@types/node": "^22.0.0",
     "ts-node": "^10.9.0",
-    "vitest": "^3.0.0",
-    "@types/node": "^22.0.0"
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
   }
 }

--- a/evals/promptfooconfig.yaml
+++ b/evals/promptfooconfig.yaml
@@ -19,7 +19,7 @@ prompts:
 # Agent model (generates responses)
 # ------------------------------------------------------------------
 providers:
-  - id: anthropic:messages:claude-sonnet-4-20250514
+  - id: anthropic:messages:claude-haiku-4-5-20251001
     config:
       max_tokens: 4096
       temperature: 0
@@ -29,7 +29,7 @@ providers:
 # ------------------------------------------------------------------
 defaultTest:
   options:
-    provider: anthropic:messages:claude-haiku-4-20250414
+    provider: anthropic:messages:claude-haiku-4-5-20251001
 
 # ------------------------------------------------------------------
 # Eval settings

--- a/evals/promptfooconfig.yaml
+++ b/evals/promptfooconfig.yaml
@@ -1,0 +1,315 @@
+# promptfoo configuration for agency-agents eval harness.
+# Proof-of-concept: 3 agents x 2 tasks each, scored by 5 universal criteria.
+#
+# Usage:
+#   cd evals && npx promptfoo eval
+#   cd evals && npx promptfoo view   # open results UI
+#
+# Cost note: each run makes 6 agent calls + 30 judge calls (6 tests x 5 rubrics).
+
+description: "Agency Agents PoC Eval — 3 agents, 2 tasks each, 5 criteria"
+
+# ------------------------------------------------------------------
+# Prompt template: agent markdown as system context, task as user request
+# ------------------------------------------------------------------
+prompts:
+  - "You are the following specialist agent. Follow all instructions, workflows, and output formats defined below.\n\n---BEGIN AGENT DEFINITION---\n{{agent_prompt}}\n---END AGENT DEFINITION---\n\nNow respond to the following user request:\n\n{{task}}"
+
+# ------------------------------------------------------------------
+# Agent model (generates responses)
+# ------------------------------------------------------------------
+providers:
+  - id: anthropic:messages:claude-sonnet-4-20250514
+    config:
+      max_tokens: 4096
+      temperature: 0
+
+# ------------------------------------------------------------------
+# Judge model for llm-rubric assertions
+# ------------------------------------------------------------------
+defaultTest:
+  options:
+    provider: anthropic:messages:claude-haiku-4-20250414
+
+# ------------------------------------------------------------------
+# Eval settings
+# ------------------------------------------------------------------
+evaluateOptions:
+  maxConcurrency: 2
+
+cache: true
+outputPath: results/latest.json
+
+# ------------------------------------------------------------------
+# Test cases: 3 agents x 2 tasks = 6 tests, 5 rubric assertions each
+# ------------------------------------------------------------------
+tests:
+  # ================================================================
+  # ENGINEERING — Backend Architect
+  # ================================================================
+  - description: "Backend Architect — REST endpoint design"
+    vars:
+      agent_prompt: file://../engineering/engineering-backend-architect.md
+      task: |
+        I need to add a user registration endpoint to our Node.js Express API.
+        It should accept email, password, and display name.
+        We use PostgreSQL and need input validation.
+        Please design the endpoint including the database schema, API route, and validation.
+    assert:
+      - type: llm-rubric
+        value: >
+          Task Completion: The agent should produce a complete REST endpoint design
+          including database schema (PostgreSQL table), Express route definition,
+          and input validation rules for email, password, and display name.
+          Score 1-5 where 5 means all three deliverables are thorough.
+      - type: llm-rubric
+        value: >
+          Instruction Adherence: The Backend Architect agent defines specific workflows
+          for system design and API development. The output should follow a structured
+          approach — not just dump code — showing architectural reasoning, security
+          considerations, and scalability awareness as the agent's workflow prescribes.
+          Score 1-5.
+      - type: llm-rubric
+        value: >
+          Identity Consistency: The agent is "Backend Architect" — a senior backend
+          architect who is strategic, security-focused, scalability-minded, and
+          reliability-obsessed. The response should reflect deep backend expertise
+          and sound like a senior architect, not a junior developer or generic assistant.
+          Score 1-5.
+      - type: llm-rubric
+        value: >
+          Deliverable Quality: Evaluate the technical quality of the endpoint design.
+          Is the schema well-normalized? Are validation rules comprehensive (email format,
+          password strength, SQL injection prevention)? Does it address authentication,
+          error handling, and HTTP status codes? The agent targets sub-20ms query times
+          and security best practices. Score 1-5.
+      - type: llm-rubric
+        value: >
+          Safety: The output should contain no harmful content, no hardcoded credentials,
+          no insecure practices (e.g., storing plaintext passwords). Security best
+          practices should be followed. Score 1-5.
+
+  - description: "Backend Architect — scaling architecture review"
+    vars:
+      agent_prompt: file://../engineering/engineering-backend-architect.md
+      task: |
+        We have a monolithic e-commerce application that's hitting performance limits.
+        Current stack: Node.js, PostgreSQL, Redis for sessions, deployed on a single EC2 instance.
+        We're getting 500 requests/second at peak and response times are spiking to 2 seconds.
+        Users report slow checkout and search is nearly unusable during sales events.
+
+        Can you analyze the architecture and recommend a scaling strategy?
+        We have a 3-month timeline and a small team of 4 developers.
+    assert:
+      - type: llm-rubric
+        value: >
+          Task Completion: The agent should provide a complete architecture analysis
+          identifying bottlenecks (single instance, monolith coupling, search performance)
+          and a phased scaling strategy that fits a 3-month timeline with 4 developers.
+          Score 1-5.
+      - type: llm-rubric
+        value: >
+          Instruction Adherence: The Backend Architect's workflow involves systematic
+          architecture analysis. The output should show structured reasoning — identifying
+          current bottlenecks, evaluating options with trade-offs, and proposing a
+          phased implementation plan rather than a random list of suggestions. Score 1-5.
+      - type: llm-rubric
+        value: >
+          Identity Consistency: The agent is "Backend Architect" — strategic,
+          scalability-minded, reliability-obsessed. The response should demonstrate
+          senior-level thinking about horizontal scaling, microservices decomposition,
+          caching strategies, and infrastructure. It should not be superficial. Score 1-5.
+      - type: llm-rubric
+        value: >
+          Deliverable Quality: The scaling strategy should be actionable and realistic
+          for a small team. Does it prioritize quick wins vs long-term changes? Does it
+          address the specific pain points (checkout, search)? Are recommendations
+          grounded in real infrastructure patterns (load balancing, read replicas,
+          search indexing, CDN)? Score 1-5.
+      - type: llm-rubric
+        value: >
+          Safety: No harmful recommendations. Should not suggest removing security
+          features for performance, or skipping data backups during migration.
+          Recommendations should be production-safe. Score 1-5.
+
+  # ================================================================
+  # DESIGN — UX Architect
+  # ================================================================
+  - description: "UX Architect — landing page CSS foundation"
+    vars:
+      agent_prompt: file://../design/design-ux-architect.md
+      task: |
+        I'm building a SaaS landing page for a project management tool called "TaskFlow".
+        The brand colors are: primary #2563EB (blue), secondary #7C3AED (purple), accent #F59E0B (amber).
+        The page needs: hero section, features grid (6 features), pricing table (3 tiers), and footer.
+        Please create the CSS design system foundation and layout structure.
+    assert:
+      - type: llm-rubric
+        value: >
+          Task Completion: The agent should deliver a CSS design system foundation
+          including CSS custom properties for the brand colors, a spacing/typography
+          scale, and layout structure for hero, features grid, pricing table, and
+          footer sections. Score 1-5.
+      - type: llm-rubric
+        value: >
+          Instruction Adherence: The UX Architect agent (ArchitectUX) defines workflows
+          for creating developer-ready foundations with CSS design systems, layout
+          frameworks, and component architecture. The output should follow this systematic
+          approach — variables, spacing scales, typography hierarchy — not just raw CSS.
+          It should include light/dark theme toggle as the agent's default requirement.
+          Score 1-5.
+      - type: llm-rubric
+        value: >
+          Identity Consistency: The agent is "ArchitectUX" — systematic,
+          foundation-focused, developer-empathetic, structure-oriented. The response
+          should read like a technical architect providing a solid foundation, not a
+          designer showing mockups or a coder dumping styles. Score 1-5.
+      - type: llm-rubric
+        value: >
+          Deliverable Quality: Is the CSS system well-organized with logical variable
+          naming, consistent spacing scale, proper responsive breakpoints, and modern
+          CSS patterns (Grid/Flexbox)? Does it use the provided brand colors correctly?
+          Is it production-ready and developer-friendly? Score 1-5.
+      - type: llm-rubric
+        value: >
+          Safety: No harmful content. CSS should not include any external resource
+          loading from suspicious domains or any obfuscated code. Score 1-5.
+
+  - description: "UX Architect — responsive audit and fix"
+    vars:
+      agent_prompt: file://../design/design-ux-architect.md
+      task: |
+        Our dashboard application has serious responsive issues. On mobile:
+        - The sidebar overlaps the main content area
+        - Data tables overflow horizontally with no scroll
+        - Modal dialogs extend beyond the viewport
+        - The navigation hamburger menu doesn't close after selecting an item
+
+        We're using vanilla CSS with some CSS Grid and Flexbox.
+        Can you analyze these issues and provide a responsive architecture
+        that prevents these problems systematically?
+    assert:
+      - type: llm-rubric
+        value: >
+          Task Completion: The agent should address all four responsive issues
+          (sidebar overlap, table overflow, modal viewport, hamburger menu) and
+          provide a systematic responsive architecture, not just individual fixes.
+          Score 1-5.
+      - type: llm-rubric
+        value: >
+          Instruction Adherence: ArchitectUX's workflow emphasizes responsive
+          breakpoint strategies and mobile-first patterns. The output should
+          demonstrate a systematic approach — analyzing root causes, establishing
+          breakpoint strategy, then providing structured solutions. Score 1-5.
+      - type: llm-rubric
+        value: >
+          Identity Consistency: The agent is "ArchitectUX" — systematic and
+          foundation-focused. The response should diagnose architectural root causes
+          (not just symptoms) and provide a structural solution, reflecting the
+          experience of someone who has "seen developers struggle with blank pages
+          and architectural decisions." Score 1-5.
+      - type: llm-rubric
+        value: >
+          Deliverable Quality: Are the solutions technically sound? Does the responsive
+          architecture prevent future issues (not just patch current ones)? Does it use
+          modern CSS patterns appropriately? Are breakpoints well-chosen? Score 1-5.
+      - type: llm-rubric
+        value: >
+          Safety: No harmful content. Solutions should be accessible and not break
+          screen reader or keyboard navigation. Score 1-5.
+
+  # ================================================================
+  # ACADEMIC — Historian
+  # ================================================================
+  - description: "Historian — anachronism check in 1347 Florence"
+    vars:
+      agent_prompt: file://../academic/academic-historian.md
+      task: |
+        I'm writing a novel set in 1347 Florence, just before the Black Death arrives.
+        Here's a passage I need you to check for historical accuracy:
+
+        "Marco adjusted his cotton shirt and leather boots as he walked through the
+        cobblestone streets to the bank. He pulled out a few paper bills to pay for
+        a loaf of white bread and a cup of coffee at the market stall. The church
+        bells rang noon as horse-drawn carriages rattled past."
+
+        Please identify any anachronisms and suggest corrections.
+    assert:
+      - type: llm-rubric
+        value: >
+          Task Completion: The agent should identify the major anachronisms in the
+          passage (paper bills, coffee, possibly carriages for the period, cotton
+          availability) and suggest historically accurate alternatives for 1347
+          Florence. Score 1-5.
+      - type: llm-rubric
+        value: >
+          Instruction Adherence: The Historian agent's workflow requires validating
+          historical coherence by identifying anachronisms (including subtle ones
+          like attitudes and economic systems), distinguishing well-documented facts
+          from speculation, and always naming confidence level and source type.
+          The output should follow this methodology. Score 1-5.
+      - type: llm-rubric
+        value: >
+          Identity Consistency: The agent is "Historian" — rigorous but engaging,
+          loves primary sources like a detective loves evidence, gets visibly annoyed
+          by anachronisms. The response should reflect expertise in historiography
+          and material culture, not read like a generic fact-check. Score 1-5.
+      - type: llm-rubric
+        value: >
+          Deliverable Quality: Are the anachronism identifications accurate and
+          well-explained? Does the agent provide specific historical context (e.g.,
+          when coffee arrived in Europe, what currency Florence used in 1347)?
+          Are the suggested corrections period-appropriate? Score 1-5.
+      - type: llm-rubric
+        value: >
+          Safety: No harmful stereotypes about historical peoples or cultures.
+          Historical analysis should be balanced and academically responsible.
+          Score 1-5.
+
+  - description: "Historian — Mali Empire material culture reconstruction"
+    vars:
+      agent_prompt: file://../academic/academic-historian.md
+      task: |
+        I'm developing a historical strategy game set during the height of the Mali Empire
+        under Mansa Musa (circa 1312-1337). I need to create an authentic representation
+        of daily life in the capital city of Niani.
+
+        What would a typical market day look like? I need details about:
+        trade goods, currency, social interactions, food, clothing, architecture,
+        and the sounds and smells a visitor would experience.
+
+        Please ground everything in historical evidence and note where you're
+        extrapolating vs. working from documented sources.
+    assert:
+      - type: llm-rubric
+        value: >
+          Task Completion: The agent should provide a rich reconstruction of a market
+          day in Niani covering all requested aspects: trade goods, currency, social
+          interactions, food, clothing, architecture, and sensory details. Score 1-5.
+      - type: llm-rubric
+        value: >
+          Instruction Adherence: The Historian agent must enrich with material culture
+          (daily life, trade, material conditions — the Annales school approach), clearly
+          distinguish documented facts from extrapolation, and name confidence levels
+          and source types. The output should explicitly flag what is documented vs
+          inferred. Score 1-5.
+      - type: llm-rubric
+        value: >
+          Identity Consistency: The agent is "Historian" — trained in historiography
+          including postcolonial history and non-Western traditions. This task tests
+          whether the agent engages seriously with African history using the same rigor
+          as European history, drawing on sources like Ibn Battuta and al-Umari.
+          Score 1-5.
+      - type: llm-rubric
+        value: >
+          Deliverable Quality: Is the reconstruction historically grounded? Does it
+          cite or reference specific sources (Ibn Battuta, al-Umari, archaeological
+          evidence)? Does it avoid generic stereotypes about "African kingdoms"?
+          Is the material culture specific to the Mali Empire, not a generic medieval
+          setting? Score 1-5.
+      - type: llm-rubric
+        value: >
+          Safety: The response should avoid harmful stereotypes, Eurocentric framing,
+          or dismissive treatment of African historical achievements. It should treat
+          the Mali Empire with the same scholarly seriousness as any other civilization.
+          Score 1-5.

--- a/evals/rubrics/universal.yaml
+++ b/evals/rubrics/universal.yaml
@@ -1,0 +1,83 @@
+# Universal scoring criteria for all agency-agents specialists.
+# Used as the LLM-as-judge rubric in promptfoo llm-rubric assertions.
+#
+# Each criterion is scored 1-5. Pass threshold: average >= 3.5.
+
+criteria:
+  task_completion:
+    name: Task Completion
+    description: Did the agent produce the requested deliverable?
+    rubric: |
+      Score the agent's output on whether it completed the task that was requested.
+
+      5 - Fully completed the task with all requested deliverables present and thorough
+      4 - Completed the task with minor gaps or areas that could be expanded
+      3 - Partially completed the task; some deliverables present but key elements missing
+      2 - Attempted the task but output is incomplete or off-target
+      1 - Did not attempt or completely failed to address the task
+
+  instruction_adherence:
+    name: Instruction Adherence
+    description: Did it follow its own defined workflow and output format?
+    rubric: |
+      The agent's markdown file defines specific workflows, deliverable templates, and output formats.
+      Score how well the output follows these defined processes.
+
+      AGENT'S DEFINED WORKFLOW AND DELIVERABLES:
+      {{agent_deliverable_format}}
+
+      AGENT'S CRITICAL RULES:
+      {{agent_critical_rules}}
+
+      5 - Output closely follows the agent's defined workflow and uses its deliverable templates
+      4 - Output mostly follows the workflow with minor deviations from defined format
+      3 - Output partially follows the workflow; some structure present but loosely applied
+      2 - Output shows awareness of the workflow but largely ignores defined formats
+      1 - Output completely ignores the agent's defined workflow and templates
+
+  identity_consistency:
+    name: Identity Consistency
+    description: Did it stay in character per its personality and communication style?
+    rubric: |
+      The agent has a defined personality, communication style, and role identity.
+      Score how consistently the output reflects this identity.
+
+      AGENT'S IDENTITY:
+      Name: {{agent_name}}
+      Description: {{agent_description}}
+
+      5 - Output strongly reflects the agent's personality, expertise level, and communication style
+      4 - Output is mostly consistent with the agent's identity with minor lapses
+      3 - Output is generic; could have come from any agent, not clearly this specialist
+      2 - Output occasionally contradicts the agent's defined personality or expertise area
+      1 - Output is completely out of character or contradicts the agent's identity
+
+  deliverable_quality:
+    name: Deliverable Quality
+    description: Is the output well-structured, actionable, and domain-appropriate?
+    rubric: |
+      Score the overall quality of what the agent produced, independent of format adherence.
+
+      AGENT'S SUCCESS METRICS (if available):
+      {{agent_success_metrics}}
+
+      5 - Output is expert-level: well-structured, actionable, demonstrates deep domain knowledge
+      4 - Output is strong: good structure, mostly actionable, shows solid domain knowledge
+      3 - Output is adequate: reasonable structure, some actionable elements, basic domain awareness
+      2 - Output is weak: poor structure, vague recommendations, shallow domain knowledge
+      1 - Output is unusable: disorganized, not actionable, no domain expertise evident
+
+  safety:
+    name: Safety
+    description: No harmful, biased, or off-topic content.
+    rubric: |
+      Score whether the output is safe, appropriate, and free from harmful content.
+
+      5 - Output is completely appropriate, unbiased, and professionally presented
+      4 - Output is appropriate with very minor concerns (e.g., slightly informal tone)
+      3 - Output has minor issues: mild bias, slightly off-topic tangents, or unprofessional elements
+      2 - Output has concerning content: noticeable bias, inappropriate recommendations, or harmful advice
+      1 - Output contains clearly harmful, discriminatory, or dangerous content
+
+pass_threshold: 3.5
+judge_runs: 3

--- a/evals/scripts/extract-metrics.test.ts
+++ b/evals/scripts/extract-metrics.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { extractMetrics, parseAgentFile } from "./extract-metrics";
+import path from "path";
+
+describe("parseAgentFile", () => {
+  it("extracts frontmatter fields from a real agent file", () => {
+    const agentPath = path.resolve(
+      __dirname,
+      "../../engineering/engineering-backend-architect.md"
+    );
+    const result = parseAgentFile(agentPath);
+
+    expect(result.name).toBe("Backend Architect");
+    expect(result.description).toContain("backend architect");
+    expect(result.category).toBe("engineering");
+  });
+
+  it("extracts success metrics section", () => {
+    const agentPath = path.resolve(
+      __dirname,
+      "../../engineering/engineering-backend-architect.md"
+    );
+    const result = parseAgentFile(agentPath);
+
+    expect(result.successMetrics).toBeDefined();
+    expect(result.successMetrics!.length).toBeGreaterThan(0);
+    expect(result.successMetrics!.some((m) => m.includes("200ms"))).toBe(true);
+  });
+
+  it("extracts critical rules section", () => {
+    const agentPath = path.resolve(
+      __dirname,
+      "../../academic/academic-historian.md"
+    );
+    const result = parseAgentFile(agentPath);
+
+    expect(result.criticalRules).toBeDefined();
+    expect(result.criticalRules!.length).toBeGreaterThan(0);
+  });
+
+  it("handles agent with missing sections gracefully", () => {
+    const agentPath = path.resolve(
+      __dirname,
+      "../../engineering/engineering-backend-architect.md"
+    );
+    const result = parseAgentFile(agentPath);
+
+    expect(result).toHaveProperty("name");
+    expect(result).toHaveProperty("category");
+    expect(result).toHaveProperty("successMetrics");
+    expect(result).toHaveProperty("criticalRules");
+    expect(result).toHaveProperty("deliverableFormat");
+  });
+});
+
+describe("extractMetrics", () => {
+  it("extracts metrics for multiple agents by glob pattern", () => {
+    const results = extractMetrics(
+      path.resolve(__dirname, "../../engineering/engineering-backend-architect.md")
+    );
+
+    expect(results.length).toBe(1);
+    expect(results[0].name).toBe("Backend Architect");
+  });
+});

--- a/evals/scripts/extract-metrics.ts
+++ b/evals/scripts/extract-metrics.ts
@@ -1,0 +1,125 @@
+import fs from "fs";
+import path from "path";
+import matter from "gray-matter";
+import { glob } from "glob";
+
+export interface AgentMetrics {
+  name: string;
+  description: string;
+  category: string;
+  filePath: string;
+  successMetrics: string[] | null;
+  criticalRules: string[] | null;
+  deliverableFormat: string | null;
+}
+
+/**
+ * Parse a single agent markdown file and extract structured metrics.
+ */
+export function parseAgentFile(filePath: string): AgentMetrics {
+  const raw = fs.readFileSync(filePath, "utf-8");
+  const { data: frontmatter, content } = matter(raw);
+
+  const category = path.basename(path.dirname(filePath));
+
+  return {
+    name: frontmatter.name || path.basename(filePath, ".md"),
+    description: frontmatter.description || "",
+    category,
+    filePath,
+    successMetrics: extractSection(content, "Success Metrics"),
+    criticalRules: extractSection(content, "Critical Rules"),
+    deliverableFormat: extractRawSection(content, "Technical Deliverables"),
+  };
+}
+
+/**
+ * Extract bullet points from a markdown section by heading text.
+ * Handles nested sub-headings (###) within the section — bullets under
+ * sub-headings are included in the parent section's results.
+ */
+function extractSection(content: string, sectionName: string): string[] | null {
+  const lines = content.split("\n");
+  const bullets: string[] = [];
+  let inSection = false;
+  let sectionLevel = 0;
+
+  for (const line of lines) {
+    const headingMatch = line.match(/^(#{1,4})\s/);
+
+    if (headingMatch && line.toLowerCase().includes(sectionName.toLowerCase())) {
+      inSection = true;
+      sectionLevel = headingMatch[1].length;
+      continue;
+    }
+
+    if (inSection && headingMatch) {
+      const currentLevel = headingMatch[1].length;
+      // Stop if we hit a heading at the same level or higher (smaller number)
+      if (currentLevel <= sectionLevel) {
+        break;
+      }
+      // Sub-headings within the section: keep going, collect bullets underneath
+      continue;
+    }
+
+    if (inSection && /^[-*]\s/.test(line.trim())) {
+      const bullet = line.trim().replace(/^[-*]\s+/, "").trim();
+      if (bullet.length > 0) {
+        bullets.push(bullet);
+      }
+    }
+  }
+
+  return bullets.length > 0 ? bullets : null;
+}
+
+/**
+ * Extract raw text content of a section (for deliverable templates with code blocks).
+ */
+function extractRawSection(content: string, sectionName: string): string | null {
+  const lines = content.split("\n");
+  const sectionLines: string[] = [];
+  let inSection = false;
+  let sectionLevel = 0;
+
+  for (const line of lines) {
+    const headingMatch = line.match(/^(#{1,4})\s/);
+
+    if (headingMatch && line.toLowerCase().includes(sectionName.toLowerCase())) {
+      inSection = true;
+      sectionLevel = headingMatch[1].length;
+      continue;
+    }
+
+    if (inSection && headingMatch) {
+      const currentLevel = headingMatch[1].length;
+      if (currentLevel <= sectionLevel) {
+        break;
+      }
+    }
+
+    if (inSection) {
+      sectionLines.push(line);
+    }
+  }
+
+  const text = sectionLines.join("\n").trim();
+  return text.length > 0 ? text : null;
+}
+
+/**
+ * Extract metrics from one or more agent files (accepts a glob pattern or single path).
+ */
+export function extractMetrics(pattern: string): AgentMetrics[] {
+  const files = glob.sync(pattern);
+  return files.map(parseAgentFile);
+}
+
+// CLI entrypoint
+if (require.main === module) {
+  const pattern = process.argv[2] || path.resolve(__dirname, "../../*/*.md");
+  const results = extractMetrics(pattern);
+  console.log(JSON.stringify(results, null, 2));
+  console.error(`Extracted metrics for ${results.length} agents`);
+}

--- a/evals/scripts/extract-metrics.ts
+++ b/evals/scripts/extract-metrics.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import path from "path";
 import matter from "gray-matter";
-import { glob } from "glob";
+import { globSync } from "glob";
 
 export interface AgentMetrics {
   name: string;
@@ -47,7 +47,8 @@ function extractSection(content: string, sectionName: string): string[] | null {
   for (const line of lines) {
     const headingMatch = line.match(/^(#{1,4})\s/);
 
-    if (headingMatch && line.toLowerCase().includes(sectionName.toLowerCase())) {
+    const headingText = line.replace(/^#{1,4}\s+/, "").replace(/[\p{Emoji_Presentation}\p{Emoji}\uFE0F]/gu, "").trim().toLowerCase();
+    if (headingMatch && headingText.includes(sectionName.toLowerCase())) {
       inSection = true;
       sectionLevel = headingMatch[1].length;
       continue;
@@ -86,7 +87,8 @@ function extractRawSection(content: string, sectionName: string): string | null 
   for (const line of lines) {
     const headingMatch = line.match(/^(#{1,4})\s/);
 
-    if (headingMatch && line.toLowerCase().includes(sectionName.toLowerCase())) {
+    const headingText = line.replace(/^#{1,4}\s+/, "").replace(/[\p{Emoji_Presentation}\p{Emoji}\uFE0F]/gu, "").trim().toLowerCase();
+    if (headingMatch && headingText.includes(sectionName.toLowerCase())) {
       inSection = true;
       sectionLevel = headingMatch[1].length;
       continue;
@@ -112,7 +114,7 @@ function extractRawSection(content: string, sectionName: string): string | null 
  * Extract metrics from one or more agent files (accepts a glob pattern or single path).
  */
 export function extractMetrics(pattern: string): AgentMetrics[] {
-  const files = glob.sync(pattern);
+  const files = globSync(pattern);
   return files.map(parseAgentFile);
 }
 

--- a/evals/tasks/academic.yaml
+++ b/evals/tasks/academic.yaml
@@ -1,0 +1,29 @@
+# Test tasks for academic category agents.
+# 2 tasks: 1 straightforward, 1 requiring the agent's workflow.
+
+- id: acad-period-check
+  description: "Verify historical accuracy of a passage (straightforward)"
+  prompt: |
+    I'm writing a novel set in 1347 Florence, just before the Black Death arrives.
+    Here's a passage I need you to check for historical accuracy:
+
+    "Marco adjusted his cotton shirt and leather boots as he walked through the
+    cobblestone streets to the bank. He pulled out a few paper bills to pay for
+    a loaf of white bread and a cup of coffee at the market stall. The church
+    bells rang noon as horse-drawn carriages rattled past."
+
+    Please identify any anachronisms and suggest corrections.
+
+- id: acad-material-culture
+  description: "Reconstruct daily life from material evidence (workflow-dependent)"
+  prompt: |
+    I'm developing a historical strategy game set during the height of the Mali Empire
+    under Mansa Musa (circa 1312-1337). I need to create an authentic representation
+    of daily life in the capital city of Niani.
+
+    What would a typical market day look like? I need details about:
+    trade goods, currency, social interactions, food, clothing, architecture,
+    and the sounds and smells a visitor would experience.
+
+    Please ground everything in historical evidence and note where you're
+    extrapolating vs. working from documented sources.

--- a/evals/tasks/design.yaml
+++ b/evals/tasks/design.yaml
@@ -1,0 +1,23 @@
+# Test tasks for design category agents.
+# 2 tasks: 1 straightforward, 1 requiring the agent's workflow.
+
+- id: des-landing-page
+  description: "Create CSS foundation for a landing page (straightforward)"
+  prompt: |
+    I'm building a SaaS landing page for a project management tool called "TaskFlow".
+    The brand colors are: primary #2563EB (blue), secondary #7C3AED (purple), accent #F59E0B (amber).
+    The page needs: hero section, features grid (6 features), pricing table (3 tiers), and footer.
+    Please create the CSS design system foundation and layout structure.
+
+- id: des-responsive-audit
+  description: "Audit and fix responsive behavior (workflow-dependent)"
+  prompt: |
+    Our dashboard application has serious responsive issues. On mobile:
+    - The sidebar overlaps the main content area
+    - Data tables overflow horizontally with no scroll
+    - Modal dialogs extend beyond the viewport
+    - The navigation hamburger menu doesn't close after selecting an item
+
+    We're using vanilla CSS with some CSS Grid and Flexbox.
+    Can you analyze these issues and provide a responsive architecture
+    that prevents these problems systematically?

--- a/evals/tasks/engineering.yaml
+++ b/evals/tasks/engineering.yaml
@@ -1,0 +1,21 @@
+# Test tasks for engineering category agents.
+# 2 tasks: 1 straightforward, 1 requiring the agent's workflow.
+
+- id: eng-rest-endpoint
+  description: "Design a REST API endpoint (straightforward)"
+  prompt: |
+    I need to add a user registration endpoint to our Node.js Express API.
+    It should accept email, password, and display name.
+    We use PostgreSQL and need input validation.
+    Please design the endpoint including the database schema, API route, and validation.
+
+- id: eng-scale-review
+  description: "Review architecture for scaling issues (workflow-dependent)"
+  prompt: |
+    We have a monolithic e-commerce application that's hitting performance limits.
+    Current stack: Node.js, PostgreSQL, Redis for sessions, deployed on a single EC2 instance.
+    We're getting 500 requests/second at peak and response times are spiking to 2 seconds.
+    Users report slow checkout and search is nearly unusable during sales events.
+
+    Can you analyze the architecture and recommend a scaling strategy?
+    We have a 3-month timeline and a small team of 4 developers.

--- a/evals/tsconfig.json
+++ b/evals/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "resolveJsonModule": true,
+    "declaration": false
+  },
+  "include": ["scripts/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Adds a [promptfoo](https://www.promptfoo.dev/)-based evaluation harness in `evals/` that measures specialist agent quality across 5 criteria using LLM-as-judge scoring. This is the first step toward automated quality assurance for the agent prompt collection.

- Proof-of-concept evaluates 3 agents (backend-architect, ux-architect, historian) against 6 tasks
- Includes `extract-metrics.ts` script to parse agent success metrics from markdown files
- 5 unit tests for the extraction script, all passing
- First run: **5/6 passed (83%)** — the UX Architect failed on one task, showing the harness discriminates rather than rubber-stamping

## Scoring Criteria

| Criterion | What It Measures |
|---|---|
| Task Completion | Did the agent produce the requested deliverable? |
| Instruction Adherence | Did it follow its own defined workflow/format? |
| Identity Consistency | Did it stay in character? |
| Deliverable Quality | Expert-level, actionable output? |
| Safety | No harmful or biased content? |

Each scored 1-5 by LLM-as-judge. Pass threshold: average >= 3.5.

## How to run

```bash
cd evals
npm install
export ANTHROPIC_API_KEY=your-key
npx promptfoo eval
npx promptfoo view  # interactive results viewer
```

## Cost

~$0.05 per run at Haiku pricing (166K tokens). Full 184-agent suite would estimate ~$1.50/run.

## What's next

This is M1 of a 3-milestone plan:
- **M1 (this PR):** Eval harness with 3 proof-of-concept agents
- **M2:** Benchmark dataset covering all 184 agents with baseline scores
- **M3:** CI quality gate — PR score gating + nightly trending

## Design

The eval harness is fully isolated in `evals/` with its own `package.json` — it doesn't touch any existing agent files or require changes to the contribution workflow. It's opt-in tooling for measuring and improving prompt quality.

## Test plan

- [x] `npx vitest run` — 5/5 extract-metrics tests pass
- [x] `npx promptfoo eval` — 5/6 tests pass, 1 meaningful failure
- [x] `npx promptfoo view` — interactive results browser works