### PR TITLE
refactor(install): replace usage() magic line numbers with sentinels

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 #
+# --- USAGE-START ---  (sentinel for usage(); do not remove)
 # install.sh -- Install The Agency agents into your local agentic tool(s).
 #
 # Reads converted files from integrations/ and copies them to the appropriate
@@ -30,6 +31,7 @@
 #   --jobs N          Max parallel jobs when using --parallel (default: nproc or 4)
 #   --help            Show this help
 #
+# --- USAGE-END ---  (sentinel for usage(); do not remove)
 # Platform support:
 #   Linux, macOS (requires bash 3.2+), Windows Git Bash / WSL
 
@@ -113,7 +115,12 @@ AGENT_DIRS=(
 # Usage
 # ---------------------------------------------------------------------------
 usage() {
-  sed -n '3,32p' "$0" | sed 's/^# \{0,1\}//'
+  # Extract everything between the USAGE-START / USAGE-END sentinels
+  # (excluding the sentinel lines themselves) and strip the leading "# ".
+  # Using sentinels instead of hard-coded line numbers means adding lines
+  # to the header comment block won't silently break --help output.
+  sed -n '/^# --- USAGE-START ---/,/^# --- USAGE-END ---/p' "$0" \
+    | sed -e '1d;$d' -e 's/^# \{0,1\}//'
   exit 0
 }
 


### PR DESCRIPTION
## What does this PR do?

A small maintenance improvement to `scripts/install.sh`. **No agent files touched.** Independent of #505.

### The problem

`usage()` extracts the help text from the file's header comment block with a hard-coded line range:

```bash
usage() {
  sed -n '3,32p' "$0" | sed 's/^# \{0,1\}//'
  exit 0
}
```

Adding a single line to the header comment silently shifts the range. The script keeps running, but the help output:
- gets a line truncated off the bottom (added line at the top), or
- gains a stray line from the next section (added line at the bottom), or
- starts mid-sentence (line removed at the top)

There is no syntax error and no test catches it -- a contributor can ship the regression without noticing.

### The fix

Replace the magic line numbers with sentinel comments at the boundaries of the header block:

```
# --- USAGE-START ---  (sentinel for usage(); do not remove)
# install.sh -- ...
# ...
# --- USAGE-END ---  (sentinel for usage(); do not remove)
```

`usage()` extracts the range between the sentinels and strips the boundary lines:

```bash
usage() {
  sed -n '/^# --- USAGE-START ---/,/^# --- USAGE-END ---/p' \"\$0\" \
    | sed -e '1d;\$d' -e 's/^# \{0,1\}//'
  exit 0
}
```

Now the help block can grow or shrink freely without touching the function.

### Verification

```bash
diff <(bash <(git show upstream/main:scripts/install.sh) --help) \
     <(bash scripts/install.sh --help)
```

Output: empty -- byte-identical to upstream.

## Agent Information (if adding/modifying an agent)

N/A -- script only, no agent files touched.

## Checklist

- [x] Tested in real scenarios -- byte-identical help output verified against upstream
- [x] Proofread and formatted correctly

## Relation to other PRs

Independent of #505 (counter increment safety). Both touch `install.sh` but in non-overlapping regions, so they will not conflict.