### PR TITLE
fix(ci): safely handle filenames with spaces/metacharacters in lint workflow

### DIFF
--- a/.github/workflows/lint-agents.yml
+++ b/.github/workflows/lint-agents.yml
@@ -52,4 +52,7 @@ jobs:
           CHANGED_FILES: ${{ steps.changed.outputs.files }}
         run: |
           chmod +x scripts/lint-agents.sh
-          ./scripts/lint-agents.sh $CHANGED_FILES
+          while IFS= read -r file; do
+            [ -n "$file" ] && files+=("$file")
+          done <<< "$CHANGED_FILES"
+          ./scripts/lint-agents.sh "${files[@]}"


### PR DESCRIPTION
The unquoted `$CHANGED_FILES` in the lint workflow is subject to word splitting and globbing by the shell.

If a PR adds a file with spaces in its name (e.g. `specialized/my agent.md`), the lint step breaks — it splits the filename into separate arguments. Worse, filenames containing glob characters (`*`, `?`, `[`) could match unintended files.

Fix: read the multi-line file list line-by-line into an array, then pass each element as a properly quoted argument to the linter.