### PR TITLE
fix(openclaw): populate agentDir so sub-agent spawns work

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -404,6 +404,7 @@ install_opencode() {
 install_openclaw() {
   local src="$INTEGRATIONS/openclaw"
   local dest="${HOME}/.openclaw/agency-agents"
+  local agents_state="${HOME}/.openclaw/agents"
   local count=0
   local existing_agents=""
   [[ -d "$src" ]] || { err "integrations/openclaw missing. Run convert.sh first."; return 1; }
@@ -419,9 +420,22 @@ install_openclaw() {
     cp "$d/SOUL.md" "$dest/$name/SOUL.md"
     cp "$d/AGENTS.md" "$dest/$name/AGENTS.md"
     cp "$d/IDENTITY.md" "$dest/$name/IDENTITY.md"
+    # Also populate the agent state directory so OpenClaw can read the
+    # agent files at spawn time. `openclaw agents add --workspace ...`
+    # registers `agentDir` as `~/.openclaw/agents/<name>/agent/` by
+    # default but does not create or populate it — leaving sub-agent
+    # spawns to fail with "agentDir does not exist". Copying the same
+    # 3 files here keeps the agentDir read-only seed in sync with the
+    # workspace; OpenClaw runtime files (HEARTBEAT.md, TOOLS.md,
+    # USER.md, .openclaw/) are created on first spawn alongside them.
+    local agent_dir="$agents_state/$name/agent"
+    mkdir -p "$agent_dir"
+    cp "$d/SOUL.md" "$agent_dir/SOUL.md"
+    cp "$d/AGENTS.md" "$agent_dir/AGENTS.md"
+    cp "$d/IDENTITY.md" "$agent_dir/IDENTITY.md"
     if command -v openclaw >/dev/null 2>&1; then
       if [[ "$existing_agents" != *$'\n'"$name"$'\n'* ]]; then
-        openclaw agents add "$name" --workspace "$dest/$name" --non-interactive || true
+        openclaw agents add "$name" --workspace "$dest/$name" --agent-dir "$agent_dir" --non-interactive || true
       fi
     fi
     (( count++ )) || true


### PR DESCRIPTION
## Summary

`./scripts/install.sh --tool openclaw` registers each agent in OpenClaw's config (via `openclaw agents add --workspace <path>`) but leaves the inferred `agentDir` (`~/.openclaw/agents/<name>/agent/`) empty on disk. The first time a user tries to delegate to one of these agents from the main agent (`sessions_spawn(runtime="subagent", agentId=...)`), OpenClaw can't find the agent files and the spawn fails.

This PR copies the same 3 files (SOUL.md / AGENTS.md / IDENTITY.md) into the `agentDir` and passes `--agent-dir` explicitly to `agents add`, so the post-install state matches the registered config.

## Why it happens

OpenClaw's `agents add` defaults `agentDir` to `~/.openclaw/agents/<name>/agent/` when only `--workspace` is given, but it does not materialize the personality files there — that's left up to the caller. The current `install_openclaw` only writes them to the `agency-agents/` workspace, so spawn is broken until the user manually copies or symlinks.

## What's not changed

OpenClaw runtime files (HEARTBEAT.md, TOOLS.md, USER.md, `.openclaw/`) are created by the gateway on first spawn alongside the 3 curated files, so they are intentionally not copied by the installer.

## Test plan

- [x] Bash syntax check (`bash -n scripts/install.sh`).
- [x] Tested on Ubuntu 22.04 with OpenClaw 2026.4.23 against a 184-agent corpus. Without the patch: `sessions_spawn(geographer, ...)` returns "agentDir does not exist". With the patch: same call succeeds; geographer responds within the spawn turn.
- [x] Idempotent: re-running `install.sh --tool openclaw` overwrites the same files (no duplication, no orphans).

## Scope

Only the `install_openclaw` function. Other targets (`claude-code`, `cursor`, `aider`, etc.) are untouched.