### PR TITLE
feat(scripts): add agents-file filtering and shared utils for install/convert

### DIFF
--- a/scripts/agents-to-install.example
+++ b/scripts/agents-to-install.example
@@ -1,0 +1,34 @@
+# This is just an example file for `--agents-file` flag of install.sh
+# Specify the `name` of the agents you want to install
+# If the specified name is not found, it will be omitted
+Agents Orchestrator
+AI Engineer
+API Tester
+Autonomous Optimization Architect
+Backend Architect
+Code Reviewer
+Database Optimizer
+DevOps Automator
+Document Generator
+Email Intelligence Engineer
+Embedded Firmware Engineer
+Feishu Integration Developer
+Frontend Developer
+Git Workflow Master
+Incident Response Commander
+Inclusive Visuals Specialist
+LSP/Index Engineer
+MCP Builder
+Mobile App Builder
+Rapid Prototyper
+Security Engineer
+Senior Developer
+Senior Project Manager
+Software Architect
+Technical Artist
+Technical Writer
+Trend Researcher
+UI Designer
+UX Architect
+UX Researcher
+Whimsy Injector

--- a/scripts/convert.sh
+++ b/scripts/convert.sh
@@ -29,79 +29,19 @@
 
 set -euo pipefail
 
-# --- Colour helpers ---
-if [[ -t 1 && -z "${NO_COLOR:-}" && "${TERM:-}" != "dumb" ]]; then
-  GREEN=$'\033[0;32m'; YELLOW=$'\033[1;33m'; RED=$'\033[0;31m'; BOLD=$'\033[1m'; RESET=$'\033[0m'
-else
-  GREEN=''; YELLOW=''; RED=''; BOLD=''; RESET=''
-fi
-
-info()    { printf "${GREEN}[OK]${RESET}  %s\n" "$*"; }
-warn()    { printf "${YELLOW}[!!]${RESET}  %s\n" "$*"; }
-error()   { printf "${RED}[ERR]${RESET} %s\n" "$*" >&2; }
-header()  { echo -e "\n${BOLD}$*${RESET}"; }
-
-# Progress bar: [=======>    ] 3/8 (tqdm-style)
-progress_bar() {
-  local current="$1" total="$2" width="${3:-20}" i filled empty
-  (( total > 0 )) || return
-  filled=$(( width * current / total ))
-  empty=$(( width - filled ))
-  printf "\r  ["
-  for (( i=0; i<filled; i++ )); do printf "="; done
-  if (( filled < width )); then printf ">"; (( empty-- )); fi
-  for (( i=0; i<empty; i++ )); do printf " "; done
-  printf "] %s/%s" "$current" "$total"
-  [[ -t 1 ]] || printf "\n"
-}
+# Source shared utilities (colors, functions, constants)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/utils.sh"
 
 # --- Paths ---
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 OUT_DIR="$REPO_ROOT/integrations"
 TODAY="$(date +%Y-%m-%d)"
-
-AGENT_DIRS=(
-  academic design engineering finance game-development marketing paid-media product project-management
-  sales spatial-computing specialized strategy support testing
-)
 
 # --- Usage ---
 usage() {
   sed -n '3,26p' "$0" | sed 's/^# \{0,1\}//'
   exit 0
-}
-
-# Default parallel job count (nproc on Linux; sysctl on macOS when nproc missing)
-parallel_jobs_default() {
-  local n
-  n=$(nproc 2>/dev/null) && [[ -n "$n" ]] && echo "$n" && return
-  n=$(sysctl -n hw.ncpu 2>/dev/null) && [[ -n "$n" ]] && echo "$n" && return
-  echo 4
-}
-
-# --- Frontmatter helpers ---
-
-# Extract a single field value from YAML frontmatter block.
-# Usage: get_field <field> <file>
-get_field() {
-  local field="$1" file="$2"
-  awk -v f="$field" '
-    /^---$/ { fm++; next }
-    fm == 1 && $0 ~ "^" f ": " { sub("^" f ": ", ""); print; exit }
-  ' "$file"
-}
-
-# Strip the leading frontmatter block and return only the body.
-# Usage: get_body <file>
-get_body() {
-  awk 'BEGIN{fm=0} /^---$/{fm++; next} fm>=2{print}' "$1"
-}
-
-# Convert a human-readable agent name to a lowercase kebab-case slug.
-# "Frontend Developer" → "frontend-developer"
-slugify() {
-  echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//'
 }
 
 # --- Per-tool converters ---
@@ -495,7 +435,7 @@ run_conversions() {
       [[ "$first_line" == "---" ]] || continue
 
       local name
-      name="$(get_field "name" "$file")"
+      name="$(get_agent_name "$file")"
       [[ -n "$name" ]] || continue
 
       case "$tool" in
@@ -532,7 +472,7 @@ main() {
       --parallel) use_parallel=true; shift ;;
       --jobs)     parallel_jobs="${2:?'--jobs requires a value'}"; shift 2 ;;
       --help|-h)  usage ;;
-      *)          error "Unknown option: $1"; usage ;;
+      *)          err "Unknown option: $1"; usage ;;
     esac
   done
 
@@ -540,7 +480,7 @@ main() {
   local valid=false
   for t in "${valid_tools[@]}"; do [[ "$t" == "$tool" ]] && valid=true && break; done
   if ! $valid; then
-    error "Unknown tool '$tool'. Valid: ${valid_tools[*]}"
+    err "Unknown tool '$tool'. Valid: ${valid_tools[*]}"
     exit 1
   fi
 
@@ -550,7 +490,7 @@ main() {
   echo "  Tool:   $tool"
   echo "  Date:   $TODAY"
   if $use_parallel && [[ "$tool" == "all" ]]; then
-    info "Parallel mode: output buffered so each tool's output stays together."
+    ok "Parallel mode: output buffered so each tool's output stays together."
   fi
 
   local tools_to_run=()
@@ -569,7 +509,7 @@ main() {
     local parallel_tools=(antigravity gemini-cli opencode cursor openclaw qwen)
     local parallel_out_dir
     parallel_out_dir="$(mktemp -d)"
-    info "Converting: ${#parallel_tools[@]}/${n_tools} tools in parallel (output buffered per tool)..."
+    ok "Converting: ${#parallel_tools[@]}/${n_tools} tools in parallel (output buffered per tool)..."
     export AGENCY_CONVERT_OUT_DIR="$parallel_out_dir"
     export AGENCY_CONVERT_SCRIPT="$SCRIPT_DIR/convert.sh"
     export AGENCY_CONVERT_OUT="$OUT_DIR"
@@ -586,7 +526,7 @@ main() {
       local count
       count="$(run_conversions "$t")"
       total=$(( total + count ))
-      info "Converted $count agents for $t"
+      ok "Converted $count agents for $t"
       (( idx++ )) || true
     done
   else
@@ -609,10 +549,10 @@ main() {
   "version": "1.0.0"
 }
 HEREDOC
-        info "Wrote gemini-extension.json"
+        ok "Wrote gemini-extension.json"
       fi
 
-      info "Converted $count agents for $t"
+      ok "Converted $count agents for $t"
     done
   fi
 
@@ -620,19 +560,19 @@ HEREDOC
   if [[ "$tool" == "all" || "$tool" == "aider" ]]; then
     mkdir -p "$OUT_DIR/aider"
     cp "$AIDER_TMP" "$OUT_DIR/aider/CONVENTIONS.md"
-    info "Wrote integrations/aider/CONVENTIONS.md"
+    ok "Wrote integrations/aider/CONVENTIONS.md"
   fi
   if [[ "$tool" == "all" || "$tool" == "windsurf" ]]; then
     mkdir -p "$OUT_DIR/windsurf"
     cp "$WINDSURF_TMP" "$OUT_DIR/windsurf/.windsurfrules"
-    info "Wrote integrations/windsurf/.windsurfrules"
+    ok "Wrote integrations/windsurf/.windsurfrules"
   fi
 
   echo ""
   if $use_parallel && [[ "$tool" == "all" ]]; then
-    info "Done. $n_tools tools (parallel; total conversions not aggregated)."
+    ok "Done. $n_tools tools (parallel; total conversions not aggregated)."
   else
-    info "Done. Total conversions: $total"
+    ok "Done. Total conversions: $total."
   fi
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -23,52 +23,22 @@
 #   all          -- Install for all detected tools (default)
 #
 # Flags:
-#   --tool <name>     Install only the specified tool
-#   --interactive     Show interactive selector (default when run in a terminal)
-#   --no-interactive  Skip interactive selector, install all detected tools
-#   --parallel        Run install for each selected tool in parallel (output order may vary)
-#   --jobs N          Max parallel jobs when using --parallel (default: nproc or 4)
-#   --help            Show this help
+#   --tool <name>           Install only the specified tool
+#   --interactive           Show interactive selector (default when run in a terminal)
+#   --no-interactive        Skip interactive selector, install all detected tools
+#   --parallel              Run install for each selected tool in parallel (output order may vary)
+#   --jobs N                Max parallel jobs when using --parallel (default: nproc or 4)
+#   --agents-file <path>    Filter agents by name (one per line); if not found, install all;
+#   --help                  Show this help
 #
 # Platform support:
 #   Linux, macOS (requires bash 3.2+), Windows Git Bash / WSL
 
 set -euo pipefail
 
-# ---------------------------------------------------------------------------
-# Colours -- only when stdout supports color
-# ---------------------------------------------------------------------------
-if [[ -t 1 && -z "${NO_COLOR:-}" && "${TERM:-}" != "dumb" ]]; then
-  C_GREEN=$'\033[0;32m'
-  C_YELLOW=$'\033[1;33m'
-  C_RED=$'\033[0;31m'
-  C_CYAN=$'\033[0;36m'
-  C_BOLD=$'\033[1m'
-  C_DIM=$'\033[2m'
-  C_RESET=$'\033[0m'
-else
-  C_GREEN=''; C_YELLOW=''; C_RED=''; C_CYAN=''; C_BOLD=''; C_DIM=''; C_RESET=''
-fi
-
-ok()     { printf "${C_GREEN}[OK]${C_RESET}  %s\n" "$*"; }
-warn()   { printf "${C_YELLOW}[!!]${C_RESET}  %s\n" "$*"; }
-err()    { printf "${C_RED}[ERR]${C_RESET} %s\n" "$*" >&2; }
-header() { printf "\n${C_BOLD}%s${C_RESET}\n" "$*"; }
-dim()    { printf "${C_DIM}%s${C_RESET}\n" "$*"; }
-
-# Progress bar: [=======>    ] 3/8 (tqdm-style)
-progress_bar() {
-  local current="$1" total="$2" width="${3:-20}" i filled empty
-  (( total > 0 )) || return
-  filled=$(( width * current / total ))
-  empty=$(( width - filled ))
-  printf "\r  ["
-  for (( i=0; i<filled; i++ )); do printf "="; done
-  if (( filled < width )); then printf ">"; (( empty-- )); fi
-  for (( i=0; i<empty; i++ )); do printf " "; done
-  printf "] %s/%s" "$current" "$total"
-  [[ -t 1 ]] || printf "\n"
-}
+# Source shared utilities (colors, functions, constants)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/utils.sh"
 
 # ---------------------------------------------------------------------------
 # Box drawing -- pure ASCII, fixed 52-char wide
@@ -94,36 +64,18 @@ box_row() {
 }
 box_blank() { printf "  |%*s|\n" $BOX_INNER ''; }
 
+usage() {
+  head -32 "$0" | tail -n +2
+  exit 0
+}
+
 # ---------------------------------------------------------------------------
 # Paths
 # ---------------------------------------------------------------------------
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 INTEGRATIONS="$REPO_ROOT/integrations"
 
 ALL_TOOLS=(claude-code copilot antigravity gemini-cli opencode openclaw cursor aider windsurf qwen kimi)
-
-# Standard agent category directories (keep sorted, sync with convert.sh / lint-agents.sh)
-AGENT_DIRS=(
-  academic design engineering finance game-development marketing paid-media product project-management
-  sales spatial-computing specialized strategy support testing
-)
-
-# ---------------------------------------------------------------------------
-# Usage
-# ---------------------------------------------------------------------------
-usage() {
-  sed -n '3,32p' "$0" | sed 's/^# \{0,1\}//'
-  exit 0
-}
-
-# Default parallel job count (nproc on Linux; sysctl on macOS when nproc missing)
-parallel_jobs_default() {
-  local n
-  n=$(nproc 2>/dev/null) && [[ -n "$n" ]] && echo "$n" && return
-  n=$(sysctl -n hw.ncpu 2>/dev/null) && [[ -n "$n" ]] && echo "$n" && return
-  echo 4
-}
 
 # ---------------------------------------------------------------------------
 # Preflight
@@ -306,12 +258,14 @@ install_claude_code() {
   local dest="${HOME}/.claude/agents"
   local count=0
   mkdir -p "$dest"
-  local dir f first_line
+  local dir f first_line name
   for dir in "${AGENT_DIRS[@]}"; do
     [[ -d "$REPO_ROOT/$dir" ]] || continue
     while IFS= read -r -d '' f; do
       first_line="$(head -1 "$f")"
       [[ "$first_line" == "---" ]] || continue
+      name="$(get_agent_name "$f")"
+      name_in_filter "$name" || continue
       cp "$f" "$dest/"
       (( count++ )) || true
     done < <(find "$REPO_ROOT/$dir" -name "*.md" -type f -print0)
@@ -324,12 +278,14 @@ install_copilot() {
   local dest_copilot="${HOME}/.copilot/agents"
   local count=0
   mkdir -p "$dest_github" "$dest_copilot"
-  local dir f first_line
+  local dir f first_line name
   for dir in "${AGENT_DIRS[@]}"; do
     [[ -d "$REPO_ROOT/$dir" ]] || continue
     while IFS= read -r -d '' f; do
       first_line="$(head -1 "$f")"
       [[ "$first_line" == "---" ]] || continue
+      name="$(get_agent_name "$f")"
+      name_in_filter "$name" || continue
       cp "$f" "$dest_github/"
       cp "$f" "$dest_copilot/"
       (( count++ )) || true
@@ -387,10 +343,12 @@ install_opencode() {
   local search_dir="$src"
   [[ -d "$src/agents" ]] && search_dir="$src/agents"
   mkdir -p "$dest"
-  local f
+  local f name
   while IFS= read -r -d '' f; do
     local base; base="$(basename "$f")"
     [[ "$base" == "README.md" ]] && continue
+    name="$(get_agent_name "$f")"
+    name_in_filter "$name" || continue
     cp "$f" "$dest/"; (( count++ )) || true
   done < <(find "$search_dir" -maxdepth 1 -name "*.md" -print0)
   if (( count == 0 )); then
@@ -442,8 +400,10 @@ install_cursor() {
   local count=0
   [[ -d "$src" ]] || { err "integrations/cursor missing. Run convert.sh first."; return 1; }
   mkdir -p "$dest"
-  local f
+  local f fname
   while IFS= read -r -d '' f; do
+    fname="$(basename "$f" .mdc)"
+    slug_in_filter "$fname" || continue
     cp "$f" "$dest/"; (( count++ )) || true
   done < <(find "$src" -maxdepth 1 -name "*.mdc" -print0)
   ok "Cursor: $count rules -> $dest"
@@ -485,8 +445,10 @@ install_qwen() {
 
   mkdir -p "$dest"
 
-  local f
+  local f fname
   while IFS= read -r -d '' f; do
+    fname="$(basename "$f" .md)"
+    slug_in_filter "$fname" || continue
     cp "$f" "$dest/"
     (( count++ )) || true
   done < <(find "$src" -maxdepth 1 -name "*.md" -print0)
@@ -539,6 +501,7 @@ install_tool() {
 # ---------------------------------------------------------------------------
 main() {
   local tool="all"
+  local agents_file=""
   local interactive_mode="auto"
   local use_parallel=false
   local parallel_jobs
@@ -547,6 +510,7 @@ main() {
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --tool)            tool="${2:?'--tool requires a value'}"; shift 2; interactive_mode="no" ;;
+      --agents-file)     agents_file="${2:?'--agents-file requires a value'}"; shift 2 ;;
       --interactive)     interactive_mode="yes"; shift ;;
       --no-interactive)  interactive_mode="no"; shift ;;
       --parallel)        use_parallel=true; shift ;;
@@ -557,6 +521,7 @@ main() {
   done
 
   check_integrations
+  load_agents_filter "$agents_file"
 
   # Validate explicit tool
   if [[ "$tool" != "all" ]]; then
@@ -633,7 +598,8 @@ main() {
     install_out_dir="$(mktemp -d)"
     export AGENCY_INSTALL_OUT_DIR="$install_out_dir"
     export AGENCY_INSTALL_SCRIPT="$SCRIPT_DIR/install.sh"
-    printf '%s\n' "${SELECTED_TOOLS[@]}" | xargs -P "$parallel_jobs" -I {} sh -c 'AGENCY_INSTALL_WORKER=1 "$AGENCY_INSTALL_SCRIPT" --tool "{}" --no-interactive > "$AGENCY_INSTALL_OUT_DIR/{}" 2>&1'
+    export AGENCY_AGENTS_FILE="$agents_file"
+    printf '%s\n' "${SELECTED_TOOLS[@]}" | xargs -P "$parallel_jobs" -I {} sh -c 'AGENCY_INSTALL_WORKER=1 "$AGENCY_INSTALL_SCRIPT" --tool "{}" --no-interactive --agents-file "$AGENCY_AGENTS_FILE" > "$AGENCY_INSTALL_OUT_DIR/{}" 2>&1'
     for t in "${SELECTED_TOOLS[@]}"; do
       [[ -f "$install_out_dir/$t" ]] && cat "$install_out_dir/$t"
     done

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+#
+# utils.sh -- Shared utility functions for install.sh and convert.sh
+#
+# This file contains common functions, color definitions, and helper utilities
+# used by both installation and conversion scripts. Source this file first in
+# convert.sh and install.sh.
+#
+# Prevent duplicate sourcing
+if [[ -n "${AGENCY_UTILS_LOADED:-}" ]]; then
+  return
+fi
+readonly AGENCY_UTILS_LOADED=1
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Colours -- only when stdout supports color
+# ---------------------------------------------------------------------------
+if [[ -t 1 && -z "${NO_COLOR:-}" && "${TERM:-}" != "dumb" ]]; then
+  C_GREEN=$'\033[0;32m'
+  C_YELLOW=$'\033[1;33m'
+  C_RED=$'\033[0;31m'
+  C_CYAN=$'\033[0;36m'
+  C_BOLD=$'\033[1m'
+  C_DIM=$'\033[2m'
+  C_RESET=$'\033[0m'
+else
+  C_GREEN=''; C_YELLOW=''; C_RED=''; C_CYAN=''; C_BOLD=''; C_DIM=''; C_RESET=''
+fi
+
+# ---------------------------------------------------------------------------
+# Output functions
+# ---------------------------------------------------------------------------
+ok()     { printf "${C_GREEN}[OK]${C_RESET}  %s\n" "$*"; }
+warn()   { printf "${C_YELLOW}[!!]${C_RESET}  %s\n" "$*"; }
+err()    { printf "${C_RED}[ERR]${C_RESET} %s\n" "$*" >&2; }
+header() { printf "\n${C_BOLD}%s${C_RESET}\n" "$*"; }
+dim()    { printf "${C_DIM}%s${C_RESET}\n" "$*"; }
+
+# ---------------------------------------------------------------------------
+# Progress bar: [=======>    ] 3/8 (tqdm-style)
+# ---------------------------------------------------------------------------
+progress_bar() {
+  local current="$1" total="$2" width="${3:-20}" i filled empty
+  (( total > 0 )) || return
+  filled=$(( width * current / total ))
+  empty=$(( width - filled ))
+  printf "\r  ["
+  for (( i=0; i<filled; i++ )); do printf "="; done
+  if (( filled < width )); then printf ">"; (( empty-- )); fi
+  for (( i=0; i<empty; i++ )); do printf " "; done
+  printf "] %s/%s" "$current" "$total"
+  [[ -t 1 ]] || printf "\n"
+}
+
+# ---------------------------------------------------------------------------
+# Paths and constants
+# ---------------------------------------------------------------------------
+
+# Standard agent category directories (keep sorted, sync with convert.sh / install.sh / lint-agents.sh)
+AGENT_DIRS=(
+  academic design engineering finance game-development marketing paid-media product project-management
+  sales spatial-computing specialized strategy support testing
+)
+
+# Agents filter list (populated by load_agents_filter)
+AGENTS_FILTER=()
+
+# ---------------------------------------------------------------------------
+# Default parallel job count (nproc on Linux; sysctl on macOS when nproc missing)
+# ---------------------------------------------------------------------------
+parallel_jobs_default() {
+  local n
+  n=$(nproc 2>/dev/null) && [[ -n "$n" ]] && echo "$n" && return
+  n=$(sysctl -n hw.ncpu 2>/dev/null) && [[ -n "$n" ]] && echo "$n" && return
+  echo 4
+}
+
+# ---------------------------------------------------------------------------
+# Frontmatter helpers
+# ---------------------------------------------------------------------------
+
+# Extract a single field value from YAML frontmatter block.
+# Usage: get_field <field> <file>
+get_field() {
+  local field="$1" file="$2"
+  awk -v f="$field" '
+    /^---$/ { fm++; next }
+    fm == 1 && $0 ~ "^" f ": " { sub("^" f ": ", ""); print; exit }
+  ' "$file"
+}
+
+# Strip the leading frontmatter block and return only the body.
+# Usage: get_body <file>
+get_body() {
+  awk 'BEGIN{fm=0} /^---$/{fm++; next} fm>=2{print}' "$1"
+}
+
+# Extract the 'name' field from an agent file's frontmatter.
+# Usage: get_agent_name <file>
+get_agent_name() {
+  get_field "name" "$1"
+}
+
+# Convert a human-readable agent name to a lowercase kebab-case slug.
+# "Frontend Developer" → "frontend-developer"
+slugify() {
+  echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//'
+}
+
+# ---------------------------------------------------------------------------
+# Agents filter functions
+# ---------------------------------------------------------------------------
+
+# Load agents filter list from a file.
+# Each line should contain an agent name (frontmatter 'name' field value).
+# Ignores empty lines and lines starting with '#'.
+# If file doesn't exist, warns and returns (doesn't filter).
+# Usage: load_agents_filter <path>
+load_agents_filter() {
+  local file="$1"
+
+  # Clear any previous filter
+  AGENTS_FILTER=()
+
+  # If no file specified, no filtering
+  [[ -z "$file" ]] && return 0
+
+  # If file doesn't exist, warn and continue (no filtering)
+  if [[ ! -f "$file" ]]; then
+    warn "agents-file '$file' not found, installing all agents."
+    return 0
+  fi
+
+  # Read file line by line
+  local line
+  while IFS= read -r line; do
+    # Trim leading/trailing whitespace
+    line="$(echo "$line" | xargs)"
+    # Skip empty lines and comments
+    [[ -z "$line" ]] && continue
+    [[ "$line" =~ ^# ]] && continue
+    # Add to filter array
+    AGENTS_FILTER+=("$line")
+  done < "$file"
+
+  ok "Loaded ${#AGENTS_FILTER[@]} agent names from filter list."
+}
+
+# Check if an agent name is in the filter list.
+# If filter is empty, returns true (0) — allows all agents.
+# Usage: name_in_filter <name>
+name_in_filter() {
+  local name="$1"
+
+  # If no filter is set, allow everything
+  [[ ${#AGENTS_FILTER[@]} -eq 0 ]] && return 0
+
+  # Check if name matches any entry in filter
+  local entry
+  for entry in "${AGENTS_FILTER[@]}"; do
+    if [[ "$entry" == "$name" ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+# Check if a slug is in the filter list (by comparing against slugified agent names).
+# If filter is empty, returns true (0) — allows all agents.
+# Usage: slug_in_filter <slug>
+slug_in_filter() {
+  local slug="$1"
+
+  # If no filter is set, allow everything
+  [[ ${#AGENTS_FILTER[@]} -eq 0 ]] && return 0
+
+  # Check if slug matches any slugified entry in filter
+  local entry slugified
+  for entry in "${AGENTS_FILTER[@]}"; do
+    slugified="$(slugify "$entry")"
+    if [[ "$slugified" == "$slug" ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}


### PR DESCRIPTION
## Summary

This PR adds selective agent installation support via `--agents-file` and extracts shared shell utilities into a reusable `utils.sh`.

## What changed

- Added `--agents-file` option in `scripts/install.sh` to install only selected agents by agent name.
- Added shared helpers in `scripts/utils.sh`:
  - unified color/output functions
  - progress and parallel job helpers
  - frontmatter parsing and slug helpers
  - agent filter loading and matching helpers
- Updated `scripts/convert.sh` and `scripts/install.sh` to source shared utilities from `utils.sh`.
- Added `scripts/agents-to-install.example` as a sample input file.

## Behavior

- Agents file format: one agent name per line.
- Empty lines and lines starting with `#` are ignored.
- If the file does not exist, installation continues with a warning and falls back to install all.
- Filtering is applied for:
  - name-based tools: `claude-code`, `copilot`, `opencode`
  - slug-based tools: `qwen`, `cursor`
- Parallel mode passes through the same `agents-file` selection.

## Validation

- Bash syntax check passed for:
  - `scripts/install.sh`
  - `scripts/convert.sh`
  - `scripts/utils.sh`
- Manual checks:
  - missing agents file warns and continues
  - valid agents file installs only listed agents
  - comments/blank lines in agents file are ignored

## Backward compatibility

- Default behavior is unchanged when `--agents-file` is not provided.

## Checklist

- [√] Follows the agent template structure from CONTRIBUTING.md
- [×][NO_NEED] Includes YAML frontmatter with `name`, `description`, `color`
- [×][NO_NEED] Has concrete code/template examples (for new agents)
- [√] Tested in real scenarios
- [√] Proofread and formatted correctly
