### PR TITLE
docs: replace Quick Start Option 3 with agent-add cross-host install

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,23 @@ Browse the agents below and copy/adapt the ones you need!
 
 See the [Multi-Tool Integrations](#-multi-tool-integrations) section below for full details.
 
+### Option 4: Quick install with agent-add (18+ hosts supported)
+
+[agent-add](https://github.com/pea3nut/agent-add) auto-detects your AI host and installs any agent from this repo as a sub-agent — no clone, no script.
+
+```bash
+# Install a specific agent (replace <category>/<agent-file>.md with any path from the roster below)
+npx -y agent-add --sub-agent 'https://raw.githubusercontent.com/msitarzewski/agency-agents/main/<category>/<agent-file>.md'
+```
+
+Example — install the Backend Architect:
+
+```bash
+npx -y agent-add --sub-agent 'https://raw.githubusercontent.com/msitarzewski/agency-agents/main/engineering/engineering-backend-architect.md'
+```
+
+> Requires [Node.js](https://nodejs.org/) 18+. Supports Cursor, Claude Code, Claude Desktop, Windsurf, GitHub Copilot, Gemini, and [more](https://github.com/pea3nut/agent-add).
+
 ---
 
 ## 🎨 The Agency Roster


### PR DESCRIPTION
## Summary

Replaces **Option 3: Use with Other Tools** in `## ⚡ Quick Start` with a one-command [agent-add](https://github.com/pea3nut/agent-get) install, so users on Cursor / Windsurf / Claude Desktop / GitHub Copilot / Gemini / Roo Code / OpenCode / etc. (18 hosts total) can install any single agent without cloning the repo or running `scripts/convert.sh` + `scripts/install.sh`:

```bash
npx -y agent-add --sub-agent 'https://raw.githubusercontent.com/msitarzewski/agency-agents/main/engineering/engineering-backend-architect.md'
```

Options 1 (Claude Code) and 2 (Reference) are unchanged. The legacy script-based flow is still linked from the new Option 3 pointing at the existing Multi-Tool Integrations section below. Docs-only change.