### PR TITLE
docs: sync OpenClaw install docs across integrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,4 +73,5 @@ integrations/opencode/agents/
 integrations/cursor/rules/
 integrations/aider/CONVENTIONS.md
 integrations/windsurf/.windsurfrules
-integrations/openclaw/
+integrations/openclaw/*
+!integrations/openclaw/README.md

--- a/README.md
+++ b/README.md
@@ -27,10 +27,13 @@ Born from a Reddit thread and months of iteration, **The Agency** is a growing c
 ### Option 1: Use with Claude Code (Recommended)
 
 ```bash
-# Copy agents to your Claude Code directory
-cp -r agency-agents/* ~/.claude/agents/
+# Install all agents to your Claude Code directory
+./scripts/install.sh --tool claude-code
 
-# Now activate any agent in your Claude Code sessions:
+# Or manually copy a category if you only want one division
+cp engineering/*.md ~/.claude/agents/
+
+# Then activate any agent in your Claude Code sessions:
 # "Hey Claude, activate Frontend Developer mode and help me build a React component"
 ```
 
@@ -44,7 +47,7 @@ Each agent file contains:
 
 Browse the agents below and copy/adapt the ones you need!
 
-### Option 3: Use with Other Tools (Cursor, Aider, Windsurf, Gemini CLI, OpenCode)
+### Option 3: Use with Other Tools (GitHub Copilot, Antigravity, Gemini CLI, OpenCode, OpenClaw, Cursor, Aider, Windsurf)
 
 ```bash
 # Step 1 -- generate integration files for all supported tools
@@ -54,8 +57,12 @@ Browse the agents below and copy/adapt the ones you need!
 ./scripts/install.sh
 
 # Or target a specific tool directly
-./scripts/install.sh --tool cursor
+./scripts/install.sh --tool antigravity
+./scripts/install.sh --tool gemini-cli
+./scripts/install.sh --tool opencode
 ./scripts/install.sh --tool copilot
+./scripts/install.sh --tool openclaw
+./scripts/install.sh --tool cursor
 ./scripts/install.sh --tool aider
 ./scripts/install.sh --tool windsurf
 ```
@@ -418,14 +425,14 @@ The Agency works natively with Claude Code, and ships conversion + install scrip
 ### Supported Tools
 
 - **[Claude Code](https://claude.ai/code)** — native `.md` agents, no conversion needed → `~/.claude/agents/`
-- **[Github Copilot](https://github.com/copilot)** — native `.md` agents, no conversion needed → `~/.github/agents/`
+- **[GitHub Copilot](https://github.com/copilot)** — native `.md` agents, no conversion needed → `~/.github/agents/`
 - **[Antigravity](https://github.com/google-gemini/antigravity)** — `SKILL.md` per agent → `~/.gemini/antigravity/skills/`
 - **[Gemini CLI](https://github.com/google-gemini/gemini-cli)** — extension + `SKILL.md` files → `~/.gemini/extensions/agency-agents/`
 - **[OpenCode](https://opencode.ai)** — `.md` agent files → `.opencode/agents/`
 - **[Cursor](https://cursor.sh)** — `.mdc` rule files → `.cursor/rules/`
 - **[Aider](https://aider.chat)** — single `CONVENTIONS.md` → `./CONVENTIONS.md`
 - **[Windsurf](https://codeium.com/windsurf)** — single `.windsurfrules` → `./.windsurfrules`
-- **[OpenClaw](https://openclaw.com)** — `SOUL.md` + `AGENTS.md` + `IDENTITY.md` per agent
+- **[OpenClaw](https://openclaw.com)** — per-agent workspaces (`SOUL.md` + `AGENTS.md` + `IDENTITY.md`) → `~/.openclaw/agency-agents/`
 
 ---
 
@@ -455,19 +462,26 @@ The installer scans your system for installed tools, shows a checkbox UI, and le
   [x]  3)  [*]  Antigravity     (~/.gemini/antigravity)
   [ ]  4)  [ ]  Gemini CLI      (gemini extension)
   [ ]  5)  [ ]  OpenCode        (opencode.ai)
-  [x]  6)  [*]  Cursor          (.cursor/rules)
-  [ ]  7)  [ ]  Aider           (CONVENTIONS.md)
-  [ ]  8)  [ ]  Windsurf        (.windsurfrules)
+  [ ]  6)  [ ]  OpenClaw        (~/.openclaw/agency-agents)
+  [x]  7)  [*]  Cursor          (.cursor/rules)
+  [ ]  8)  [ ]  Aider           (CONVENTIONS.md)
+  [ ]  9)  [ ]  Windsurf        (.windsurfrules)
 
-  [1-8] toggle   [a] all   [n] none   [d] detected
+  [1-9] toggle   [a] all   [n] none   [d] detected
   [Enter] install   [q] quit
 ```
 
 **Or install a specific tool directly:**
 ```bash
+./scripts/install.sh --tool claude-code
+./scripts/install.sh --tool copilot
+./scripts/install.sh --tool antigravity
+./scripts/install.sh --tool gemini-cli
 ./scripts/install.sh --tool cursor
 ./scripts/install.sh --tool opencode
-./scripts/install.sh --tool antigravity
+./scripts/install.sh --tool openclaw
+./scripts/install.sh --tool aider
+./scripts/install.sh --tool windsurf
 ```
 
 **Non-interactive (CI/scripts):**
@@ -497,7 +511,7 @@ See [integrations/claude-code/README.md](integrations/claude-code/README.md) for
 </details>
 
 <details>
-<summary><strong>Github Copilot</strong></summary>
+<summary><strong>GitHub Copilot</strong></summary>
 
 Agents are copied directly from the repo into `~/.github/agents/` -- no conversion needed.
 
@@ -505,7 +519,7 @@ Agents are copied directly from the repo into `~/.github/agents/` -- no conversi
 ./scripts/install.sh --tool copilot
 ```
 
-Then activate in Github Copilot:
+Then activate in GitHub Copilot:
 ```
 Use the Frontend Developer agent to review this component.
 ```
@@ -533,7 +547,7 @@ See [integrations/antigravity/README.md](integrations/antigravity/README.md) for
 <details>
 <summary><strong>Gemini CLI</strong></summary>
 
-Installs as a Gemini CLI extension with 80 skills + a manifest.
+Installs as a Gemini CLI extension with generated skills plus a manifest.
 
 ```bash
 ./scripts/install.sh --tool gemini-cli
@@ -564,6 +578,24 @@ Activate in OpenCode:
 ```
 
 See [integrations/opencode/README.md](integrations/opencode/README.md) for details.
+</details>
+
+<details>
+<summary><strong>OpenClaw</strong></summary>
+
+OpenClaw uses generated workspaces containing `SOUL.md`, `AGENTS.md`, and
+`IDENTITY.md` for each agent.
+
+```bash
+./scripts/convert.sh --tool openclaw
+./scripts/install.sh --tool openclaw
+```
+
+If the `openclaw` CLI is available, the installer registers each workspace
+automatically. Run `openclaw gateway restart` after installation so the new
+agents are activated.
+
+See [integrations/openclaw/README.md](integrations/openclaw/README.md) for details.
 </details>
 
 <details>

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -1,14 +1,16 @@
 # 🔌 Integrations
 
-This directory contains The Agency's 61 AI agents converted into formats
-compatible with popular agentic coding tools.
+This directory contains converted integration assets and installation notes for
+the current Agency roster.
 
 ## Supported Tools
 
 - **[Claude Code](#claude-code)** — `.md` agents, use the repo directly
+- **[GitHub Copilot](#github-copilot)** — native `.md` agents, no conversion needed
 - **[Antigravity](#antigravity)** — `SKILL.md` per agent in `antigravity/`
 - **[Gemini CLI](#gemini-cli)** — extension + `SKILL.md` files in `gemini-cli/`
 - **[OpenCode](#opencode)** — `.md` agent files in `opencode/`
+- **[OpenClaw](#openclaw)** — generated workspaces for `~/.openclaw/agency-agents/`
 - **[Cursor](#cursor)** — `.mdc` rule files in `cursor/`
 - **[Aider](#aider)** — `CONVENTIONS.md` in `aider/`
 - **[Windsurf](#windsurf)** — `.windsurfrules` in `windsurf/`
@@ -20,12 +22,15 @@ compatible with popular agentic coding tools.
 ./scripts/install.sh
 
 # Install for a specific tool
+./scripts/install.sh --tool claude-code
+./scripts/install.sh --tool copilot
 ./scripts/install.sh --tool antigravity
 ./scripts/install.sh --tool gemini-cli
+./scripts/install.sh --tool opencode
+./scripts/install.sh --tool openclaw
 ./scripts/install.sh --tool cursor
 ./scripts/install.sh --tool aider
 ./scripts/install.sh --tool windsurf
-./scripts/install.sh --tool claude-code
 ```
 
 ## Regenerating Integration Files
@@ -53,6 +58,19 @@ See [claude-code/README.md](claude-code/README.md) for details.
 
 ---
 
+## GitHub Copilot
+
+The Agency also works natively with GitHub Copilot using the same `.md` + YAML
+frontmatter files used for Claude Code.
+
+```bash
+./scripts/install.sh --tool copilot
+```
+
+See [github-copilot/README.md](github-copilot/README.md) for details.
+
+---
+
 ## Antigravity
 
 Skills are installed to `~/.gemini/antigravity/skills/`. Each agent becomes
@@ -76,6 +94,37 @@ The extension is installed to `~/.gemini/extensions/agency-agents/`.
 ```
 
 See [gemini-cli/README.md](gemini-cli/README.md) for details.
+
+---
+
+## OpenCode
+
+OpenCode agents are generated as `.md` files in `.opencode/agents/`. This is a
+project-scoped install, so run the installer from your project root.
+
+```bash
+cd /your/project && /path/to/agency-agents/scripts/install.sh --tool opencode
+```
+
+See [opencode/README.md](opencode/README.md) for details.
+
+---
+
+## OpenClaw
+
+OpenClaw support is generated on demand and installs agent workspaces into
+`~/.openclaw/agency-agents/`.
+
+```bash
+./scripts/convert.sh --tool openclaw
+./scripts/install.sh --tool openclaw
+```
+
+The installer also registers generated workspaces with OpenClaw when the
+`openclaw` CLI is available. Run `openclaw gateway restart` after installation
+to activate the new agents.
+
+See [openclaw/README.md](openclaw/README.md) for details.
 
 ---
 

--- a/integrations/aider/README.md
+++ b/integrations/aider/README.md
@@ -1,6 +1,6 @@
 # Aider Integration
 
-All 61 Agency agents are consolidated into a single `CONVENTIONS.md` file.
+The full Agency roster is consolidated into a single `CONVENTIONS.md` file.
 Aider reads this file automatically when it's present in your project root.
 
 ## Install

--- a/integrations/antigravity/README.md
+++ b/integrations/antigravity/README.md
@@ -1,6 +1,6 @@
 # Antigravity Integration
 
-Installs all 61 Agency agents as Antigravity skills. Each agent is prefixed
+Installs the full Agency roster as Antigravity skills. Each agent is prefixed
 with `agency-` to avoid conflicts with existing skills.
 
 ## Install

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -28,4 +28,4 @@ Use the Reality Checker agent to verify this feature is production-ready.
 ## Agent Directory
 
 Agents are organized into divisions. See the [main README](../../README.md) for
-the full roster of 61 specialists.
+the full Agency roster.

--- a/integrations/cursor/README.md
+++ b/integrations/cursor/README.md
@@ -1,6 +1,6 @@
 # Cursor Integration
 
-Converts all 61 Agency agents into Cursor `.mdc` rule files. Rules are
+Converts the full Agency roster into Cursor `.mdc` rule files. Rules are
 **project-scoped** — install them from your project root.
 
 ## Install

--- a/integrations/gemini-cli/README.md
+++ b/integrations/gemini-cli/README.md
@@ -1,6 +1,6 @@
 # Gemini CLI Integration
 
-Packages all 61 Agency agents as a Gemini CLI extension. The extension
+Packages the full Agency roster as a Gemini CLI extension. The extension
 installs to `~/.gemini/extensions/agency-agents/`.
 
 ## Install

--- a/integrations/github-copilot/README.md
+++ b/integrations/github-copilot/README.md
@@ -1,12 +1,12 @@
-# Github Copilot Integration
+# GitHub Copilot Integration
 
-The Agency was built for Github Copilot. No conversion needed — agents work
+The Agency works natively with GitHub Copilot. No conversion needed — agents work
 natively with the existing `.md` + YAML frontmatter format.
 
 ## Install
 
 ```bash
-# Copy all agents to your Github Copilot agents directory
+# Copy all agents to your GitHub Copilot agents directory
 ./scripts/install.sh --tool copilot
 
 # Or manually copy a category
@@ -15,7 +15,7 @@ cp engineering/*.md ~/.github/agents/
 
 ## Activate an Agent
 
-In any Github Copilot session, reference an agent by name:
+In any GitHub Copilot session, reference an agent by name:
 
 ```
 Activate Frontend Developer and help me build a React component.
@@ -28,4 +28,4 @@ Use the Reality Checker agent to verify this feature is production-ready.
 ## Agent Directory
 
 Agents are organized into divisions. See the [main README](../../README.md) for
-the full roster of 61 specialists.
+the full Agency roster.

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -1,0 +1,33 @@
+# OpenClaw Integration
+
+OpenClaw support is generated as per-agent workspaces. Each workspace contains
+`SOUL.md`, `AGENTS.md`, and `IDENTITY.md` so persona and operational guidance
+can be loaded separately.
+
+## Generate
+
+```bash
+./scripts/convert.sh --tool openclaw
+```
+
+This writes generated workspaces to `integrations/openclaw/<agent-slug>/`.
+
+## Install
+
+```bash
+./scripts/install.sh --tool openclaw
+```
+
+The installer copies generated workspaces to `~/.openclaw/agency-agents/`.
+If the `openclaw` CLI is available, it also registers each workspace. Run
+`openclaw gateway restart` after installation to activate the new agents.
+
+## Regenerate After Changes
+
+If you add or edit agents, regenerate the OpenClaw workspaces before
+reinstalling:
+
+```bash
+./scripts/convert.sh --tool openclaw
+./scripts/install.sh --tool openclaw
+```

--- a/integrations/windsurf/README.md
+++ b/integrations/windsurf/README.md
@@ -1,6 +1,6 @@
 # Windsurf Integration
 
-All 61 Agency agents are consolidated into a single `.windsurfrules` file.
+The full Agency roster is consolidated into a single `.windsurfrules` file.
 Rules are **project-scoped** — install them from your project root.
 
 ## Install

--- a/scripts/convert.sh
+++ b/scripts/convert.sh
@@ -12,11 +12,11 @@
 # Tools:
 #   antigravity  — Antigravity skill files (~/.gemini/antigravity/skills/)
 #   gemini-cli   — Gemini CLI extension (skills/ + gemini-extension.json)
-#   opencode     — OpenCode agent files (.opencode/agent/*.md)
+#   opencode     — OpenCode agent files (.opencode/agents/*.md)
 #   cursor       — Cursor rule files (.cursor/rules/*.mdc)
 #   aider        — Single CONVENTIONS.md for Aider
 #   windsurf     — Single .windsurfrules for Windsurf
-#   openclaw     — OpenClaw SOUL.md files (openclaw_workspace/<agent>/SOUL.md)
+#   openclaw     — OpenClaw workspaces (integrations/openclaw/<agent>/SOUL.md)
 #   all          — All tools (default)
 #
 # Output is written to integrations/<tool>/ relative to the repo root.
@@ -216,8 +216,8 @@ convert_openclaw() {
   # Split body sections into SOUL.md (persona) vs AGENTS.md (operations)
   # by matching ## header keywords. Unmatched sections go to AGENTS.md.
   #
-  # SOUL keywords: identity, memory (paired with identity), communication,
-  #   style, critical rules, rules you must follow
+  # SOUL keywords: identity, learning & memory, communication, style,
+  #   critical rules, rules you must follow
   # AGENTS keywords: everything else (mission, deliverables, workflow, etc.)
 
   local current_target="agents"  # default bucket
@@ -241,6 +241,7 @@ convert_openclaw() {
       header_lower="$(echo "$line" | tr '[:upper:]' '[:lower:]')"
 
       if [[ "$header_lower" =~ identity ]] ||
+         [[ "$header_lower" =~ learning.*memory ]] ||
          [[ "$header_lower" =~ communication ]] ||
          [[ "$header_lower" =~ style ]] ||
          [[ "$header_lower" =~ critical.rule ]] ||

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -14,7 +14,7 @@
 #   copilot      -- Copy agents to ~/.github/agents/
 #   antigravity  -- Copy skills to ~/.gemini/antigravity/skills/
 #   gemini-cli   -- Install extension to ~/.gemini/extensions/agency-agents/
-#   opencode     -- Copy agents to .opencode/agent/ in current directory
+#   opencode     -- Copy agents to .opencode/agents/ in current directory
 #   cursor       -- Copy rules to .cursor/rules/ in current directory
 #   aider        -- Copy CONVENTIONS.md to current directory
 #   windsurf     -- Copy .windsurfrules to current directory
@@ -137,7 +137,7 @@ tool_label() {
     antigravity) printf "%-14s  %s" "Antigravity"  "(~/.gemini/antigravity)" ;;
     gemini-cli)  printf "%-14s  %s" "Gemini CLI"   "(gemini extension)"      ;;
     opencode)    printf "%-14s  %s" "OpenCode"     "(opencode.ai)"           ;;
-    openclaw)    printf "%-14s  %s" "OpenClaw"     "(~/.openclaw)"           ;;
+    openclaw)    printf "%-14s  %s" "OpenClaw"     "(~/.openclaw/agency-agents)" ;;
     cursor)      printf "%-14s  %s" "Cursor"       "(.cursor/rules)"         ;;
     aider)       printf "%-14s  %s" "Aider"        "(CONVENTIONS.md)"        ;;
     windsurf)    printf "%-14s  %s" "Windsurf"     "(.windsurfrules)"        ;;
@@ -285,7 +285,7 @@ install_copilot() {
   local count=0
   mkdir -p "$dest"
   local dir f first_line
-  for dir in design engineering marketing product project-management \
+  for dir in design engineering game-development marketing paid-media product project-management \
               testing support spatial-computing specialized; do
     [[ -d "$REPO_ROOT/$dir" ]] || continue
     while IFS= read -r -d '' f; do
@@ -293,7 +293,7 @@ install_copilot() {
       [[ "$first_line" == "---" ]] || continue
       cp "$f" "$dest/"
       (( count++ )) || true
-    done < <(find "$REPO_ROOT/$dir" -maxdepth 1 -name "*.md" -type f -print0)
+    done < <(find "$REPO_ROOT/$dir" -name "*.md" -type f -print0)
   done
   ok "Copilot: $count agents -> $dest"
 }
@@ -349,21 +349,31 @@ install_openclaw() {
   local src="$INTEGRATIONS/openclaw"
   local dest="${HOME}/.openclaw/agency-agents"
   local count=0
+  local existing_agents=""
   [[ -d "$src" ]] || { err "integrations/openclaw missing. Run convert.sh first."; return 1; }
   mkdir -p "$dest"
+  if command -v openclaw >/dev/null 2>&1; then
+    existing_agents=$'\n'"$(openclaw agents list --json 2>/dev/null | sed -n 's/^[[:space:]]*"id": "\([^"]*\)".*/\1/p')"$'\n'
+  fi
   local d
   while IFS= read -r -d '' d; do
     local name; name="$(basename "$d")"
+    [[ -f "$d/SOUL.md" && -f "$d/AGENTS.md" && -f "$d/IDENTITY.md" ]] || continue
     mkdir -p "$dest/$name"
     cp "$d/SOUL.md" "$dest/$name/SOUL.md"
     cp "$d/AGENTS.md" "$dest/$name/AGENTS.md"
     cp "$d/IDENTITY.md" "$dest/$name/IDENTITY.md"
-    # Register with OpenClaw so agents are usable by agentId immediately
     if command -v openclaw >/dev/null 2>&1; then
-      openclaw agents add "$name" --workspace "$dest/$name" --non-interactive || true
+      if [[ "$existing_agents" != *$'\n'"$name"$'\n'* ]]; then
+        openclaw agents add "$name" --workspace "$dest/$name" --non-interactive || true
+      fi
     fi
     (( count++ )) || true
   done < <(find "$src" -mindepth 1 -maxdepth 1 -type d -print0)
+  if (( count == 0 )); then
+    err "integrations/openclaw contains no generated workspaces. Run ./scripts/convert.sh --tool openclaw first."
+    return 1
+  fi
   ok "OpenClaw: $count workspaces -> $dest"
   if command -v openclaw >/dev/null 2>&1; then
     warn "OpenClaw: run 'openclaw gateway restart' to activate new agents"


### PR DESCRIPTION
## Summary
- align the root and integration READMEs around the current OpenClaw install flow and supported tools
- add the missing OpenClaw integration page and refresh the converter / installer scripts to match the docs
- remove stale integration roster wording so generated docs stay coherent

## Verification
- docs-only branch; no project test script is defined in this repo
