### PR TITLE
docs: sync OpenClaw install docs and integration paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,13 @@ Born from a Reddit thread and months of iteration, **The Agency** is a growing c
 ### Option 1: Use with Claude Code (Recommended)
 
 ```bash
-# Copy agents to your Claude Code directory
-cp -r agency-agents/* ~/.claude/agents/
+# Install all agents to your Claude Code directory
+./scripts/install.sh --tool claude-code
 
-# Now activate any agent in your Claude Code sessions:
+# Or manually copy a category if you only want one division
+cp engineering/*.md ~/.claude/agents/
+
+# Then activate any agent in your Claude Code sessions:
 # "Hey Claude, activate Frontend Developer mode and help me build a React component"
 ```
 
@@ -44,7 +47,7 @@ Each agent file contains:
 
 Browse the agents below and copy/adapt the ones you need!
 
-### Option 3: Use with Other Tools (Cursor, Aider, Windsurf, Gemini CLI, OpenCode, Kimi Code)
+### Option 3: Use with Other Tools (GitHub Copilot, Antigravity, Gemini CLI, OpenCode, OpenClaw, Cursor, Aider, Windsurf, Kimi Code)
 
 ```bash
 # Step 1 -- generate integration files for all supported tools
@@ -54,8 +57,12 @@ Browse the agents below and copy/adapt the ones you need!
 ./scripts/install.sh
 
 # Or target a specific tool directly
-./scripts/install.sh --tool cursor
+./scripts/install.sh --tool antigravity
+./scripts/install.sh --tool gemini-cli
+./scripts/install.sh --tool opencode
 ./scripts/install.sh --tool copilot
+./scripts/install.sh --tool openclaw
+./scripts/install.sh --tool cursor
 ./scripts/install.sh --tool aider
 ./scripts/install.sh --tool windsurf
 ./scripts/install.sh --tool kimi
@@ -740,10 +747,12 @@ See [integrations/windsurf/README.md](integrations/windsurf/README.md) for detai
 Each agent becomes a workspace with `SOUL.md`, `AGENTS.md`, and `IDENTITY.md` in `~/.openclaw/agency-agents/`.
 
 ```bash
+./scripts/convert.sh --tool openclaw
 ./scripts/install.sh --tool openclaw
 ```
 
-Agents are registered and available by `agentId` in OpenClaw sessions.
+If the `openclaw` CLI is available, the installer registers each workspace automatically.
+Run `openclaw gateway restart` after installation so the new agents are activated.
 
 See [integrations/openclaw/README.md](integrations/openclaw/README.md) for details.
 

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -33,6 +33,12 @@ supported agentic coding tools.
 ./scripts/install.sh --tool gemini-cli
 ```
 
+If you install OpenClaw and the gateway is already running, restart it after installation:
+
+```bash
+openclaw gateway restart
+```
+
 For project-scoped tools such as OpenCode, Cursor, Aider, and Windsurf, run
 the installer from your target project root as shown in the tool-specific
 sections below.

--- a/integrations/aider/README.md
+++ b/integrations/aider/README.md
@@ -1,6 +1,6 @@
 # Aider Integration
 
-All 61 Agency agents are consolidated into a single `CONVENTIONS.md` file.
+The full Agency roster is consolidated into a single `CONVENTIONS.md` file.
 Aider reads this file automatically when it's present in your project root.
 
 ## Install

--- a/integrations/antigravity/README.md
+++ b/integrations/antigravity/README.md
@@ -1,6 +1,6 @@
 # Antigravity Integration
 
-Installs all 61 Agency agents as Antigravity skills. Each agent is prefixed
+Installs the full Agency roster as Antigravity skills. Each agent is prefixed
 with `agency-` to avoid conflicts with existing skills.
 
 ## Install

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -28,4 +28,4 @@ Use the Reality Checker agent to verify this feature is production-ready.
 ## Agent Directory
 
 Agents are organized into divisions. See the [main README](../../README.md) for
-the full current roster.
+the full Agency roster.

--- a/integrations/cursor/README.md
+++ b/integrations/cursor/README.md
@@ -1,6 +1,6 @@
 # Cursor Integration
 
-Converts all 61 Agency agents into Cursor `.mdc` rule files. Rules are
+Converts the full Agency roster into Cursor `.mdc` rule files. Rules are
 **project-scoped** — install them from your project root.
 
 ## Install

--- a/integrations/windsurf/README.md
+++ b/integrations/windsurf/README.md
@@ -1,6 +1,6 @@
 # Windsurf Integration
 
-All 61 Agency agents are consolidated into a single `.windsurfrules` file.
+The full Agency roster is consolidated into a single `.windsurfrules` file.
 Rules are **project-scoped** — install them from your project root.
 
 ## Install

--- a/scripts/convert.sh
+++ b/scripts/convert.sh
@@ -12,11 +12,11 @@
 # Tools:
 #   antigravity  — Antigravity skill files (~/.gemini/antigravity/skills/)
 #   gemini-cli   — Gemini CLI extension (skills/ + gemini-extension.json)
-#   opencode     — OpenCode agent files (.opencode/agent/*.md)
+#   opencode     — OpenCode agent files (.opencode/agents/*.md)
 #   cursor       — Cursor rule files (.cursor/rules/*.mdc)
 #   aider        — Single CONVENTIONS.md for Aider
 #   windsurf     — Single .windsurfrules for Windsurf
-#   openclaw     — OpenClaw SOUL.md files (openclaw_workspace/<agent>/SOUL.md)
+#   openclaw     — OpenClaw workspaces (integrations/openclaw/<agent>/SOUL.md)
 #   qwen         — Qwen Code SubAgent files (~/.qwen/agents/*.md)
 #   kimi         — Kimi Code CLI agent files (~/.config/kimi/agents/)
 #   all          — All tools (default)
@@ -264,8 +264,8 @@ convert_openclaw() {
   # Split body sections into SOUL.md (persona) vs AGENTS.md (operations)
   # by matching ## header keywords. Unmatched sections go to AGENTS.md.
   #
-  # SOUL keywords: identity, memory (paired with identity), communication,
-  #   style, critical rules, rules you must follow
+  # SOUL keywords: identity, learning & memory, communication, style,
+  #   critical rules, rules you must follow
   # AGENTS keywords: everything else (mission, deliverables, workflow, etc.)
 
   local current_target="agents"  # default bucket
@@ -289,6 +289,7 @@ convert_openclaw() {
       header_lower="$(echo "$line" | tr '[:upper:]' '[:lower:]')"
 
       if [[ "$header_lower" =~ identity ]] ||
+         [[ "$header_lower" =~ learning.*memory ]] ||
          [[ "$header_lower" =~ communication ]] ||
          [[ "$header_lower" =~ style ]] ||
          [[ "$header_lower" =~ critical.rule ]] ||

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -14,7 +14,7 @@
 #   copilot      -- Copy agents to ~/.github/agents/ and ~/.copilot/agents/
 #   antigravity  -- Copy skills to ~/.gemini/antigravity/skills/
 #   gemini-cli   -- Install extension to ~/.gemini/extensions/agency-agents/
-#   opencode     -- Copy agents to .opencode/agent/ in current directory
+#   opencode     -- Copy agents to .opencode/agents/ in current directory
 #   cursor       -- Copy rules to .cursor/rules/ in current directory
 #   aider        -- Copy CONVENTIONS.md to current directory
 #   windsurf     -- Copy .windsurfrules to current directory
@@ -169,7 +169,7 @@ tool_label() {
     antigravity) printf "%-14s  %s" "Antigravity"  "(~/.gemini/antigravity)" ;;
     gemini-cli)  printf "%-14s  %s" "Gemini CLI"   "(gemini extension)"      ;;
     opencode)    printf "%-14s  %s" "OpenCode"     "(opencode.ai)"           ;;
-    openclaw)    printf "%-14s  %s" "OpenClaw"     "(~/.openclaw)"           ;;
+    openclaw)    printf "%-14s  %s" "OpenClaw"     "(~/.openclaw/agency-agents)" ;;
     cursor)      printf "%-14s  %s" "Cursor"       "(.cursor/rules)"         ;;
     aider)       printf "%-14s  %s" "Aider"        "(CONVENTIONS.md)"        ;;
     windsurf)    printf "%-14s  %s" "Windsurf"     "(.windsurfrules)"        ;;
@@ -390,21 +390,31 @@ install_openclaw() {
   local src="$INTEGRATIONS/openclaw"
   local dest="${HOME}/.openclaw/agency-agents"
   local count=0
+  local existing_agents=""
   [[ -d "$src" ]] || { err "integrations/openclaw missing. Run convert.sh first."; return 1; }
   mkdir -p "$dest"
+  if command -v openclaw >/dev/null 2>&1; then
+    existing_agents=$'\n'"$(openclaw agents list --json 2>/dev/null | sed -n 's/^[[:space:]]*\"id\": \"\\([^\"]*\\)\".*/\\1/p')"$'\n'
+  fi
   local d
   while IFS= read -r -d '' d; do
     local name; name="$(basename "$d")"
+    [[ -f "$d/SOUL.md" && -f "$d/AGENTS.md" && -f "$d/IDENTITY.md" ]] || continue
     mkdir -p "$dest/$name"
     cp "$d/SOUL.md" "$dest/$name/SOUL.md"
     cp "$d/AGENTS.md" "$dest/$name/AGENTS.md"
     cp "$d/IDENTITY.md" "$dest/$name/IDENTITY.md"
-    # Register with OpenClaw so agents are usable by agentId immediately
     if command -v openclaw >/dev/null 2>&1; then
-      openclaw agents add "$name" --workspace "$dest/$name" --non-interactive || true
+      if [[ "$existing_agents" != *$'\n'"$name"$'\n'* ]]; then
+        openclaw agents add "$name" --workspace "$dest/$name" --non-interactive || true
+      fi
     fi
     (( count++ )) || true
   done < <(find "$src" -mindepth 1 -maxdepth 1 -type d -print0)
+  if (( count == 0 )); then
+    err "integrations/openclaw contains no generated workspaces. Run ./scripts/convert.sh --tool openclaw first."
+    return 1
+  fi
   ok "OpenClaw: $count workspaces -> $dest"
   if command -v openclaw >/dev/null 2>&1; then
     warn "OpenClaw: run 'openclaw gateway restart' to activate new agents"


### PR DESCRIPTION
## Summary
- replace the stale dirty OpenClaw docs branch with a clean branch from current `main`
- align README and integration docs with the current supported tool set and install commands
- tighten OpenClaw install behavior by skipping malformed workspaces, avoiding duplicate registrations, and surfacing missing generated outputs
- fix script comments and OpenClaw conversion routing for `Learning & Memory` sections

## Validation
- `bash -n scripts/convert.sh scripts/install.sh`

## Notes
- supersedes #425
