### PR TITLE
fix: resolve inconsistent agent count in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,7 +530,7 @@ Each agent is designed with:
 
 ## 📊 Stats
 
-- 🎭 **144 Specialized Agents** across 12 divisions
+- 🎭 **147 Specialized Agents** across 12 divisions
 - 📝 **10,000+ lines** of personality, process, and code examples
 - ⏱️ **Months of iteration** from real-world usage
 - 🌟 **Battle-tested** in production environments


### PR DESCRIPTION
## Summary

- Stats section at the top of README listed **144** agents
- Acknowledgments section at the bottom of the same file listed **147** agents
- Updated Stats to match Acknowledgments so the page is self-consistent

## Test plan
- [x] Verified both occurrences now say the same number (147)

🤖 Generated with [Claude Code](https://claude.com/claude-code)