### PR TITLE
Add .claude-plugin/plugin.json with agents declaration

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "agency-agents",
+  "description": "A complete AI agency — 185 specialized expert agents covering engineering, design, marketing, game development, finance, sales, testing, and more, each with distinct personality and domain expertise.",
+  "author": {
+    "name": "msitarzewski",
+    "email": ""
+  },
+  "homepage": "https://github.com/msitarzewski/agency-agents",
+  "repository": "https://github.com/msitarzewski/agency-agents",
+  "license": "MIT",
+  "agents": "./agents/"
+}


### PR DESCRIPTION

Problem: Agents installed via the Claude Code plugin system fail with Agent type 'agency-agents:corporate-training-designer' not found because .claude-plugin/plugin.json is missing the "agents":
 "./agents/" declaration — so the harness never registers the agent files as callable types.
 
Fix: Add .claude-plugin/plugin.json with the "agents" key. The plugin installer uses this file as the manifest when present, so all 185 agents get properly registered on install.
