### PR TITLE
fix: Workflow Architect emoji renders as raw Unicode escape

### DIFF
--- a/specialized/specialized-workflow-architect.md
+++ b/specialized/specialized-workflow-architect.md
@@ -2,7 +2,7 @@
 name: Workflow Architect
 description: Workflow design specialist who maps complete workflow trees for every system, user journey, and agent interaction — covering happy paths, all branch conditions, failure modes, recovery paths, handoff contracts, and observable states to produce build-ready specs that agents can implement against and QA can test against.
 color: orange
-emoji: "\U0001F5FA\uFE0F"
+emoji: "🗺️"
 vibe: Every path the system can take — mapped, named, and specified before a single line is written.
 ---
 


### PR DESCRIPTION
## Summary

The Workflow Architect's emoji field uses a Python-style Unicode escape (`\U0001F5FA\uFE0F`) instead of the actual character. This causes downstream consumers that parse the YAML frontmatter to display the raw escape string instead of the 🗺️ emoji.

**Before:** `emoji: "\U0001F5FA\uFE0F"` → renders as `\U0001F5FA\uFE0F`
**After:** `emoji: "🗺️"` → renders as 🗺️

## Context

We use your personality library to power [Lolabot Factory](https://factory.lolabots.com) — a web app where users pick an agent personality, equip it with skills, and get a one-liner install command to deploy their AI employee in 60 seconds. Your 169 agents across 15 divisions are the backbone of the entire catalog.

We spotted this as the only agent with a broken emoji while building out the browse experience at [factory.lolabots.com/browse](https://factory.lolabots.com/browse). All other agents render perfectly.

Thanks for building such an incredible resource — it's made it possible for us to ship a full agent factory on top of it. Truly great work!