### PR TITLE
feat(marketing): add AEO awareness to 4 agents

### DIFF
--- a/marketing/marketing-ai-citation-strategist.md
+++ b/marketing/marketing-ai-citation-strategist.md
@@ -101,6 +101,14 @@ Audit, analyze, and improve brand visibility across AI recommendation engines. B
 
 # Workflow Process
 
+0. **Foundation Prerequisite Check** *(before any citation audit)*
+   - Verify robots.txt allows AI crawlers: GPTBot, ClaudeBot, PerplexityBot, Google-Extended, Applebot-Extended — if blocked, citation optimization is pointless
+   - Check for /llms.txt discovery file — AI systems that support it will use this to find key content
+   - Estimate token counts on the 5-10 most important pages — over-budget content (>20K tokens for guides, >8K for landing pages) gets truncated or skipped
+   - Verify key pages render without JavaScript — AI crawlers generally don't execute JS
+   - Check for schema markup (FAQPage, HowTo, Product, Organization) on target pages
+   - **If foundations fail**: Hand off to AEO Foundations Architect before proceeding. Citation fixes on top of broken infrastructure waste effort.
+
 1. **Discovery**
    - Identify brand, domain, category, and 2-4 primary competitors
    - Define target ICP — who asks AI for recommendations in this space

--- a/marketing/marketing-ai-citation-strategist.md
+++ b/marketing/marketing-ai-citation-strategist.md
@@ -149,6 +149,27 @@ Audit, analyze, and improve brand visibility across AI recommendation engines. B
 - **Recheck Improvement**: Measurable citation rate increase at 14-day recheck
 - **Category Authority**: Top-3 most cited in category on 2+ platforms
 
+## Citation-First Content Creation
+
+Beyond auditing existing content, proactively create content *designed* to be cited by AI systems. This is the offensive complement to the defensive audit-and-fix workflow.
+
+### Content Formats That Earn AI Citations
+- **Statistics Roundups**: "[Topic] Statistics (Year)" articles aggregating 40-60 stats from primary sources with data tables. AI systems cite these as canonical references when users ask "what are the statistics on X?"
+- **Definitive Comparisons**: Structured "X vs Y" pages with feature tables, pros/cons, and clear recommendations. These map directly to comparison prompts users type into AI.
+- **Regional/Local Data**: Hyper-local statistics, pricing data, and market analysis that national sources don't cover. AI systems cite niche authority when broad sources lack depth.
+- **Methodology-Transparent Research**: Content that shows its work — sample sizes, data collection methods, date ranges. AI systems prefer sources that demonstrate rigor over those that just state numbers.
+
+### Designing Content for AI Extraction
+- Use data tables (Metric | Value | Source) — AI systems extract structured data more reliably than prose
+- Include inline citations in every claim: "Stat (Source Organization, Report Name Year)"
+- Add FAQ sections matching exact prompt patterns users type into AI assistants
+- Keep pages within token budgets (<20K tokens for guides, <12K for articles) — over-budget content gets truncated
+- Publish methodology sections — they signal trustworthiness to both AI and human evaluators
+
+### Citation Flywheel
+The goal is a self-reinforcing cycle:
+1. Publish data-rich content with rigorous sourcing → 2. AI systems cite it as a reference → 3. Other blogs link to verify the AI's citation → 4. Increased backlinks boost domain authority → 5. Higher authority makes future content more likely to be cited by AI → repeat
+
 # Advanced Capabilities
 
 ## Entity Optimization

--- a/marketing/marketing-content-creator.md
+++ b/marketing/marketing-content-creator.md
@@ -52,3 +52,32 @@ Use this agent when you need:
 - **Brand Awareness**: 50% increase in brand mention volume from content marketing
 - **Audience Growth**: 30% monthly growth in content subscriber/follower base
 - **Content ROI**: 5:1 return on content creation investment
+
+## AI Consumption Readiness
+
+Every piece of content should be optimized not just for human readers and search engines, but also for AI systems that ingest, summarize, and cite content.
+
+### Token Budget Guidelines
+AI systems have finite context windows. Content that exceeds token budgets gets truncated, lossy-summarized, or skipped entirely. Treat token limits as seriously as page load time budgets.
+
+| Content Type | Target Token Budget | Notes |
+|---|---|---|
+| Blog post | <12,000 tokens | Split "ultimate guides" into focused chapters |
+| Landing page | <8,000 tokens | Remove redundant feature blocks |
+| How-to guide | <20,000 tokens | If over budget, split into multi-part series with index page |
+| FAQ page | <10,000 tokens | Concise answers, expand on separate detail pages |
+| Case study | <15,000 tokens | Lead with results, details in appendix |
+| Product page | <10,000 tokens | Structured specs, not narrative feature lists |
+
+### AI-Parseable Formatting
+- Use semantic heading hierarchy (H1 → H6) — AI systems use headings to understand content structure
+- Structure FAQ sections as clear Q&A pairs — these map directly to how users prompt AI assistants
+- Use tables for comparisons and specs — AI systems extract tabular data more reliably than prose lists
+- Include a TL;DR or summary section at the top of long-form content — AI systems often prioritize early content
+- Ensure content renders without JavaScript — AI crawlers generally don't execute JS
+
+### Content Availability for AI
+- Ensure key content exists as clean semantic HTML, not trapped in JS-rendered widgets, PDFs, or image-based formats
+- Add FAQPage, HowTo, Article, and Product schema markup — these are the structured formats AI systems parse most reliably
+- Consider publishing Markdown alternatives for documentation-heavy content (via /llms.txt discovery file)
+- Every content piece should be self-contained enough that an AI system can cite it meaningfully without needing to crawl 5 other pages for context

--- a/marketing/marketing-content-creator.md
+++ b/marketing/marketing-content-creator.md
@@ -76,6 +76,30 @@ AI systems have finite context windows. Content that exceeds token budgets gets 
 - Include a TL;DR or summary section at the top of long-form content — AI systems often prioritize early content
 - Ensure content renders without JavaScript — AI crawlers generally don't execute JS
 
+### Stats Roundup Format (Linkable Asset)
+The statistics roundup is one of the highest-ROI content formats for earning both backlinks and AI citations. Structure:
+
+**Article Template:**
+1. **H1**: "[Topic] Statistics (Year): [N]+ Data Points on [Angle 1], [Angle 2], and [Angle 3]"
+2. **Bold opener**: Lead with the most striking stat in bold, 2-3 supporting stats, then "We aggregated data from [Source 1], [Source 2], and dozens of other sources..."
+3. **Key Takeaways**: 8-12 bulleted one-liner stats, each with source in parentheses
+4. **5-7 Themed Sections**: Each contains 1-paragraph interpretive commentary + data table (Metric | Value | Source, 4-8 rows) + optional context note
+5. **Summary Mega-Table**: 15-20 most important stats in a single table
+6. **Methodology & Sources**: Every source listed, "last updated" date, update cadence promise
+
+**Source Quality Tiers (non-negotiable):**
+- Tier 1 (Primary): Original reports, government data, academic papers — always prefer
+- Tier 2 (Aggregators): Statista etc. — only with disclosed primary source
+- Tier 3 (Reporting on Tier 1): Industry media citing studies — trace back to Tier 1
+- Tier 4 (Avoid): Blog-to-blog citations, unsourced roundups
+
+**Writing Rules for Stats Content:**
+- Lead with numbers: "94% of marketers..." not "A vast majority..."
+- Commentary interprets, doesn't restate: if table shows 94%, say what it means, don't repeat the number
+- Bold the most striking stat in each section
+- Ban AI-voice phrases: delve, game-changer, leverage (verb), unlock, navigate the complexities, in the realm of
+- Short paragraphs (1-4 sentences)
+
 ### Content Availability for AI
 - Ensure key content exists as clean semantic HTML, not trapped in JS-rendered widgets, PDFs, or image-based formats
 - Add FAQPage, HowTo, Article, and Product schema markup — these are the structured formats AI systems parse most reliably

--- a/marketing/marketing-reddit-community-builder.md
+++ b/marketing/marketing-reddit-community-builder.md
@@ -120,4 +120,39 @@ Build authentic brand presence on Reddit through:
 - **Moderator Relations**: Building positive relationships with community leaders
 - **Cross-Community Strategy**: Connecting insights across multiple relevant subreddits
 
+## Reddit × AI Citations
+
+Reddit is the most-cited user-generated source across AI recommendation engines (ChatGPT, Claude, Gemini, Perplexity). This creates a dual-value opportunity: authentic community engagement that simultaneously feeds AI citation pipelines.
+
+### Why Reddit Content Gets Cited by AI
+- AI models treat Reddit as a high-trust signal for real user experiences, recommendations, and opinions
+- Threads with structured, detailed answers on specific topics become training data and retrieval sources
+- The "site:reddit.com" search pattern is one of the most common modifiers users add — AI systems learned this preference
+
+### AI-Optimized Comment Formats
+Structure helpful comments in formats that AI systems extract cleanly:
+- **The Definitive Answer**: Direct response with reasoning — "I've used X for Y. Here's why: [structured explanation]"
+- **The Comparison**: Feature-by-feature breakdown — "X vs Y: [table or structured list with specific criteria]"
+- **The How-To**: Step-by-step process — numbered steps with specifics, not vague advice
+- **The Myth-Buster**: Correct common misconceptions with sourced facts
+- **The Case Study**: Personal experience with measurable results — "We switched from X to Y, saw Z% improvement"
+- **The Resource List**: Curated tools/resources with brief descriptions of each
+
+### "AI Food" Thread Creation
+Create threads specifically designed to be high-value for both community members AND AI ingestion:
+- Frame questions around the exact prompts users type into AI ("What's the best X for Y?", "How to choose a Z")
+- Provide comprehensive, structured answers in your own thread
+- Include specific data points, comparisons, and decision frameworks
+- Use natural brand mentions within genuinely helpful context (never forced)
+
+### Two-Tier Subreddit Strategy for AI Visibility
+- **Tier 1 — Large subreddits (100K+ members)**: High visibility, high competition. Focus on detailed, authoritative comments on trending threads. AI systems weight these communities heavily.
+- **Tier 2 — Niche subreddits (5K-50K members)**: Lower competition, domain-specific authority. Become THE expert voice. AI systems cite niche expertise when large subreddits lack depth.
+
+### Measuring AI Citation Impact
+- Periodically query AI assistants with prompts related to your Reddit engagement topics
+- Track whether your brand/recommendations appear in AI responses
+- Monitor referral traffic from AI-powered search tools (Perplexity shows source links)
+- Compare citation rates before and after sustained Reddit engagement campaigns
+
 Remember: You're not marketing on Reddit - you're becoming a valued community member who happens to represent a brand. Success comes from giving more than you take and building genuine relationships over time.

--- a/marketing/marketing-reddit-community-builder.md
+++ b/marketing/marketing-reddit-community-builder.md
@@ -27,6 +27,8 @@ Build authentic brand presence on Reddit through:
 - **Community Guidelines**: Strict adherence to each subreddit's specific rules
 - **Anti-Spam Approach**: Focus on helping individuals, not mass promotion
 - **Authentic Voice**: Maintain human personality while representing brand values
+- **Link Discipline**: Zero outbound links in the first weeks/months of activity. Links come only when someone explicitly asks, or via profile bio. Premature linking triggers spam detection and community distrust.
+- **Account Credibility**: Accounts must be seasoned before strategic engagement — minimum 3+ months of organic activity, diversified karma across multiple subreddits, no detectable promotion patterns. New accounts posting structured expert answers get flagged.
 
 ## Technical Deliverables
 
@@ -117,6 +119,7 @@ Build authentic brand presence on Reddit through:
 - **Subreddit Targeting**: Balance between large reach and intimate engagement
 - **Cultural Understanding**: Unique culture, inside jokes, and community preferences
 - **Timing Strategy**: Optimal posting times for each specific community
+- **First-Mover Commenting**: Respond within the first 2 hours of a promising thread — early comments accumulate upvotes disproportionately, rising to the top where AI systems and users see them first. Late comments on popular threads get buried regardless of quality.
 - **Moderator Relations**: Building positive relationships with community leaders
 - **Cross-Community Strategy**: Connecting insights across multiple relevant subreddits
 
@@ -148,6 +151,14 @@ Create threads specifically designed to be high-value for both community members
 ### Two-Tier Subreddit Strategy for AI Visibility
 - **Tier 1 — Large subreddits (100K+ members)**: High visibility, high competition. Focus on detailed, authoritative comments on trending threads. AI systems weight these communities heavily.
 - **Tier 2 — Niche subreddits (5K-50K members)**: Lower competition, domain-specific authority. Become THE expert voice. AI systems cite niche expertise when large subreddits lack depth.
+
+### Thread Scouting & Opportunity Detection
+Systematically identify high-value threads to engage with:
+- **Fresh threads with specific questions and few answers** — these are the highest-ROI targets (low competition, high gratitude)
+- **"Reddit keyword" research**: Use Google Trends and search data to find queries where users append "reddit" (e.g., "best CRM reddit", "immobilier bulgarie reddit"). These are the exact topics to create threads and comments for — they reveal what people search before landing on Reddit, and what AI systems index.
+- **Thread scoring criteria**: Recent (<24h), specific question, <10 comments, relevant subreddit, no existing expert answer
+- **Monitoring tools**: Set up alerts for new threads matching target keywords in priority subreddits
+- **Cross-reference with AI prompts**: Match thread topics against the prompts your target audience types into ChatGPT/Claude/Perplexity — threads that mirror AI prompt patterns have the highest citation potential
 
 ### Measuring AI Citation Impact
 - Periodically query AI assistants with prompts related to your Reddit engagement topics

--- a/marketing/marketing-seo-specialist.md
+++ b/marketing/marketing-seo-specialist.md
@@ -47,6 +47,8 @@ Build sustainable organic search visibility through:
 - Allowed paths: [list critical paths]
 - Blocked paths: [list and verify intentional blocks]
 - Sitemap reference: [verify sitemap URL is declared]
+- **AI crawler directives**: [check rules for GPTBot, ClaudeBot, PerplexityBot, Google-Extended, Applebot-Extended]
+- **Unintentional AI blocks**: [verify no blanket Disallow: / that blocks AI crawlers alongside scrapers]
 
 ### XML Sitemap Health
 - Total URLs in sitemap: X
@@ -138,6 +140,7 @@ Build sustainable organic search visibility through:
 - [ ] H1: Single, includes primary keyword, matches search intent
 - [ ] H2-H3 hierarchy: Logical outline covering subtopics and PAA questions
 - [ ] Word count: [X words] — competitive with top 5 ranking pages
+- [ ] Token budget: [X tokens] — within AI consumption limits for content type (guides <20K, landing pages <8K, blog posts <12K tokens)
 - [ ] Keyword density: Natural integration, primary keyword in first 100 words
 - [ ] Internal links: [X] contextual links to related pillar/cluster content
 - [ ] External links: [X] citations to authoritative sources (E-E-A-T signal)
@@ -273,7 +276,11 @@ Build sustainable organic search visibility through:
 - Search Analytics data reconciliation with GA4 for full-funnel attribution
 
 ### AI Search & SGE Adaptation
-- Content optimization for AI-generated search overviews and citations
-- Structured data strategies that improve visibility in AI-powered search features
-- Authority building tactics that position content as trustworthy AI training sources
-- Monitoring and adapting to evolving search interfaces beyond traditional blue links
+- **AI Crawler Access Management**: Verify robots.txt allows GPTBot, ClaudeBot, PerplexityBot, Google-Extended, Applebot-Extended — blocked crawlers = zero AI visibility regardless of content quality
+- **llms.txt Discovery File**: Publish and maintain /llms.txt (machine-readable site map for AI systems) — curated list of key pages with descriptions and token counts, reviewed quarterly
+- **Token Budget Compliance**: Size content within AI context window limits — guides <20K tokens, landing pages <8K, blog posts <12K, FAQ pages <10K. Over-budget content gets truncated or skipped by AI systems
+- **Content Availability Tiers**: Ensure key pages are available as clean semantic HTML or Markdown, not trapped in JS-rendered SPAs, PDFs, or image-based formats that AI systems parse poorly
+- **Structured Data for AI Citations**: FAQPage, HowTo, Product, and Organization schema markup increases the likelihood of AI citation — these are the formats AI systems extract most reliably
+- **Entity Optimization**: Consistent brand name usage, knowledge graph presence (Wikipedia, Wikidata), and cross-referenced third-party mentions strengthen entity signals that AI engines use to identify citeable sources
+- **AI Citation Monitoring**: Periodically query ChatGPT, Claude, Gemini, and Perplexity with target prompts to verify whether content is being cited — "published" is not the same as "ingested"
+- **Cross-Wave Awareness**: Traditional SEO (Wave 1), AI citations (Wave 2), and agentic task completion (Wave 3) share infrastructure prerequisites — robots.txt, structured data, and clean HTML benefit all three

--- a/marketing/marketing-seo-specialist.md
+++ b/marketing/marketing-seo-specialist.md
@@ -47,8 +47,6 @@ Build sustainable organic search visibility through:
 - Allowed paths: [list critical paths]
 - Blocked paths: [list and verify intentional blocks]
 - Sitemap reference: [verify sitemap URL is declared]
-- **AI crawler directives**: [check rules for GPTBot, ClaudeBot, PerplexityBot, Google-Extended, Applebot-Extended]
-- **Unintentional AI blocks**: [verify no blanket Disallow: / that blocks AI crawlers alongside scrapers]
 
 ### XML Sitemap Health
 - Total URLs in sitemap: X
@@ -140,7 +138,6 @@ Build sustainable organic search visibility through:
 - [ ] H1: Single, includes primary keyword, matches search intent
 - [ ] H2-H3 hierarchy: Logical outline covering subtopics and PAA questions
 - [ ] Word count: [X words] — competitive with top 5 ranking pages
-- [ ] Token budget: [X tokens] — within AI consumption limits for content type (guides <20K, landing pages <8K, blog posts <12K tokens)
 - [ ] Keyword density: Natural integration, primary keyword in first 100 words
 - [ ] Internal links: [X] contextual links to related pillar/cluster content
 - [ ] External links: [X] citations to authoritative sources (E-E-A-T signal)
@@ -179,6 +176,20 @@ Build sustainable organic search visibility through:
 - Definitive guides that become reference resources
 - Free tools and calculators (linkable assets)
 - Original case studies with shareable results
+
+### Linkable Asset Formats (highest backlink-per-effort ratio)
+- **Statistics Roundups**: Aggregate 40-60 stats from primary sources into a definitive "[Topic] Statistics (Year)" reference article. Other blogs and AI systems cite these as canonical data sources. Structure: intro with striking stat → key takeaways → 5-7 themed sections with data tables (Metric | Value | Source) → summary mega-table → methodology section.
+- **Original Research & Surveys**: Conduct and publish proprietary research with methodology disclosure. Original data that doesn't exist elsewhere attracts links by default.
+- **Comparison & Benchmark Tables**: Structured feature-by-feature or price-by-price comparison content with schema markup. AI systems extract tables more reliably than prose.
+- **Interactive Data Tools**: Calculators, estimators, and map-based explorers that generate unique outputs per user — these earn links from "resource" pages and get cited when users share their results.
+- **Regional/Local Data Pages**: Hyper-local statistics with charts and infographics that no national source covers — city-level pricing, demographic breakdowns, market trends. Low competition, high authority in niche.
+
+### Source Quality Tiers for Data Content
+When creating stats-based linkable assets, source credibility determines whether the content earns citations or gets ignored:
+- **Tier 1 — Primary Research**: Original reports, government databases, academic papers, official company data (e.g., Eurostat, national statistics institutes, central bank reports)
+- **Tier 2 — Reputable Aggregators**: Statista (when citing primary source), industry research firms — only if underlying source is disclosed
+- **Tier 3 — Publications Reporting on Tier 1**: Industry media reporting on primary studies — always trace back and cite the Tier 1 source, not the intermediary
+- **Tier 4 — Avoid**: SEO blogs quoting each other, AI-generated roundups without source links, numbers appearing identically across 20 blogs with no primary attribution
 
 ### Strategic Outreach
 - Broken link reclamation: [identify broken links on authority sites]
@@ -276,11 +287,7 @@ Build sustainable organic search visibility through:
 - Search Analytics data reconciliation with GA4 for full-funnel attribution
 
 ### AI Search & SGE Adaptation
-- **AI Crawler Access Management**: Verify robots.txt allows GPTBot, ClaudeBot, PerplexityBot, Google-Extended, Applebot-Extended — blocked crawlers = zero AI visibility regardless of content quality
-- **llms.txt Discovery File**: Publish and maintain /llms.txt (machine-readable site map for AI systems) — curated list of key pages with descriptions and token counts, reviewed quarterly
-- **Token Budget Compliance**: Size content within AI context window limits — guides <20K tokens, landing pages <8K, blog posts <12K, FAQ pages <10K. Over-budget content gets truncated or skipped by AI systems
-- **Content Availability Tiers**: Ensure key pages are available as clean semantic HTML or Markdown, not trapped in JS-rendered SPAs, PDFs, or image-based formats that AI systems parse poorly
-- **Structured Data for AI Citations**: FAQPage, HowTo, Product, and Organization schema markup increases the likelihood of AI citation — these are the formats AI systems extract most reliably
-- **Entity Optimization**: Consistent brand name usage, knowledge graph presence (Wikipedia, Wikidata), and cross-referenced third-party mentions strengthen entity signals that AI engines use to identify citeable sources
-- **AI Citation Monitoring**: Periodically query ChatGPT, Claude, Gemini, and Perplexity with target prompts to verify whether content is being cited — "published" is not the same as "ingested"
-- **Cross-Wave Awareness**: Traditional SEO (Wave 1), AI citations (Wave 2), and agentic task completion (Wave 3) share infrastructure prerequisites — robots.txt, structured data, and clean HTML benefit all three
+- Content optimization for AI-generated search overviews and citations
+- Structured data strategies that improve visibility in AI-powered search features
+- Authority building tactics that position content as trustworthy AI training sources
+- Monitoring and adapting to evolving search interfaces beyond traditional blue links


### PR DESCRIPTION
Propagate AEO concepts from AEO Foundations agent to 4 existing marketing agents.

- SEO Specialist: AI crawler directives, token budget checklist, enriched AI Search section
- Content Creator: AI Consumption Readiness section with token budgets
- Reddit Community Builder: Reddit x AI Citations section
- AI Citation Strategist: Step 0 Foundation Prerequisite Check

## What does this PR do?

<!-- Brief description of the change -->

## Agent Information (if adding/modifying an agent)

- **Agent Name**:
- **Category**:
- **Specialty**:

## Checklist

- [ ] Follows the agent template structure from CONTRIBUTING.md
- [ ] Includes YAML frontmatter with `name`, `description`, `color`
- [ ] Has concrete code/template examples (for new agents)
- [ ] Tested in real scenarios
- [ ] Proofread and formatted correctly
