### PR TITLE
Add native Codex agents integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Each agent file contains:
 
 Browse the agents below and copy/adapt the ones you need!
 
-### Option 3: Use with Other Tools (GitHub Copilot, Antigravity, Gemini CLI, OpenCode, OpenClaw, Cursor, Aider, Windsurf, Kimi Code)
+### Option 3: Use with Other Tools (Codex, GitHub Copilot, Antigravity, Gemini CLI, OpenCode, OpenClaw, Cursor, Aider, Windsurf, Kimi Code)
 
 ```bash
 # Step 1 -- generate integration files for all supported tools
@@ -58,6 +58,7 @@ Browse the agents below and copy/adapt the ones you need!
 
 # Or target a specific tool directly
 ./scripts/install.sh --tool antigravity
+./scripts/install.sh --tool codex
 ./scripts/install.sh --tool gemini-cli
 ./scripts/install.sh --tool opencode
 ./scripts/install.sh --tool copilot
@@ -545,6 +546,7 @@ The Agency works natively with Claude Code, and ships conversion + install scrip
 ### Supported Tools
 
 - **[Claude Code](https://claude.ai/code)** — native `.md` agents, no conversion needed → `~/.claude/agents/`
+- **[Codex](https://openai.com/codex/)** — native custom agent TOML files → `~/.codex/agents/`
 - **[GitHub Copilot](https://github.com/copilot)** — native `.md` agents, no conversion needed → `~/.github/agents/` + `~/.copilot/agents/`
 - **[Antigravity](https://github.com/google-gemini/antigravity)** — `SKILL.md` per agent → `~/.gemini/antigravity/skills/`
 - **[Gemini CLI](https://github.com/google-gemini/gemini-cli)** — extension + `SKILL.md` files → `~/.gemini/extensions/agency-agents/`
@@ -582,24 +584,26 @@ The installer scans your system for installed tools, shows a checkbox UI, and le
   System scan: [*] = detected on this machine
 
   [x]  1)  [*]  Claude Code     (claude.ai/code)
-  [x]  2)  [*]  Copilot         (~/.github + ~/.copilot)
-  [x]  3)  [*]  Antigravity     (~/.gemini/antigravity)
-  [ ]  4)  [ ]  Gemini CLI      (gemini extension)
-  [ ]  5)  [ ]  OpenCode        (opencode.ai)
-  [ ]  6)  [ ]  OpenClaw        (~/.openclaw/agency-agents)
-  [x]  7)  [*]  Cursor          (.cursor/rules)
-  [ ]  8)  [ ]  Aider           (CONVENTIONS.md)
-  [ ]  9)  [ ]  Windsurf        (.windsurfrules)
-  [ ] 10)  [ ]  Qwen Code       (~/.qwen/agents)
-  [ ] 11)  [ ]  Kimi Code       (~/.config/kimi/agents)
+  [x]  2)  [*]  Codex           (~/.codex/agents)
+  [x]  3)  [*]  Copilot         (~/.github + ~/.copilot)
+  [x]  4)  [*]  Antigravity     (~/.gemini/antigravity)
+  [ ]  5)  [ ]  Gemini CLI      (gemini extension)
+  [ ]  6)  [ ]  OpenCode        (opencode.ai)
+  [ ]  7)  [ ]  OpenClaw        (~/.openclaw/agency-agents)
+  [x]  8)  [*]  Cursor          (.cursor/rules)
+  [ ]  9)  [ ]  Aider           (CONVENTIONS.md)
+  [ ] 10)  [ ]  Windsurf        (.windsurfrules)
+  [ ] 11)  [ ]  Qwen Code       (~/.qwen/agents)
+  [ ] 12)  [ ]  Kimi Code       (~/.config/kimi/agents)
 
-  [1-11] toggle   [a] all   [n] none   [d] detected
+  [1-12] toggle   [a] all   [n] none   [d] detected
   [Enter] install   [q] quit
 ```
 
 **Or install a specific tool directly:**
 ```bash
 ./scripts/install.sh --tool cursor
+./scripts/install.sh --tool codex
 ./scripts/install.sh --tool opencode
 ./scripts/install.sh --tool openclaw
 ./scripts/install.sh --tool antigravity
@@ -639,6 +643,23 @@ Use the Frontend Developer agent to review this component.
 ```
 
 See [integrations/claude-code/README.md](integrations/claude-code/README.md) for details.
+</details>
+
+<details>
+<summary><strong>Codex</strong></summary>
+
+Agents are generated as native Codex custom agent TOML files in `~/.codex/agents/`.
+The installer also writes audit metadata to `~/.codex/agency-agents/`.
+
+```bash
+./scripts/install.sh --tool codex
+```
+
+Each generated agent uses the `agency_` prefix and embeds the original Agency
+instructions with Codex-specific routing, sandbox, MCP, skill, and safety
+guidance.
+
+See [integrations/codex/README.md](integrations/codex/README.md) for details.
 </details>
 
 <details>
@@ -849,7 +870,7 @@ When you add new agents or edit existing ones, regenerate all integration files:
 
 - [ ] Interactive agent selector web tool
 - [x] Multi-agent workflow examples -- see [examples/](examples/)
-- [x] Multi-tool integration scripts (Claude Code, GitHub Copilot, Antigravity, Gemini CLI, OpenCode, OpenClaw, Cursor, Aider, Windsurf, Qwen Code, Kimi Code)
+- [x] Multi-tool integration scripts (Claude Code, Codex, GitHub Copilot, Antigravity, Gemini CLI, OpenCode, OpenClaw, Cursor, Aider, Windsurf, Qwen Code, Kimi Code)
 - [ ] Video tutorials on agent design
 - [ ] Community agent marketplace
 - [ ] Agent "personality quiz" for project matching

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -6,6 +6,7 @@ supported agentic coding tools.
 ## Supported Tools
 
 - **[Claude Code](#claude-code)** — `.md` agents, use the repo directly
+- **[Codex](#codex)** — native `.toml` custom agents in `~/.codex/agents/`
 - **[GitHub Copilot](#github-copilot)** — `.md` agents, use the repo directly
 - **[Antigravity](#antigravity)** — `SKILL.md` per agent in `antigravity/`
 - **[Gemini CLI](#gemini-cli)** — extension + `SKILL.md` files in `gemini-cli/`
@@ -25,6 +26,7 @@ supported agentic coding tools.
 
 # Install a specific home-scoped tool
 ./scripts/install.sh --tool antigravity
+./scripts/install.sh --tool codex
 ./scripts/install.sh --tool copilot
 ./scripts/install.sh --tool openclaw
 ./scripts/install.sh --tool claude-code
@@ -71,6 +73,26 @@ cp -r <category>/*.md ~/.claude/agents/
 ```
 
 See [claude-code/README.md](claude-code/README.md) for details.
+
+---
+
+## Codex
+
+Codex agents are generated as native custom agent TOML files in
+`~/.codex/agents/`, with audit metadata in `~/.codex/agency-agents/`.
+
+```bash
+./scripts/install.sh --tool codex
+```
+
+To generate Codex integration files into the repo-local `integrations/codex/`
+output directory without installing them:
+
+```bash
+./scripts/convert.sh --tool codex
+```
+
+See [codex/README.md](codex/README.md) for details.
 
 ---
 

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -1,0 +1,56 @@
+# Codex Integration
+
+Generate native Codex custom agents from the Agency Agents catalog.
+
+Codex loads personal custom agents from `~/.codex/agents/*.toml`. Each generated
+agent uses the `agency_` prefix, includes the original Agency instructions, and
+adds Codex-specific routing, safety, sandbox, MCP, and skill guidance.
+
+## Install Locally
+
+```bash
+./scripts/install.sh --tool codex
+```
+
+You can also run the integration script directly:
+
+```bash
+./integrations/codex/scripts/install_codex_agents.sh
+```
+
+To generate repo-local integration files without installing them:
+
+```bash
+./scripts/convert.sh --tool codex
+```
+
+Optional environment variables:
+
+- `CODEX_HOME`: Codex home directory, defaults to `~/.codex`
+- `CLAUDE_AGENTS_DIR`: optional extra Claude agents directory, unset by default
+- `CODEX_SKILLS_DIR`: optional Codex Agency skills directory, defaults to `~/.codex/plugins/agency-agents/skills`
+
+## Generated Files
+
+- `~/.codex/agents/agency_*.toml`
+- `~/.codex/agency-agents/manifest.json`
+- `~/.codex/agency-agents/source-map.json`
+- `~/.codex/agency-agents/router.md`
+
+## Validate
+
+```bash
+./integrations/codex/scripts/validate_codex_agents.py \
+  --agents-dir ~/.codex/agents \
+  --manifest ~/.codex/agency-agents/manifest.json
+```
+
+The validator checks TOML syntax, required Codex fields, `agency_` naming, manifest
+count, and obvious secret markers.
+
+## Notes
+
+- Existing MCP server secrets are not copied into generated agent files.
+- Recommended MCPs and skills are recorded in the generated instructions and manifest.
+- The generated agents can coexist with the Agency Agents Codex plugin until native
+  agent tests pass.

--- a/integrations/codex/examples/minimal-agent.toml
+++ b/integrations/codex/examples/minimal-agent.toml
@@ -1,0 +1,5 @@
+name = "agency_example_specialist"
+description = "Example Agency specialist generated for Codex."
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+developer_instructions = "Use this file as a minimal shape reference for generated Agency agents."

--- a/integrations/codex/scripts/generate_codex_agents.py
+++ b/integrations/codex/scripts/generate_codex_agents.py
@@ -1,0 +1,496 @@
+#!/usr/bin/env python3
+"""Generate native Codex custom agents from Agency Agents markdown files."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+EXCLUDED_DIRS = {
+    ".git",
+    ".github",
+    ".claude",
+    "_docs",
+    "examples",
+    "integrations",
+    "playbooks",
+    "runbooks",
+    "scripts",
+}
+
+EXCLUDED_FILES = {
+    "README.md",
+    "QUICKSTART.md",
+    "SECURITY.md",
+    "CONTRIBUTING.md",
+    "CONTRIBUTING_zh-CN.md",
+    "PULL_REQUEST_TEMPLATE.md",
+    "EXECUTIVE-BRIEF.md",
+    "agent-activation-prompts.md",
+    "handoff-templates.md",
+}
+
+SECRET_PATTERNS = [
+    re.compile(r"(?i)(github_pat_[A-Za-z0-9_]{20,}|ghp_[A-Za-z0-9]{20,}|sk-[A-Za-z0-9]{20,})"),
+    re.compile(r"(?i)bearer\s+[A-Za-z0-9._-]{20,}"),
+]
+
+WRITE_HINTS = {
+    "developer",
+    "engineer",
+    "builder",
+    "automator",
+    "prototyper",
+    "scripter",
+    "architect",
+    "cms",
+    "mobile",
+    "devops",
+    "sre",
+}
+
+READ_ONLY_HINTS = {
+    "reviewer",
+    "auditor",
+    "checker",
+    "strategist",
+    "analyst",
+    "researcher",
+    "advisor",
+    "coach",
+    "guardian",
+    "compliance",
+    "security",
+    "legal",
+    "qa",
+    "tester",
+    "evidence",
+}
+
+HIGH_REASONING_HINTS = {
+    "architect",
+    "security",
+    "reviewer",
+    "auditor",
+    "mcp",
+    "backend",
+    "database",
+    "data",
+    "legal",
+    "compliance",
+    "sre",
+    "incident",
+}
+
+
+@dataclass(frozen=True)
+class AgentSource:
+    source_kind: str
+    source_path: Path
+    source_slug: str
+    category: str
+    display_name: str
+    description: str
+    body: str
+    checksum: str
+
+
+def repo_root_from_script() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def slugify(value: str) -> str:
+    value = value.strip().lower()
+    value = value.replace("&", " and ")
+    value = re.sub(r"[^a-z0-9]+", "_", value)
+    value = re.sub(r"_+", "_", value).strip("_")
+    return value or "agent"
+
+
+def parse_frontmatter(text: str) -> tuple[dict[str, str], str]:
+    if not text.startswith("---\n"):
+        return {}, text
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return {}, text
+    raw = text[4:end]
+    body = text[end + 5 :].lstrip()
+    meta: dict[str, str] = {}
+    for line in raw.splitlines():
+        if ":" not in line or line.startswith(" "):
+            continue
+        key, value = line.split(":", 1)
+        value = value.strip().strip('"').strip("'")
+        meta[key.strip()] = value
+    return meta, body
+
+
+def read_agent(path: Path, source_kind: str, repo_root: Path) -> AgentSource | None:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        text = path.read_text(encoding="utf-8", errors="replace")
+
+    meta, body = parse_frontmatter(text)
+    display_name = meta.get("name") or path.stem.replace("-", " ").title()
+    description = meta.get("description") or first_sentence(body) or display_name
+    source_slug = slugify(path.stem)
+    try:
+        category = path.relative_to(repo_root).parts[0]
+    except ValueError:
+        category = "claude-active"
+    if source_kind == "claude_active":
+        category = "claude-active"
+
+    checksum = hashlib.sha256(text.encode("utf-8", errors="replace")).hexdigest()
+    return AgentSource(
+        source_kind=source_kind,
+        source_path=path,
+        source_slug=source_slug,
+        category=category,
+        display_name=display_name,
+        description=clean_line(description),
+        body=body.strip(),
+        checksum=checksum,
+    )
+
+
+def first_sentence(text: str) -> str:
+    for line in text.splitlines():
+        line = line.strip(" #")
+        if len(line) > 20:
+            return clean_line(line)
+    return ""
+
+
+def clean_line(value: str, limit: int = 480) -> str:
+    value = re.sub(r"\s+", " ", value).strip()
+    if len(value) <= limit:
+        return value
+    return value[: limit - 1].rstrip() + "…"
+
+
+def official_markdown_files(repo_root: Path) -> Iterable[Path]:
+    for path in sorted(repo_root.rglob("*.md")):
+        rel_parts = path.relative_to(repo_root).parts
+        if len(rel_parts) < 2:
+            continue
+        if any(part in EXCLUDED_DIRS for part in rel_parts[:-1]):
+            continue
+        if path.name in EXCLUDED_FILES:
+            continue
+        yield path
+
+
+def claude_markdown_files(claude_agents_dir: Path | None) -> Iterable[Path]:
+    if not claude_agents_dir or not claude_agents_dir.exists():
+        return []
+    return sorted(claude_agents_dir.glob("*.md"))
+
+
+def collect_agents(repo_root: Path, claude_agents_dir: Path | None) -> list[AgentSource]:
+    by_name: dict[str, AgentSource] = {}
+
+    for path in official_markdown_files(repo_root):
+        agent = read_agent(path, "official", repo_root)
+        if agent:
+            by_name.setdefault(slugify(agent.display_name), agent)
+
+    for path in claude_markdown_files(claude_agents_dir):
+        agent = read_agent(path, "claude_active", repo_root)
+        if not agent:
+            continue
+        name_slug = slugify(agent.display_name)
+        by_name.setdefault(name_slug, agent)
+
+    return sorted(by_name.values(), key=lambda item: (item.category, item.display_name.lower()))
+
+
+def recommended_mcps(agent: AgentSource) -> list[str]:
+    haystack = " ".join(
+        [agent.source_slug, agent.category, agent.display_name, agent.description]
+    ).lower()
+    mapping = [
+        ("linkedin", "linkedin-mcp"),
+        ("github", "github"),
+        ("git", "github"),
+        ("google", "google-workspace"),
+        ("gmail", "google-workspace"),
+        ("sheet", "google-workspace"),
+        ("document", "google-workspace"),
+        ("n8n", "mcpsrv_n8n"),
+        ("workflow", "mcpsrv_n8n"),
+        ("automation", "mcpsrv_n8n"),
+        ("crawl", "crawl4ai"),
+        ("seo", "crawl4ai"),
+        ("research", "crawl4ai"),
+        ("web", "playwright"),
+        ("browser", "playwright"),
+        ("mcp", "context7"),
+        ("docs", "context7"),
+        ("technical writer", "context7"),
+        ("pdf", "md-to-pdf"),
+        ("report", "md-to-pdf"),
+        ("twitter", "bird-mcp"),
+        (" x ", "bird-mcp"),
+        ("memory", "basic-memory"),
+        ("knowledge", "basic-memory"),
+    ]
+    result: list[str] = []
+    for needle, mcp in mapping:
+        if needle in haystack and mcp not in result:
+            result.append(mcp)
+    if "basic-memory" not in result:
+        result.append("basic-memory")
+    return result
+
+
+def recommended_skills(agent: AgentSource, codex_skills_dir: Path | None) -> list[str]:
+    if not codex_skills_dir:
+        return []
+    display_slug = slugify(agent.display_name).replace("_", "-")
+    candidates = [
+        codex_skills_dir / f"agency-{display_slug}" / "SKILL.md",
+        codex_skills_dir / f"agency-{agent.source_slug}" / "SKILL.md",
+        codex_skills_dir / agent.source_slug / "SKILL.md",
+        codex_skills_dir / display_slug / "SKILL.md",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return [candidate.parent.name]
+    return []
+
+
+def sandbox_mode(agent: AgentSource) -> str:
+    haystack = f"{agent.source_slug} {agent.display_name} {agent.description}".lower()
+    if any(hint in haystack for hint in READ_ONLY_HINTS):
+        return "read-only"
+    if any(hint in haystack for hint in WRITE_HINTS):
+        return "workspace-write"
+    return "read-only"
+
+
+def reasoning_effort(agent: AgentSource) -> str:
+    haystack = f"{agent.source_slug} {agent.display_name} {agent.description}".lower()
+    if any(hint in haystack for hint in HIGH_REASONING_HINTS):
+        return "high"
+    return "medium"
+
+
+def toml_string(value: str) -> str:
+    return json.dumps(value, ensure_ascii=False)
+
+
+def agent_name(agent: AgentSource, used: set[str]) -> str:
+    base = "agency_" + slugify(agent.display_name)
+    name = base
+    if name in used:
+        name = "agency_" + agent.source_slug
+    suffix = 2
+    while name in used:
+        name = f"{base}_{suffix}"
+        suffix += 1
+    used.add(name)
+    return name
+
+
+def build_instructions(agent: AgentSource, name: str, mcps: list[str], skills: list[str], soul_path: Path) -> str:
+    mcp_line = ", ".join(mcps) if mcps else "none"
+    skill_line = ", ".join(skills) if skills else "none"
+    return f"""You are {name}, a native Codex custom agent generated from the Agency Agents catalog.
+
+Routing:
+- Use this agent for: {agent.description}
+- Do not use this agent for unrelated generic work when a narrower Agency agent matches better.
+- Reply in the user's language; for Ben, French is the default unless the task requires another language.
+
+Tooling:
+- Recommended MCPs: {mcp_line}
+- Recommended skills: {skill_line}
+- Never reveal or copy secrets, tokens, API keys, cookies, OAuth credentials, or .env values.
+- If you encounter a possible secret, mention only the file path and recommend rotation.
+- Prefer focused changes, existing repository patterns, and explicit verification.
+
+Source:
+- Source kind: {agent.source_kind}
+- Source file: {agent.source_path}
+- Source checksum: {agent.checksum}
+- Codex SOUL file: {soul_path}
+
+Original Agency Agent instructions:
+
+{agent.body}
+"""
+
+
+def write_agent_file(path: Path, name: str, agent: AgentSource, mcps: list[str], skills: list[str], soul_path: Path) -> None:
+    instructions = build_instructions(agent, name, mcps, skills, soul_path)
+    description = f"{agent.display_name}: {agent.description}"
+    content = "\n".join(
+        [
+            f"name = {toml_string(name)}",
+            f"description = {toml_string(description)}",
+            f"model_reasoning_effort = {toml_string(reasoning_effort(agent))}",
+            f"sandbox_mode = {toml_string(sandbox_mode(agent))}",
+            f"developer_instructions = {toml_string(instructions)}",
+            "",
+        ]
+    )
+    path.write_text(content, encoding="utf-8")
+
+
+def write_soul_file(path: Path, name: str, agent: AgentSource, mcps: list[str], skills: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    frontmatter = {
+        "agent": name,
+        "role": agent.display_name,
+        "category": agent.category,
+        "source_kind": agent.source_kind,
+        "source_path": str(agent.source_path),
+        "source_checksum": agent.checksum,
+        "recommended_mcp_servers": mcps,
+        "recommended_skills": skills,
+    }
+    content = [
+        "---",
+        *[f"{key}: {json.dumps(value, ensure_ascii=False)}" for key, value in frontmatter.items()],
+        "---",
+        "",
+        f"# {agent.display_name} SOUL",
+        "",
+        "This file mirrors the original Agency Agent instructions used to generate the native Codex TOML agent.",
+        "Codex loads the TOML `developer_instructions`; this SOUL file is kept for auditability, routing, and human review.",
+        "",
+        "## Original Agency Agent Instructions",
+        "",
+        agent.body,
+        "",
+    ]
+    path.write_text("\n".join(content), encoding="utf-8")
+
+
+def has_secret_marker(path: Path) -> bool:
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    return any(pattern.search(text) for pattern in SECRET_PATTERNS)
+
+
+def render_router(records: list[dict[str, object]]) -> str:
+    lines = [
+        "# Agency Agents Router for Codex",
+        "",
+        "Use this router before spawning an Agency agent. Prefer the narrowest matching agent from the full index.",
+        "Do not rely on a fixed shortlist: inspect the request, compare it with the manifest descriptions, and route to the most specific available specialist.",
+        "",
+        "## Full Index",
+        "",
+    ]
+    for record in sorted(records, key=lambda item: (str(item["category"]), str(item["agent"]))):
+        mcps = ", ".join(record["recommended_mcp_servers"]) or "none"
+        skills = ", ".join(record["recommended_skills"]) or "none"
+        lines.append(
+            f"- `{record['agent']}` ({record['category']}): {record['role']} | MCPs: {mcps} | skills: {skills} | sandbox: {record['sandbox_mode']}"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def generate(args: argparse.Namespace) -> int:
+    repo_root = args.repo_root.resolve()
+    output_agents_dir = args.output_agents_dir.expanduser().resolve()
+    metadata_dir = args.metadata_dir.expanduser().resolve()
+    codex_skills_dir = args.codex_skills_dir.expanduser().resolve() if args.codex_skills_dir else None
+    claude_agents_dir = args.claude_agents_dir.expanduser().resolve() if args.claude_agents_dir else None
+
+    agents = collect_agents(repo_root, claude_agents_dir)
+    output_agents_dir.mkdir(parents=True, exist_ok=True)
+    metadata_dir.mkdir(parents=True, exist_ok=True)
+
+    for stale in output_agents_dir.glob("agency_*.toml"):
+        stale.unlink()
+    souls_dir = metadata_dir / "souls"
+    if souls_dir.exists():
+        for stale in souls_dir.glob("agency_*/SOUL.md"):
+            stale.unlink()
+
+    used_names: set[str] = set()
+    records: list[dict[str, object]] = []
+    source_map: dict[str, dict[str, str]] = {}
+
+    for agent in agents:
+        name = agent_name(agent, used_names)
+        file_name = f"{name}.toml"
+        mcps = recommended_mcps(agent)
+        skills = recommended_skills(agent, codex_skills_dir)
+        destination = output_agents_dir / file_name
+        soul_path = metadata_dir / "souls" / name / "SOUL.md"
+        write_agent_file(destination, name, agent, mcps, skills, soul_path)
+        write_soul_file(soul_path, name, agent, mcps, skills)
+        if has_secret_marker(destination):
+            destination.unlink(missing_ok=True)
+            soul_path.unlink(missing_ok=True)
+            print(f"Refused generated agent because secret marker appeared: {destination}", file=sys.stderr)
+            return 2
+        record = {
+            "agent": name,
+            "file": str(destination),
+            "soul_file": str(soul_path),
+            "category": agent.category,
+            "role": agent.display_name,
+            "description": agent.description,
+            "when_to_use": agent.description,
+            "when_not_to_use": "Use a narrower Agency agent when the request better matches another specialist.",
+            "recommended_mcp_servers": mcps,
+            "recommended_skills": skills,
+            "autonomy": "execution" if sandbox_mode(agent) == "workspace-write" else "advisory",
+            "sandbox_mode": sandbox_mode(agent),
+            "source_kind": agent.source_kind,
+            "source_path": str(agent.source_path),
+            "source_checksum": agent.checksum,
+        }
+        records.append(record)
+        source_map[name] = {
+            "source_kind": agent.source_kind,
+            "source_path": str(agent.source_path),
+            "soul_file": str(soul_path),
+            "source_checksum": agent.checksum,
+            "source_slug": agent.source_slug,
+        }
+
+    (metadata_dir / "manifest.json").write_text(
+        json.dumps({"agents": records}, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    (metadata_dir / "source-map.json").write_text(
+        json.dumps(source_map, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    (metadata_dir / "router.md").write_text(render_router(records), encoding="utf-8")
+
+    print(f"Generated {len(records)} Codex agents in {output_agents_dir}")
+    print(f"Metadata written to {metadata_dir}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=repo_root_from_script())
+    parser.add_argument("--output-agents-dir", type=Path, default=Path("~/.codex/agents"))
+    parser.add_argument("--metadata-dir", type=Path, default=Path("~/.codex/agency-agents"))
+    parser.add_argument("--claude-agents-dir", type=Path, default=None)
+    parser.add_argument("--codex-skills-dir", type=Path, default=None)
+    args = parser.parse_args()
+    return generate(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/integrations/codex/scripts/install_codex_agents.sh
+++ b/integrations/codex/scripts/install_codex_agents.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+CLAUDE_AGENTS_DIR="${CLAUDE_AGENTS_DIR:-}"
+CODEX_SKILLS_DIR="${CODEX_SKILLS_DIR:-}"
+
+GENERATE_ARGS=(
+  --repo-root "$REPO_ROOT"
+  --output-agents-dir "$CODEX_HOME/agents"
+  --metadata-dir "$CODEX_HOME/agency-agents"
+)
+
+if [[ -n "$CLAUDE_AGENTS_DIR" ]]; then
+  GENERATE_ARGS+=(--claude-agents-dir "$CLAUDE_AGENTS_DIR")
+fi
+
+if [[ -n "$CODEX_SKILLS_DIR" ]]; then
+  GENERATE_ARGS+=(--codex-skills-dir "$CODEX_SKILLS_DIR")
+fi
+
+python3 "$SCRIPT_DIR/generate_codex_agents.py" "${GENERATE_ARGS[@]}"
+
+python3 "$SCRIPT_DIR/validate_codex_agents.py" \
+  --agents-dir "$CODEX_HOME/agents" \
+  --manifest "$CODEX_HOME/agency-agents/manifest.json"

--- a/integrations/codex/scripts/validate_codex_agents.py
+++ b/integrations/codex/scripts/validate_codex_agents.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Validate generated Codex custom agents."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+
+REQUIRED_FIELDS = {"name", "description", "developer_instructions"}
+SECRET_PATTERNS = [
+    re.compile(r"(?i)(github_pat_[A-Za-z0-9_]{20,}|ghp_[A-Za-z0-9]{20,}|sk-[A-Za-z0-9]{20,})"),
+    re.compile(r"(?i)bearer\s+[A-Za-z0-9._-]{20,}"),
+]
+
+
+def validate_file(path: Path) -> list[str]:
+    errors: list[str] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+        data = tomllib.loads(text)
+    except Exception as exc:  # noqa: BLE001 - validator should report all parse failures.
+        return [f"{path}: TOML parse failed: {exc}"]
+
+    missing = REQUIRED_FIELDS - set(data)
+    if missing:
+        errors.append(f"{path}: missing required fields: {', '.join(sorted(missing))}")
+    if not str(data.get("name", "")).startswith("agency_"):
+        errors.append(f"{path}: name must start with agency_")
+    if path.stem != data.get("name"):
+        errors.append(f"{path}: filename stem should match name")
+    for pattern in SECRET_PATTERNS:
+        if pattern.search(text):
+            errors.append(f"{path}: contains a possible secret marker")
+            break
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--agents-dir", type=Path, default=Path("~/.codex/agents"))
+    parser.add_argument("--manifest", type=Path, default=Path("~/.codex/agency-agents/manifest.json"))
+    args = parser.parse_args()
+
+    agents_dir = args.agents_dir.expanduser().resolve()
+    manifest = args.manifest.expanduser().resolve()
+    files = sorted(agents_dir.glob("agency_*.toml"))
+    errors: list[str] = []
+
+    if not files:
+        errors.append(f"{agents_dir}: no agency_*.toml files found")
+    for path in files:
+        errors.extend(validate_file(path))
+
+    if manifest.exists():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            manifest_count = len(data.get("agents", []))
+            if manifest_count != len(files):
+                errors.append(
+                    f"{manifest}: manifest count {manifest_count} does not match TOML count {len(files)}"
+                )
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"{manifest}: JSON parse failed: {exc}")
+    else:
+        errors.append(f"{manifest}: missing manifest")
+
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print(f"Validated {len(files)} Codex agency agents in {agents_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/integrations/codex/tests/test_generate_codex_agents.py
+++ b/integrations/codex/tests/test_generate_codex_agents.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "generate_codex_agents.py"
+VALIDATE = Path(__file__).resolve().parents[1] / "scripts" / "validate_codex_agents.py"
+
+
+class GenerateCodexAgentsTest(unittest.TestCase):
+    def test_generates_valid_toml_from_markdown_agent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            agent_dir = root / "engineering"
+            nested_agent_dir = root / "game-development" / "unity"
+            out = Path(tmp) / "agents"
+            meta = Path(tmp) / "meta"
+            agent_dir.mkdir(parents=True)
+            nested_agent_dir.mkdir(parents=True)
+            (agent_dir / "engineering-test-agent.md").write_text(
+                "---\n"
+                "name: Test Agent\n"
+                "description: Helps test Codex generation.\n"
+                "---\n\n"
+                "# Test Agent\n\n"
+                "Follow the test instructions.\n",
+                encoding="utf-8",
+            )
+            (nested_agent_dir / "unity-test-agent.md").write_text(
+                "---\n"
+                "name: Unity Test Agent\n"
+                "description: Verifies nested Codex agent discovery.\n"
+                "---\n\n"
+                "# Unity Test Agent\n\n"
+                "Follow the nested test instructions.\n",
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [
+                    "python3",
+                    str(SCRIPT),
+                    "--repo-root",
+                    str(root),
+                    "--output-agents-dir",
+                    str(out),
+                    "--metadata-dir",
+                    str(meta),
+                ],
+                check=False,
+                text=True,
+                capture_output=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertTrue((out / "agency_test_agent.toml").exists())
+            self.assertTrue((out / "agency_unity_test_agent.toml").exists())
+
+            validation = subprocess.run(
+                [
+                    "python3",
+                    str(VALIDATE),
+                    "--agents-dir",
+                    str(out),
+                    "--manifest",
+                    str(meta / "manifest.json"),
+                ],
+                check=False,
+                text=True,
+                capture_output=True,
+            )
+            self.assertEqual(validation.returncode, 0, validation.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/convert.sh
+++ b/scripts/convert.sh
@@ -17,6 +17,7 @@
 #   aider        — Single CONVENTIONS.md for Aider
 #   windsurf     — Single .windsurfrules for Windsurf
 #   openclaw     — OpenClaw workspaces (integrations/openclaw/<agent>/SOUL.md)
+#   codex        — Codex native TOML agents (~/.codex/agents/*.toml)
 #   qwen         — Qwen Code SubAgent files (~/.qwen/agents/*.md)
 #   kimi         — Kimi Code CLI agent files (~/.config/kimi/agents/)
 #   all          — All tools (default)
@@ -408,6 +409,22 @@ ${body}
 HEREDOC
 }
 
+convert_codex() {
+  local codex_dir="$OUT_DIR/codex"
+  local agents_dir="$codex_dir/agents"
+  local metadata_dir="$codex_dir/agency-agents"
+
+  mkdir -p "$codex_dir"
+  python3 "$REPO_ROOT/integrations/codex/scripts/generate_codex_agents.py" \
+    --repo-root "$REPO_ROOT" \
+    --output-agents-dir "$agents_dir" \
+    --metadata-dir "$metadata_dir" >/dev/null
+
+  python3 "$REPO_ROOT/integrations/codex/scripts/validate_codex_agents.py" \
+    --agents-dir "$agents_dir" \
+    --manifest "$metadata_dir/manifest.json" >/dev/null
+}
+
 # Aider and Windsurf are single-file formats — accumulate into temp files
 # then write at the end.
 AIDER_TMP="$(mktemp)"
@@ -484,6 +501,12 @@ run_conversions() {
   local tool="$1"
   local count=0
 
+  if [[ "$tool" == "codex" ]]; then
+    convert_codex
+    find "$OUT_DIR/codex/agents" -maxdepth 1 -name "agency_*.toml" -type f | wc -l | tr -d '[:space:]'
+    return
+  fi
+
   for dir in "${AGENT_DIRS[@]}"; do
     local dirpath="$REPO_ROOT/$dir"
     [[ -d "$dirpath" ]] || continue
@@ -536,7 +559,7 @@ main() {
     esac
   done
 
-  local valid_tools=("antigravity" "gemini-cli" "opencode" "cursor" "aider" "windsurf" "openclaw" "qwen" "kimi" "all")
+  local valid_tools=("antigravity" "gemini-cli" "opencode" "cursor" "aider" "windsurf" "openclaw" "codex" "qwen" "kimi" "all")
   local valid=false
   for t in "${valid_tools[@]}"; do [[ "$t" == "$tool" ]] && valid=true && break; done
   if ! $valid; then
@@ -555,7 +578,7 @@ main() {
 
   local tools_to_run=()
   if [[ "$tool" == "all" ]]; then
-    tools_to_run=("antigravity" "gemini-cli" "opencode" "cursor" "aider" "windsurf" "openclaw" "qwen" "kimi")
+    tools_to_run=("antigravity" "gemini-cli" "opencode" "cursor" "aider" "windsurf" "openclaw" "codex" "qwen" "kimi")
   else
     tools_to_run=("$tool")
   fi
@@ -566,7 +589,7 @@ main() {
 
   if $use_parallel && [[ "$tool" == "all" ]]; then
     # Tools that write to separate dirs can run in parallel; buffer output so each tool's output stays together
-    local parallel_tools=(antigravity gemini-cli opencode cursor openclaw qwen)
+    local parallel_tools=(antigravity gemini-cli opencode cursor openclaw codex qwen kimi)
     local parallel_out_dir
     parallel_out_dir="$(mktemp -d)"
     info "Converting: ${#parallel_tools[@]}/${n_tools} tools in parallel (output buffered per tool)..."
@@ -578,7 +601,7 @@ main() {
       [[ -f "$parallel_out_dir/$t" ]] && cat "$parallel_out_dir/$t"
     done
     rm -rf "$parallel_out_dir"
-    local idx=7
+    local idx=$(( ${#parallel_tools[@]} + 1 ))
     for t in aider windsurf; do
       progress_bar "$idx" "$n_tools"
       printf "\n"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,6 +11,7 @@
 #
 # Tools:
 #   claude-code  -- Copy agents to ~/.claude/agents/
+#   codex        -- Generate native Codex TOML agents in ~/.codex/agents/
 #   copilot      -- Copy agents to ~/.github/agents/ and ~/.copilot/agents/
 #   antigravity  -- Copy skills to ~/.gemini/antigravity/skills/
 #   gemini-cli   -- Install extension to ~/.gemini/extensions/agency-agents/
@@ -20,6 +21,7 @@
 #   windsurf     -- Copy .windsurfrules to current directory
 #   openclaw     -- Copy workspaces to ~/.openclaw/agency-agents/
 #   qwen         -- Copy SubAgents to ~/.qwen/agents/ (user-wide) or .qwen/agents/ (project)
+#   kimi         -- Copy Kimi Code agent specs to ~/.config/kimi/agents/
 #   all          -- Install for all detected tools (default)
 #
 # Flags:
@@ -101,7 +103,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 INTEGRATIONS="$REPO_ROOT/integrations"
 
-ALL_TOOLS=(claude-code copilot antigravity gemini-cli opencode openclaw cursor aider windsurf qwen kimi)
+ALL_TOOLS=(claude-code codex copilot antigravity gemini-cli opencode openclaw cursor aider windsurf qwen kimi)
 
 # Standard agent category directories (keep sorted, sync with convert.sh / lint-agents.sh)
 AGENT_DIRS=(
@@ -113,7 +115,7 @@ AGENT_DIRS=(
 # Usage
 # ---------------------------------------------------------------------------
 usage() {
-  sed -n '3,32p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '3,35p' "$0" | sed 's/^# \{0,1\}//'
   exit 0
 }
 
@@ -139,6 +141,7 @@ check_integrations() {
 # Tool detection
 # ---------------------------------------------------------------------------
 detect_claude_code() { [[ -d "${HOME}/.claude" ]]; }
+detect_codex()        { command -v codex >/dev/null 2>&1 || [[ -d "${HOME}/.codex" ]]; }
 detect_copilot()      { command -v code >/dev/null 2>&1 || [[ -d "${HOME}/.github" || -d "${HOME}/.copilot" ]]; }
 detect_antigravity()  { [[ -d "${HOME}/.gemini/antigravity/skills" ]]; }
 detect_gemini_cli()   { command -v gemini >/dev/null 2>&1 || [[ -d "${HOME}/.gemini" ]]; }
@@ -153,6 +156,7 @@ detect_kimi()         { command -v kimi >/dev/null 2>&1; }
 is_detected() {
   case "$1" in
     claude-code) detect_claude_code ;;
+    codex)       detect_codex       ;;
     copilot)     detect_copilot     ;;
     antigravity) detect_antigravity ;;
     gemini-cli)  detect_gemini_cli  ;;
@@ -171,6 +175,7 @@ is_detected() {
 tool_label() {
   case "$1" in
     claude-code) printf "%-14s  %s" "Claude Code"  "(claude.ai/code)"        ;;
+    codex)       printf "%-14s  %s" "Codex"        "(~/.codex/agents)"      ;;
     copilot)     printf "%-14s  %s" "Copilot"      "(~/.github + ~/.copilot)" ;;
     antigravity) printf "%-14s  %s" "Antigravity"  "(~/.gemini/antigravity)" ;;
     gemini-cli)  printf "%-14s  %s" "Gemini CLI"   "(gemini extension)"      ;;
@@ -317,6 +322,17 @@ install_claude_code() {
     done < <(find "$REPO_ROOT/$dir" -name "*.md" -type f -print0)
   done
   ok "Claude Code: $count agents -> $dest"
+}
+
+install_codex() {
+  local script="$INTEGRATIONS/codex/scripts/install_codex_agents.sh"
+  local dest="${CODEX_HOME:-$HOME/.codex}"
+
+  [[ -f "$script" ]] || { err "integrations/codex missing. Run from a repo that includes the Codex integration."; return 1; }
+
+  CODEX_HOME="$dest" bash "$script"
+  ok "Codex: native agents -> $dest/agents"
+  ok "Codex: metadata -> $dest/agency-agents"
 }
 
 install_copilot() {
@@ -521,6 +537,7 @@ install_kimi() {
 install_tool() {
   case "$1" in
     claude-code) install_claude_code ;;
+    codex)       install_codex       ;;
     copilot)     install_copilot     ;;
     antigravity) install_antigravity ;;
     gemini-cli)  install_gemini_cli  ;;


### PR DESCRIPTION
## Summary
- add a native Codex integration that generates TOML custom agents from the Agency Agents markdown sources
- add installer and validator scripts for Codex agent directories
- document Codex usage alongside existing integrations
- wire Codex into the top-level conversion and installation helpers

## Verification
- python3 integrations/codex/scripts/generate_codex_agents.py --repo-root . --output-agents-dir /tmp/agency-codex-agents-verify/agents --metadata-dir /tmp/agency-codex-agents-verify/meta
- python3 integrations/codex/scripts/validate_codex_agents.py --agents-dir /tmp/agency-codex-agents-verify/agents --manifest /tmp/agency-codex-agents-verify/meta/manifest.json
- python3 integrations/codex/tests/test_generate_codex_agents.py
- git diff --check HEAD~1..HEAD
- actionable secret scan on added diff: 0 hits