### PR TITLE
refactor(install): make counter increments safe under set -e

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,10 @@ Thumbs.db
 *.sublime-project
 *.sublime-workspace
 
+# AI assistant local state (keep team-shared settings.json / agents / skills)
+.claude/settings.local.json
+.claude/.credentials.json
+
 # Node.js (if adding web tools later)
 node_modules/
 npm-debug.log*

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -36,6 +36,17 @@
 set -euo pipefail
 
 # ---------------------------------------------------------------------------
+# Counter increment under 'set -e'
+# ---------------------------------------------------------------------------
+# Use ': $((var++))' to increment counters, NOT '(( var++ ))'.
+#
+# '(( var++ ))' returns the *pre-increment* value as its exit status. When
+# var is 0 the command exits with status 1 and 'set -e' aborts the script
+# on the first increment. ': $((var++))' wraps the arithmetic in the ':'
+# (true) builtin, so the exit status is always 0 -- safe under errexit.
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
 # Colours -- only when stdout supports color
 # ---------------------------------------------------------------------------
 if [[ -t 1 && -z "${NO_COLOR:-}" && "${TERM:-}" != "dumb" ]]; then
@@ -230,7 +241,7 @@ interactive_select() {
         chk="${C_DIM}[ ]${C_RESET}"
       fi
       printf "  %s  %s)  %s  %s\n" "$chk" "$num" "$dot" "$label"
-      (( i++ )) || true
+      : $((i++))
     done
 
     # --- controls ---
@@ -294,7 +305,7 @@ interactive_select() {
   local i=0
   for t in "${ALL_TOOLS[@]}"; do
     [[ "${selected[$i]}" == "1" ]] && SELECTED_TOOLS+=("$t")
-    (( i++ )) || true
+    : $((i++))
   done
 }
 
@@ -313,7 +324,7 @@ install_claude_code() {
       first_line="$(head -1 "$f")"
       [[ "$first_line" == "---" ]] || continue
       cp "$f" "$dest/"
-      (( count++ )) || true
+      : $((count++))
     done < <(find "$REPO_ROOT/$dir" -name "*.md" -type f -print0)
   done
   ok "Claude Code: $count agents -> $dest"
@@ -332,7 +343,7 @@ install_copilot() {
       [[ "$first_line" == "---" ]] || continue
       cp "$f" "$dest_github/"
       cp "$f" "$dest_copilot/"
-      (( count++ )) || true
+      : $((count++))
     done < <(find "$REPO_ROOT/$dir" -name "*.md" -type f -print0)
   done
   ok "Copilot: $count agents -> $dest_github"
@@ -352,7 +363,7 @@ install_antigravity() {
     local name; name="$(basename "$d")"
     mkdir -p "$dest/$name"
     cp "$d/SKILL.md" "$dest/$name/SKILL.md"
-    (( count++ )) || true
+    : $((count++))
   done < <(find "$src" -mindepth 1 -maxdepth 1 -type d -print0)
   ok "Antigravity: $count skills -> $dest"
 }
@@ -373,7 +384,7 @@ install_gemini_cli() {
     local name; name="$(basename "$d")"
     mkdir -p "$dest/skills/$name"
     cp "$d/SKILL.md" "$dest/skills/$name/SKILL.md"
-    (( count++ )) || true
+    : $((count++))
   done < <(find "$skills_dir" -mindepth 1 -maxdepth 1 -type d -print0)
   ok "Gemini CLI: $count skills -> $dest"
 }
@@ -391,7 +402,7 @@ install_opencode() {
   while IFS= read -r -d '' f; do
     local base; base="$(basename "$f")"
     [[ "$base" == "README.md" ]] && continue
-    cp "$f" "$dest/"; (( count++ )) || true
+    cp "$f" "$dest/"; : $((count++))
   done < <(find "$search_dir" -maxdepth 1 -name "*.md" -print0)
   if (( count == 0 )); then
     warn "OpenCode: no agent files found in $search_dir. Run convert.sh --tool opencode first."
@@ -424,7 +435,7 @@ install_openclaw() {
         openclaw agents add "$name" --workspace "$dest/$name" --non-interactive || true
       fi
     fi
-    (( count++ )) || true
+    : $((count++))
   done < <(find "$src" -mindepth 1 -maxdepth 1 -type d -print0)
   if (( count == 0 )); then
     err "integrations/openclaw contains no generated workspaces. Run ./scripts/convert.sh --tool openclaw first."
@@ -444,7 +455,7 @@ install_cursor() {
   mkdir -p "$dest"
   local f
   while IFS= read -r -d '' f; do
-    cp "$f" "$dest/"; (( count++ )) || true
+    cp "$f" "$dest/"; : $((count++))
   done < <(find "$src" -maxdepth 1 -name "*.mdc" -print0)
   ok "Cursor: $count rules -> $dest"
   warn "Cursor: project-scoped. Run from your project root to install there."
@@ -488,7 +499,7 @@ install_qwen() {
   local f
   while IFS= read -r -d '' f; do
     cp "$f" "$dest/"
-    (( count++ )) || true
+    : $((count++))
   done < <(find "$src" -maxdepth 1 -name "*.md" -print0)
 
   ok "Qwen Code: installed $count agents to $dest"
@@ -511,7 +522,7 @@ install_kimi() {
     mkdir -p "$dest/$name"
     cp "$d/agent.yaml" "$dest/$name/agent.yaml"
     cp "$d/system.md" "$dest/$name/system.md"
-    (( count++ )) || true
+    : $((count++))
   done < <(find "$src" -mindepth 1 -maxdepth 1 -type d -print0)
 
   ok "Kimi Code: installed $count agents to $dest"
@@ -641,12 +652,12 @@ main() {
     installed=$n_selected
   else
     for t in "${SELECTED_TOOLS[@]}"; do
-      (( i++ )) || true
+      : $((i++))
       progress_bar "$i" "$n_selected"
       printf "\n"
       printf "  ${C_DIM}[%s/%s]${C_RESET} %s\n" "$i" "$n_selected" "$t"
       install_tool "$t"
-      (( installed++ )) || true
+      : $((installed++))
     done
   fi
 


### PR DESCRIPTION
## What does this PR do?

Two small maintenance improvements to `scripts/install.sh` and `.gitignore`. **No agent files touched.**

### 1. Replace `(( var++ )) || true` with `: $((var++))` (13 sites)

`scripts/install.sh` already runs under `set -euo pipefail`, but it uses the brittle pattern `(( count++ )) || true` to dodge a known interaction:

> `(( var++ ))` returns the **pre-increment** value as its exit status. When `var == 0`, the first increment exits with status 1 and `set -e` aborts the script. The `|| true` workaround masked the hazard but obscured intent — and contributors who haven't hit this trap would reasonably read `|| true` as redundant and remove it, reintroducing the bug.

The fix replaces all 13 occurrences with `: $((var++))`. The `:` (true) builtin guarantees exit status 0, so the arithmetic is safe under `errexit` and self-explanatory.

A header comment near `set -euo pipefail` documents the convention so future contributors don't reintroduce `(( var++ ))`.

**Verified:**
- `bash -n scripts/install.sh` — syntax OK
- `bash scripts/install.sh --help` — exits 0, output unchanged

### 2. Ignore Claude Code local state

`.claude/settings.local.json` (per-machine permission cache) and `.claude/.credentials.json` (machine-local auth) are generated by Claude Code when contributors use it on this repo. They should never be committed.

The rule is intentionally **narrow** — `.claude/settings.json`, `.claude/agents/`, `.claude/skills/`, and `.claude/hooks/` remain trackable so the repo can adopt team-wide Claude defaults later if desired.

## Agent Information (if adding/modifying an agent)

N/A — script and config only, no agent files touched.

## Checklist

- [x] Follows the agent template structure from CONTRIBUTING.md *(N/A — no agents)*
- [x] Includes YAML frontmatter with `name`, `description`, `color` *(N/A — no agents)*
- [x] Has concrete code/template examples (for new agents) *(N/A — no agents)*
- [x] Tested in real scenarios — `bash -n` + `--help` smoke test pass
- [x] Proofread and formatted correctly

## Commits

1. `refactor(install): make counter increments safe under set -e` — the 13-site replacement + explanatory comment
2. `chore: ignore Claude Code local state (settings.local.json, credentials)` — the `.gitignore` entry