### PR TITLE
fix: quote zk-steward description to satisfy YAML frontmatter parsing (#473)

### DIFF
--- a/specialized/zk-steward.md
+++ b/specialized/zk-steward.md
@@ -1,6 +1,6 @@
 ---
 name: ZK Steward
-description: Knowledge-base steward in the spirit of Niklas Luhmann's Zettelkasten. Default perspective: Luhmann; switches to domain experts (Feynman, Munger, Ogilvy, etc.) by task. Enforces atomic notes, connectivity, and validation loops. Use for knowledge-base building, note linking, complex task breakdown, and cross-domain decision support.
+description: "Knowledge-base steward in the spirit of Niklas Luhmann's Zettelkasten. Default perspective: Luhmann; switches to domain experts (Feynman, Munger, Ogilvy, etc.) by task. Enforces atomic notes, connectivity, and validation loops. Use for knowledge-base building, note linking, complex task breakdown, and cross-domain decision support."
 color: teal
 emoji: 🗃️
 vibe: Channels Luhmann's Zettelkasten to build connected, validated knowledge bases.


### PR DESCRIPTION
Closes #473.

The unquoted \`description\` value on \`specialized/zk-steward.md\` contains a colon inside \`Default perspective: Luhmann\`, which YAML parses as a nested mapping entry and rejects with:

\`\`\`
yaml.YAMLError: mapping values are not allowed here
  in "<unicode string>", line 2, column 104:
     ... ettelkasten. Default perspective: Luhmann; switches to domain ex ...
                                         ^
\`\`\`

Column 104 of the description line lines up exactly with the error reported in the issue (\`bad indentation of a mapping entry (2:104)\`).

## Fix

Wrap the description value in double quotes so YAML treats the whole string as a single scalar. No other frontmatter or prose is touched — the visible description is byte-identical, just quoted.

## Verification

- **Baseline (main):** \`yaml.safe_load\` on the frontmatter raises \`YAMLError: mapping values are not allowed here\` at line 2, column 104 — matches the issue exactly.
- **After the fix:** \`yaml.safe_load\` returns a mapping with all five expected keys (\`name\`, \`description\`, \`color\`, \`emoji\`, \`vibe\`) and the full description string intact.

The same colon-in-unquoted-scalar pattern isn't present in other agent frontmatter — ran \`grep -rln "description:.*:" specialized/\` and \`zk-steward.md\` was the only hit.

Kept the change to just this one file and just this one line, so it's easy to land without entangling the manifest-generation direction discussed on #340.

🤖 AI-assisted.