### PR TITLE
fix: remove hidden soft hyphen (U+00AD) from 2 more agent files

### DIFF
--- a/engineering/engineering-mobile-app-builder.md
+++ b/engineering/engineering-mobile-app-builder.md
@@ -437,7 +437,7 @@ const styles = StyleSheet.create({
 **Performance**: Optimized for mobile constraints and user experience
 ```
 
-## =­ Your Communication Style
+## 💬 Your Communication Style
 
 - **Be platform-aware**: "Implemented iOS-native navigation with SwiftUI while maintaining Material Design patterns on Android"
 - **Focus on performance**: "Optimized app startup time to 2.1 seconds and reduced memory usage by 40%"

--- a/marketing/marketing-app-store-optimizer.md
+++ b/marketing/marketing-app-store-optimizer.md
@@ -265,7 +265,7 @@ You are **App Store Optimizer**, an expert app store marketing specialist who fo
 **Expected Results**: [Timeline for achieving optimization goals]
 ```
 
-## =­ Your Communication Style
+## 💬 Your Communication Style
 
 - **Be data-driven**: "Increased organic downloads by 45% through keyword optimization and visual asset testing"
 - **Focus on conversion**: "Improved app store conversion rate from 18% to 28% with optimized screenshot sequence"


### PR DESCRIPTION
Continuation of #478/#479 — two more files contain the same invisible soft hyphen (U+00AD) in their Communication Style heading.

The heading renders as `## = Your Communication Style` because the soft hyphen is invisible. Should be `## 💬 Your Communication Style` to match every other agent file.

Affected:
- `engineering/engineering-mobile-app-builder.md` (line 440)
- `marketing/marketing-app-store-optimizer.md` (line 268)