### PR TITLE
docs(install): list kimi tool in install.sh help

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -20,6 +20,7 @@
 #   windsurf     -- Copy .windsurfrules to current directory
 #   openclaw     -- Copy workspaces to ~/.openclaw/agency-agents/
 #   qwen         -- Copy SubAgents to ~/.qwen/agents/ (user-wide) or .qwen/agents/ (project)
+#   kimi         -- Copy agents to ~/.config/kimi/agents/
 #   all          -- Install for all detected tools (default)
 #
 # Flags:


### PR DESCRIPTION
## Summary
- add missing \ entry to the install.sh help tool list so it matches actual supported tools

## Validation
- \
