### PR TITLE
Add Codex tool support to convert/install workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ NOTES.md
 # The scripts/ and integrations/*/README.md files ARE committed; only generated
 # agent/skill files are excluded.
 integrations/antigravity/agency-*/
+integrations/codex/agency-*/
 integrations/gemini-cli/skills/
 integrations/gemini-cli/gemini-extension.json
 integrations/opencode/agents/
@@ -78,3 +79,4 @@ integrations/qwen/agents/
 integrations/kimi/*/
 !integrations/openclaw/README.md
 !integrations/kimi/README.md
+!integrations/codex/README.md

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Each agent file contains:
 
 Browse the agents below and copy/adapt the ones you need!
 
-### Option 3: Use with Other Tools (Cursor, Aider, Windsurf, Gemini CLI, OpenCode, Kimi Code)
+### Option 3: Use with Other Tools (Codex, Cursor, Aider, Windsurf, Gemini CLI, OpenCode, Kimi Code)
 
 ```bash
 # Step 1 -- generate integration files for all supported tools
@@ -59,6 +59,7 @@ Browse the agents below and copy/adapt the ones you need!
 ./scripts/install.sh --tool aider
 ./scripts/install.sh --tool windsurf
 ./scripts/install.sh --tool kimi
+./scripts/install.sh --tool codex
 ```
 
 See the [Multi-Tool Integrations](#-multi-tool-integrations) section below for full details.
@@ -514,6 +515,7 @@ The Agency works natively with Claude Code, and ships conversion + install scrip
 - **[Claude Code](https://claude.ai/code)** — native `.md` agents, no conversion needed → `~/.claude/agents/`
 - **[GitHub Copilot](https://github.com/copilot)** — native `.md` agents, no conversion needed → `~/.github/agents/` + `~/.copilot/agents/`
 - **[Antigravity](https://github.com/google-gemini/antigravity)** — `SKILL.md` per agent → `~/.gemini/antigravity/skills/`
+- **Codex** — `SKILL.md` per agent → `~/.codex/skills/`
 - **[Gemini CLI](https://github.com/google-gemini/gemini-cli)** — extension + `SKILL.md` files → `~/.gemini/extensions/agency-agents/`
 - **[OpenCode](https://opencode.ai)** — `.md` agent files → `.opencode/agents/`
 - **[Cursor](https://cursor.sh)** — `.mdc` rule files → `.cursor/rules/`
@@ -551,16 +553,17 @@ The installer scans your system for installed tools, shows a checkbox UI, and le
   [x]  1)  [*]  Claude Code     (claude.ai/code)
   [x]  2)  [*]  Copilot         (~/.github + ~/.copilot)
   [x]  3)  [*]  Antigravity     (~/.gemini/antigravity)
-  [ ]  4)  [ ]  Gemini CLI      (gemini extension)
-  [ ]  5)  [ ]  OpenCode        (opencode.ai)
-  [ ]  6)  [ ]  OpenClaw        (~/.openclaw)
-  [x]  7)  [*]  Cursor          (.cursor/rules)
-  [ ]  8)  [ ]  Aider           (CONVENTIONS.md)
-  [ ]  9)  [ ]  Windsurf        (.windsurfrules)
-  [ ] 10)  [ ]  Qwen Code       (~/.qwen/agents)
-  [ ] 11)  [ ]  Kimi Code       (~/.config/kimi/agents)
+  [x]  4)  [*]  Codex           (~/.codex/skills)
+  [ ]  5)  [ ]  Gemini CLI      (gemini extension)
+  [ ]  6)  [ ]  OpenCode        (opencode.ai)
+  [ ]  7)  [ ]  OpenClaw        (~/.openclaw)
+  [x]  8)  [*]  Cursor          (.cursor/rules)
+  [ ]  9)  [ ]  Aider           (CONVENTIONS.md)
+  [ ] 10)  [ ]  Windsurf        (.windsurfrules)
+  [ ] 11)  [ ]  Qwen Code       (~/.qwen/agents)
+  [ ] 12)  [ ]  Kimi Code       (~/.config/kimi/agents)
 
-  [1-11] toggle   [a] all   [n] none   [d] detected
+  [1-12] toggle   [a] all   [n] none   [d] detected
   [Enter] install   [q] quit
 ```
 
@@ -570,6 +573,7 @@ The installer scans your system for installed tools, shows a checkbox UI, and le
 ./scripts/install.sh --tool opencode
 ./scripts/install.sh --tool openclaw
 ./scripts/install.sh --tool antigravity
+./scripts/install.sh --tool codex
 ```
 
 **Non-interactive (CI/scripts):**
@@ -640,6 +644,25 @@ Activate in Gemini with Antigravity:
 ```
 
 See [integrations/antigravity/README.md](integrations/antigravity/README.md) for details.
+</details>
+
+<details>
+<summary><strong>Codex</strong></summary>
+
+Each agent becomes a skill in `~/.codex/skills/agency-<slug>/`.
+
+```bash
+./scripts/convert.sh --tool codex
+./scripts/install.sh --tool codex
+```
+
+Then invoke by skill name in Codex:
+```
+Use the agency-frontend-developer skill to review this React component.
+```
+
+See [integrations/codex/README.md](integrations/codex/README.md) for details.
+
 </details>
 
 <details>
@@ -814,7 +837,7 @@ When you add new agents or edit existing ones, regenerate all integration files:
 
 - [ ] Interactive agent selector web tool
 - [x] Multi-agent workflow examples -- see [examples/](examples/)
-- [x] Multi-tool integration scripts (Claude Code, GitHub Copilot, Antigravity, Gemini CLI, OpenCode, OpenClaw, Cursor, Aider, Windsurf, Qwen Code, Kimi Code)
+- [x] Multi-tool integration scripts (Claude Code, GitHub Copilot, Antigravity, Codex, Gemini CLI, OpenCode, OpenClaw, Cursor, Aider, Windsurf, Qwen Code, Kimi Code)
 - [ ] Video tutorials on agent design
 - [ ] Community agent marketplace
 - [ ] Agent "personality quiz" for project matching

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -8,6 +8,7 @@ supported agentic coding tools.
 - **[Claude Code](#claude-code)** — `.md` agents, use the repo directly
 - **[GitHub Copilot](#github-copilot)** — `.md` agents, use the repo directly
 - **[Antigravity](#antigravity)** — `SKILL.md` per agent in `antigravity/`
+- **[Codex](#codex)** — `SKILL.md` per agent in `codex/`
 - **[Gemini CLI](#gemini-cli)** — extension + `SKILL.md` files in `gemini-cli/`
 - **[OpenCode](#opencode)** — `.md` agent files in `opencode/`
 - **[OpenClaw](#openclaw)** — `SOUL.md` + `AGENTS.md` + `IDENTITY.md` workspaces
@@ -24,6 +25,7 @@ supported agentic coding tools.
 
 # Install a specific home-scoped tool
 ./scripts/install.sh --tool antigravity
+./scripts/install.sh --tool codex
 ./scripts/install.sh --tool copilot
 ./scripts/install.sh --tool openclaw
 ./scripts/install.sh --tool claude-code
@@ -85,6 +87,20 @@ a separate skill prefixed with `agency-` to avoid naming conflicts.
 ```
 
 See [antigravity/README.md](antigravity/README.md) for details.
+
+---
+
+## Codex
+
+Skills are installed to `~/.codex/skills/`. Each agent becomes
+a separate skill prefixed with `agency-` to avoid naming conflicts.
+
+```bash
+./scripts/convert.sh --tool codex
+./scripts/install.sh --tool codex
+```
+
+See [codex/README.md](codex/README.md) for details.
 
 ---
 

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -1,0 +1,23 @@
+# Codex Integration
+
+Agency agents are converted into Codex skills (`SKILL.md`) and installed to:
+
+`~/.codex/skills/agency-<slug>/SKILL.md`
+
+## Install
+
+```bash
+# Generate Codex skill files (required on fresh clone)
+./scripts/convert.sh --tool codex
+
+# Install to ~/.codex/skills/
+./scripts/install.sh --tool codex
+```
+
+## Usage
+
+In Codex, call the installed skill by name:
+
+```text
+Use the agency-frontend-developer skill to review this component.
+```

--- a/scripts/convert.sh
+++ b/scripts/convert.sh
@@ -11,6 +11,7 @@
 #
 # Tools:
 #   antigravity  — Antigravity skill files (~/.gemini/antigravity/skills/)
+#   codex        — Codex skill files (~/.codex/skills/)
 #   gemini-cli   — Gemini CLI extension (skills/ + gemini-extension.json)
 #   opencode     — OpenCode agent files (.opencode/agent/*.md)
 #   cursor       — Cursor rule files (.cursor/rules/*.mdc)
@@ -120,6 +121,32 @@ convert_antigravity() {
   mkdir -p "$outdir"
 
   # Antigravity SKILL.md format mirrors community skills in ~/.gemini/antigravity/skills/
+  cat > "$outfile" <<HEREDOC
+---
+name: ${slug}
+description: ${description}
+risk: low
+source: community
+date_added: '${TODAY}'
+---
+${body}
+HEREDOC
+}
+
+convert_codex() {
+  local file="$1"
+  local name description slug outdir outfile body
+
+  name="$(get_field "name" "$file")"
+  description="$(get_field "description" "$file")"
+  slug="agency-$(slugify "$name")"
+  body="$(get_body "$file")"
+
+  outdir="$OUT_DIR/codex/$slug"
+  outfile="$outdir/SKILL.md"
+  mkdir -p "$outdir"
+
+  # Codex skill format mirrors community skills in ~/.codex/skills/
   cat > "$outfile" <<HEREDOC
 ---
 name: ${slug}
@@ -499,6 +526,7 @@ run_conversions() {
 
       case "$tool" in
         antigravity) convert_antigravity "$file" ;;
+        codex)       convert_codex       "$file" ;;
         gemini-cli)  convert_gemini_cli  "$file" ;;
         opencode)    convert_opencode    "$file" ;;
         cursor)      convert_cursor      "$file" ;;
@@ -535,7 +563,7 @@ main() {
     esac
   done
 
-  local valid_tools=("antigravity" "gemini-cli" "opencode" "cursor" "aider" "windsurf" "openclaw" "qwen" "kimi" "all")
+  local valid_tools=("antigravity" "codex" "gemini-cli" "opencode" "cursor" "aider" "windsurf" "openclaw" "qwen" "kimi" "all")
   local valid=false
   for t in "${valid_tools[@]}"; do [[ "$t" == "$tool" ]] && valid=true && break; done
   if ! $valid; then
@@ -554,7 +582,7 @@ main() {
 
   local tools_to_run=()
   if [[ "$tool" == "all" ]]; then
-    tools_to_run=("antigravity" "gemini-cli" "opencode" "cursor" "aider" "windsurf" "openclaw" "qwen" "kimi")
+    tools_to_run=("antigravity" "codex" "gemini-cli" "opencode" "cursor" "aider" "windsurf" "openclaw" "qwen" "kimi")
   else
     tools_to_run=("$tool")
   fi
@@ -565,7 +593,7 @@ main() {
 
   if $use_parallel && [[ "$tool" == "all" ]]; then
     # Tools that write to separate dirs can run in parallel; buffer output so each tool's output stays together
-    local parallel_tools=(antigravity gemini-cli opencode cursor openclaw qwen)
+    local parallel_tools=(antigravity codex gemini-cli opencode cursor openclaw qwen kimi)
     local parallel_out_dir
     parallel_out_dir="$(mktemp -d)"
     info "Converting: ${#parallel_tools[@]}/${n_tools} tools in parallel (output buffered per tool)..."
@@ -577,7 +605,7 @@ main() {
       [[ -f "$parallel_out_dir/$t" ]] && cat "$parallel_out_dir/$t"
     done
     rm -rf "$parallel_out_dir"
-    local idx=7
+    local idx=$(( ${#parallel_tools[@]} + 1 ))
     for t in aider windsurf; do
       progress_bar "$idx" "$n_tools"
       printf "\n"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -13,6 +13,7 @@
 #   claude-code  -- Copy agents to ~/.claude/agents/
 #   copilot      -- Copy agents to ~/.github/agents/ and ~/.copilot/agents/
 #   antigravity  -- Copy skills to ~/.gemini/antigravity/skills/
+#   codex        -- Copy skills to ~/.codex/skills/
 #   gemini-cli   -- Install extension to ~/.gemini/extensions/agency-agents/
 #   opencode     -- Copy agents to .opencode/agent/ in current directory
 #   cursor       -- Copy rules to .cursor/rules/ in current directory
@@ -101,7 +102,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 INTEGRATIONS="$REPO_ROOT/integrations"
 
-ALL_TOOLS=(claude-code copilot antigravity gemini-cli opencode openclaw cursor aider windsurf qwen kimi)
+ALL_TOOLS=(claude-code copilot antigravity codex gemini-cli opencode openclaw cursor aider windsurf qwen kimi)
 
 # ---------------------------------------------------------------------------
 # Usage
@@ -135,6 +136,7 @@ check_integrations() {
 detect_claude_code() { [[ -d "${HOME}/.claude" ]]; }
 detect_copilot()      { command -v code >/dev/null 2>&1 || [[ -d "${HOME}/.github" || -d "${HOME}/.copilot" ]]; }
 detect_antigravity()  { [[ -d "${HOME}/.gemini/antigravity/skills" ]]; }
+detect_codex()        { command -v codex >/dev/null 2>&1 || [[ -d "${HOME}/.codex" ]]; }
 detect_gemini_cli()   { command -v gemini >/dev/null 2>&1 || [[ -d "${HOME}/.gemini" ]]; }
 detect_cursor()       { command -v cursor >/dev/null 2>&1 || [[ -d "${HOME}/.cursor" ]]; }
 detect_opencode()     { command -v opencode >/dev/null 2>&1 || [[ -d "${HOME}/.config/opencode" ]]; }
@@ -149,6 +151,7 @@ is_detected() {
     claude-code) detect_claude_code ;;
     copilot)     detect_copilot     ;;
     antigravity) detect_antigravity ;;
+    codex)       detect_codex       ;;
     gemini-cli)  detect_gemini_cli  ;;
     opencode)    detect_opencode    ;;
     openclaw)    detect_openclaw    ;;
@@ -167,6 +170,7 @@ tool_label() {
     claude-code) printf "%-14s  %s" "Claude Code"  "(claude.ai/code)"        ;;
     copilot)     printf "%-14s  %s" "Copilot"      "(~/.github + ~/.copilot)" ;;
     antigravity) printf "%-14s  %s" "Antigravity"  "(~/.gemini/antigravity)" ;;
+    codex)       printf "%-14s  %s" "Codex"        "(~/.codex/skills)"       ;;
     gemini-cli)  printf "%-14s  %s" "Gemini CLI"   "(gemini extension)"      ;;
     opencode)    printf "%-14s  %s" "OpenCode"     "(opencode.ai)"           ;;
     openclaw)    printf "%-14s  %s" "OpenClaw"     "(~/.openclaw)"           ;;
@@ -351,6 +355,25 @@ install_antigravity() {
   ok "Antigravity: $count skills -> $dest"
 }
 
+install_codex() {
+  local src="$INTEGRATIONS/codex"
+  local dest="${HOME}/.codex/skills"
+  local count=0
+  [[ -d "$src" ]] || { err "integrations/codex missing. Run ./scripts/convert.sh --tool codex first."; return 1; }
+  local first_skill
+  first_skill="$(find "$src" -mindepth 2 -maxdepth 2 -type f -name "SKILL.md" -print -quit)"
+  [[ -n "$first_skill" ]] || { err "No Codex skills found in integrations/codex. Run ./scripts/convert.sh --tool codex first."; return 1; }
+  mkdir -p "$dest"
+  local d
+  while IFS= read -r -d '' d; do
+    local name; name="$(basename "$d")"
+    mkdir -p "$dest/$name"
+    cp "$d/SKILL.md" "$dest/$name/SKILL.md"
+    (( count++ )) || true
+  done < <(find "$src" -mindepth 1 -maxdepth 1 -type d -print0)
+  ok "Codex: $count skills -> $dest"
+}
+
 install_gemini_cli() {
   local src="$INTEGRATIONS/gemini-cli"
   local dest="${HOME}/.gemini/extensions/agency-agents"
@@ -498,6 +521,7 @@ install_tool() {
     claude-code) install_claude_code ;;
     copilot)     install_copilot     ;;
     antigravity) install_antigravity ;;
+    codex)       install_codex       ;;
     gemini-cli)  install_gemini_cli  ;;
     opencode)    install_opencode    ;;
     openclaw)    install_openclaw    ;;


### PR DESCRIPTION
## What does this PR do?

Adds first-class Codex integration to the existing convert/install workflow without changing the current installation model.

### Included changes
- Add `--tool codex` to `scripts/convert.sh` and generate Codex skills at `integrations/codex/agency-<slug>/SKILL.md`
- Add `--tool codex` to `scripts/install.sh` and install to `~/.codex/skills/`
- Add Codex detection and installer menu label
- Add guardrails for missing generated Codex skills
- Update docs (`README.md`, `integrations/README.md`) to include Codex in the same flow as other tools
- Add `integrations/codex/README.md`
- Update `.gitignore` to ignore generated Codex artifacts while keeping docs tracked

### Validation
- `bash -n scripts/convert.sh`
- `bash -n scripts/install.sh`
- `./scripts/convert.sh --tool codex`
- `./scripts/install.sh --tool codex --no-interactive`

## Agent Information (if adding/modifying an agent)

- **Agent Name**: N/A (no agent added/modified)
- **Category**: N/A
- **Specialty**: N/A

## Checklist

- [x] Follows the agent template structure from CONTRIBUTING.md (N/A, no agent file change)
- [x] Includes YAML frontmatter with `name`, `description`, `color` (N/A, no agent file change)
- [x] Has concrete code/template examples (for new agents) (N/A)
- [x] Tested in real scenarios (Applied to integration scripts/docs workflow)
- [x] Proofread and formatted correctly
