### PR TITLE
Replace corrupt soft-hyphen heading with intended thought-bubble emoji

### DIFF
--- a/engineering/engineering-mobile-app-builder.md
+++ b/engineering/engineering-mobile-app-builder.md
@@ -437,7 +437,7 @@ const styles = StyleSheet.create({
 **Performance**: Optimized for mobile constraints and user experience
 ```
 
-## =­ Your Communication Style
+## 💭 Your Communication Style
 
 - **Be platform-aware**: "Implemented iOS-native navigation with SwiftUI while maintaining Material Design patterns on Android"
 - **Focus on performance**: "Optimized app startup time to 2.1 seconds and reduced memory usage by 40%"

--- a/marketing/marketing-app-store-optimizer.md
+++ b/marketing/marketing-app-store-optimizer.md
@@ -265,7 +265,7 @@ You are **App Store Optimizer**, an expert app store marketing specialist who fo
 **Expected Results**: [Timeline for achieving optimization goals]
 ```
 
-## =­ Your Communication Style
+## 💭 Your Communication Style
 
 - **Be data-driven**: "Increased organic downloads by 45% through keyword optimization and visual asset testing"
 - **Focus on conversion**: "Improved app store conversion rate from 18% to 28% with optimized screenshot sequence"


### PR DESCRIPTION
Closes #478.

Both affected files had a heading whose source bytes read `## =<U+00AD> Your Communication Style`. The `<U+00AD>` is a SOFT HYPHEN, invisible in rendered Markdown and in most editors; the adjacent `=` literal only visibly leaks out when the file bytes are dumped directly.

Every other `## ... Your Communication Style` heading in the repo (29 files across design, engineering, project-management, spatial-computing, and specialized agents) uses the 💭 thought-bubble emoji. `💭` is `U+1F4AD`, which encodes in UTF-8 as `f0 9f 92 ad`; the trailing `92 ad` byte pair is the most likely origin of a mangled copy-paste that collapsed into a literal `=` plus a stray SOFT HYPHEN.

Replace the corrupt heading with `## 💭 Your Communication Style` in both files to match the repo-wide convention. After the fix a full-tree scan for `\\xc2\\xad` / ZWSP / ZWNJ / ZWJ / WORD-JOIN / BOM shows zero remaining invisible Unicode characters.

Verified locally:

```console
$ find . -name '*.md' -exec python3 -c 'import sys; sys.exit(1 if b"\\xc2\\xad" in open(sys.argv[1], "rb").read() else 0)' {} \;
$ echo $?
0
```