### PR TITLE
fix: add finance/ to scripts, CI, README, and CONTRIBUTING.md

### DIFF
--- a/.github/workflows/lint-agents.yml
+++ b/.github/workflows/lint-agents.yml
@@ -6,6 +6,7 @@ on:
       - "academic/**"
       - "design/**"
       - "engineering/**"
+      - "finance/**"
       - "game-development/**"
       - "marketing/**"
       - "paid-media/**"
@@ -30,7 +31,7 @@ jobs:
         id: changed
         run: |
           FILES=$(git diff --name-only --diff-filter=ACMR origin/${{ github.base_ref }}...HEAD -- \
-            'academic/**/*.md' 'design/**/*.md' 'engineering/**/*.md' 'game-development/**/*.md' 'marketing/**/*.md' 'paid-media/**/*.md' 'sales/**/*.md' 'product/**/*.md' \
+            'academic/**/*.md' 'design/**/*.md' 'engineering/**/*.md' 'finance/**/*.md' 'game-development/**/*.md' 'marketing/**/*.md' 'paid-media/**/*.md' 'sales/**/*.md' 'product/**/*.md' \
             'project-management/**/*.md' 'testing/**/*.md' 'support/**/*.md' \
             'spatial-computing/**/*.md' 'specialized/**/*.md')
           {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,7 @@ Have an idea for a specialized agent? Great! Here's how to add one:
 2. **Choose the appropriate category** (or propose a new one):
    - `engineering/` - Software development specialists
    - `design/` - UX/UI and creative specialists
+   - `finance/` - Financial planning, accounting, and investment specialists
    - `game-development/` - Game design and development specialists
    - `marketing/` - Growth and marketing specialists
    - `paid-media/` - Paid acquisition and media specialists

--- a/README.md
+++ b/README.md
@@ -289,6 +289,18 @@ The unique specialists who don't fit in a box.
 | 🇰🇷 [Korean Business Navigator](specialized/specialized-korean-business-navigator.md) | Korean business culture, 품의 process, relationship mechanics | Foreign professionals navigating Korean business relationships |
 | 🏗️ [Civil Engineer](specialized/specialized-civil-engineer.md) | Structural analysis, geotechnical design, global building codes | Multi-standard structural engineering across Eurocode, ACI, AISC, and more |
 
+### 💵 Finance Division
+
+Accounting, financial analysis, tax strategy, and investment research specialists.
+
+| Agent | Specialty | When to Use |
+|-------|-----------|-------------|
+| 📒 [Bookkeeper & Controller](finance/finance-bookkeeper-controller.md) | Month-end close, reconciliation, GAAP compliance, internal controls | Day-to-day accounting operations, audit readiness, financial record-keeping |
+| 📊 [Financial Analyst](finance/finance-financial-analyst.md) | Financial modeling, forecasting, scenario analysis, decision support | Three-statement models, variance analysis, data-driven business intelligence |
+| 📈 [FP&A Analyst](finance/finance-fpa-analyst.md) | Budgeting, rolling forecasts, variance analysis, business reviews | Annual operating plans, monthly business reviews, strategic resource allocation |
+| 🔍 [Investment Researcher](finance/finance-investment-researcher.md) | Due diligence, portfolio analysis, asset valuation, equity research | Investment thesis development, risk assessment, market research |
+| 🏛️ [Tax Strategist](finance/finance-tax-strategist.md) | Tax optimization, multi-jurisdictional compliance, transfer pricing | Entity structuring, ETR analysis, audit defense, strategic tax planning |
+
 ### 🎮 Game Development Division
 
 Building worlds, systems, and experiences across every major engine.

--- a/scripts/convert.sh
+++ b/scripts/convert.sh
@@ -62,7 +62,7 @@ OUT_DIR="$REPO_ROOT/integrations"
 TODAY="$(date +%Y-%m-%d)"
 
 AGENT_DIRS=(
-  academic design engineering game-development marketing paid-media product project-management
+  academic design engineering finance game-development marketing paid-media product project-management
   sales spatial-computing specialized strategy support testing
 )
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -105,7 +105,7 @@ ALL_TOOLS=(claude-code copilot antigravity gemini-cli opencode openclaw cursor a
 
 # Standard agent category directories (keep sorted, sync with convert.sh / lint-agents.sh)
 AGENT_DIRS=(
-  academic design engineering game-development marketing paid-media product project-management
+  academic design engineering finance game-development marketing paid-media product project-management
   sales spatial-computing specialized strategy support testing
 )
 

--- a/scripts/lint-agents.sh
+++ b/scripts/lint-agents.sh
@@ -15,10 +15,10 @@ AGENT_DIRS=(
   academic
   design
   engineering
+  finance
   game-development
   marketing
   paid-media
-  sales
   product
   project-management
   sales


### PR DESCRIPTION
## Summary

The Finance Division (5 agents from PR #431) was merged without updating the surrounding infrastructure. This PR closes the coverage gap.

**Changes:**
- `scripts/install.sh` — added `finance` to `AGENT_DIRS`
- `scripts/convert.sh` — added `finance` to `AGENT_DIRS`
- `scripts/lint-agents.sh` — added `finance` to `AGENT_DIRS`, fixed duplicate `sales` entry
- `.github/workflows/lint-agents.yml` — added `finance/**` to CI trigger paths and diff globs
- `CONTRIBUTING.md` — added `finance/` to the category directory list
- `README.md` — added Finance Division section with all 5 agent entries (Bookkeeper & Controller, Financial Analyst, FP&A Analyst, Investment Researcher, Tax Strategist)

## Test plan

- [ ] `bash scripts/lint-agents.sh finance/*.md` passes (verified: 0 errors)
- [ ] `grep finance scripts/install.sh scripts/convert.sh scripts/lint-agents.sh` shows finance in all AGENT_DIRS
- [ ] Finance Division appears in README between Specialized and Game Development divisions
- [ ] CI workflow triggers on finance/ file changes