### PR TITLE
fix: add missing divisions to lint script and CI workflow

### DIFF
--- a/.github/workflows/lint-agents.yml
+++ b/.github/workflows/lint-agents.yml
@@ -3,6 +3,7 @@ name: Lint Agent Files
 on:
   pull_request:
     paths:
+      - 'academic/**'
       - 'design/**'
       - 'engineering/**'
       - 'game-development/**'
@@ -11,6 +12,7 @@ on:
       - 'sales/**'
       - 'product/**'
       - 'project-management/**'
+      - 'strategy/**'
       - 'testing/**'
       - 'support/**'
       - 'spatial-computing/**'
@@ -29,8 +31,8 @@ jobs:
         id: changed
         run: |
           FILES=$(git diff --name-only --diff-filter=ACMR origin/${{ github.base_ref }}...HEAD -- \
-            'design/**/*.md' 'engineering/**/*.md' 'game-development/**/*.md' 'marketing/**/*.md' 'paid-media/**/*.md' 'sales/**/*.md' 'product/**/*.md' \
-            'project-management/**/*.md' 'testing/**/*.md' 'support/**/*.md' \
+            'academic/**/*.md' 'design/**/*.md' 'engineering/**/*.md' 'game-development/**/*.md' 'marketing/**/*.md' 'paid-media/**/*.md' 'sales/**/*.md' 'product/**/*.md' \
+            'project-management/**/*.md' 'strategy/**/*.md' 'testing/**/*.md' 'support/**/*.md' \
             'spatial-computing/**/*.md' 'specialized/**/*.md')
           {
             echo "files<<ENDOFLIST"

--- a/scripts/lint-agents.sh
+++ b/scripts/lint-agents.sh
@@ -11,6 +11,7 @@
 set -euo pipefail
 
 AGENT_DIRS=(
+  academic
   design
   engineering
   game-development
@@ -18,10 +19,11 @@ AGENT_DIRS=(
   paid-media
   product
   project-management
-  testing
-  support
+  sales
   spatial-computing
   specialized
+  support
+  testing
 )
 
 REQUIRED_FRONTMATTER=("name" "description" "color")


### PR DESCRIPTION
## What

Adds missing division directories to `lint-agents.sh` and `.github/workflows/lint-agents.yml` so all agent files are linted and CI-triggered.

Fixes #242

## Changes

| File | What changed |
|------|-------------|
| `scripts/lint-agents.sh` | Added `academic/` and `sales/` to `AGENT_DIRS` |
| `.github/workflows/lint-agents.yml` | Added `academic/` and `strategy/` to `paths` trigger and `git diff` filter |

**Note:** `strategy/` is intentionally excluded from `lint-agents.sh` because it contains playbooks and docs (no frontmatter), not agent `.md` files. It is included in CI paths trigger so workflow changes are still detected.

## Before / After

```bash
# Before: 142 files scanned, academic/sales agents skipped
# After:  162 files scanned, 0 errors, 65 warnings — PASSED
```

## Relation to PR #333

PR #333 partially addresses this by adding `academic/` to CI. This PR completes the fix by also adding `sales/` to lint and `strategy/` to CI.