### PR TITLE
Add Codex integration support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ integrations/cursor/rules/
 integrations/aider/CONVENTIONS.md
 integrations/windsurf/.windsurfrules
 integrations/openclaw/*
+integrations/codex/agents/
 integrations/qwen/agents/
 integrations/kimi/*/
 !integrations/openclaw/README.md

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Each agent file contains:
 
 Browse the agents below and copy/adapt the ones you need!
 
-### Option 3: Use with Other Tools (GitHub Copilot, Antigravity, Gemini CLI, OpenCode, OpenClaw, Cursor, Aider, Windsurf, Kimi Code)
+### Option 3: Use with Other Tools (GitHub Copilot, Antigravity, Gemini CLI, OpenCode, OpenClaw, Codex, Cursor, Aider, Windsurf, Qwen Code, Kimi Code)
 
 ```bash
 # Step 1 -- generate integration files for all supported tools
@@ -62,6 +62,7 @@ Browse the agents below and copy/adapt the ones you need!
 ./scripts/install.sh --tool opencode
 ./scripts/install.sh --tool copilot
 ./scripts/install.sh --tool openclaw
+./scripts/install.sh --tool codex
 ./scripts/install.sh --tool cursor
 ./scripts/install.sh --tool aider
 ./scripts/install.sh --tool windsurf
@@ -549,6 +550,7 @@ The Agency works natively with Claude Code, and ships conversion + install scrip
 - **[Antigravity](https://github.com/google-gemini/antigravity)** — `SKILL.md` per agent → `~/.gemini/antigravity/skills/`
 - **[Gemini CLI](https://github.com/google-gemini/gemini-cli)** — extension + `SKILL.md` files → `~/.gemini/extensions/agency-agents/`
 - **[OpenCode](https://opencode.ai)** — `.md` agent files → `.opencode/agents/`
+- **[Codex](https://openai.com/codex)** — `.toml` custom agents → `~/.codex/agents/`
 - **[Cursor](https://cursor.sh)** — `.mdc` rule files → `.cursor/rules/`
 - **[Aider](https://aider.chat)** — single `CONVENTIONS.md` → `./CONVENTIONS.md`
 - **[Windsurf](https://codeium.com/windsurf)** — single `.windsurfrules` → `./.windsurfrules`
@@ -587,13 +589,14 @@ The installer scans your system for installed tools, shows a checkbox UI, and le
   [ ]  4)  [ ]  Gemini CLI      (gemini extension)
   [ ]  5)  [ ]  OpenCode        (opencode.ai)
   [ ]  6)  [ ]  OpenClaw        (~/.openclaw/agency-agents)
-  [x]  7)  [*]  Cursor          (.cursor/rules)
-  [ ]  8)  [ ]  Aider           (CONVENTIONS.md)
-  [ ]  9)  [ ]  Windsurf        (.windsurfrules)
-  [ ] 10)  [ ]  Qwen Code       (~/.qwen/agents)
-  [ ] 11)  [ ]  Kimi Code       (~/.config/kimi/agents)
+  [x]  7)  [*]  Codex           (~/.codex/agents)
+  [x]  8)  [*]  Cursor          (.cursor/rules)
+  [ ]  9)  [ ]  Aider           (CONVENTIONS.md)
+  [ ] 10)  [ ]  Windsurf        (.windsurfrules)
+  [ ] 11)  [ ]  Qwen Code       (~/.qwen/agents)
+  [ ] 12)  [ ]  Kimi Code       (~/.config/kimi/agents)
 
-  [1-11] toggle   [a] all   [n] none   [d] detected
+  [1-12] toggle   [a] all   [n] none   [d] detected
   [Enter] install   [q] quit
 ```
 
@@ -602,6 +605,7 @@ The installer scans your system for installed tools, shows a checkbox UI, and le
 ./scripts/install.sh --tool cursor
 ./scripts/install.sh --tool opencode
 ./scripts/install.sh --tool openclaw
+./scripts/install.sh --tool codex
 ./scripts/install.sh --tool antigravity
 ```
 
@@ -785,6 +789,22 @@ See [integrations/openclaw/README.md](integrations/openclaw/README.md) for detai
 </details>
 
 <details>
+<summary><strong>Codex</strong></summary>
+
+Agents are converted to Codex custom agent TOML files and installed to `~/.codex/agents/`.
+
+```bash
+./scripts/convert.sh --tool codex
+./scripts/install.sh --tool codex
+```
+
+Restart Codex or open a new session after installation so the agent list is refreshed.
+
+See [integrations/codex/README.md](integrations/codex/README.md) for details.
+
+</details>
+
+<details>
 <summary><strong>Qwen Code</strong></summary>
 
 SubAgents are installed to `.qwen/agents/` in your project root (project-scoped).
@@ -849,7 +869,7 @@ When you add new agents or edit existing ones, regenerate all integration files:
 
 - [ ] Interactive agent selector web tool
 - [x] Multi-agent workflow examples -- see [examples/](examples/)
-- [x] Multi-tool integration scripts (Claude Code, GitHub Copilot, Antigravity, Gemini CLI, OpenCode, OpenClaw, Cursor, Aider, Windsurf, Qwen Code, Kimi Code)
+- [x] Multi-tool integration scripts (Claude Code, GitHub Copilot, Antigravity, Gemini CLI, OpenCode, OpenClaw, Codex, Cursor, Aider, Windsurf, Qwen Code, Kimi Code)
 - [ ] Video tutorials on agent design
 - [ ] Community agent marketplace
 - [ ] Agent "personality quiz" for project matching

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -11,6 +11,7 @@ supported agentic coding tools.
 - **[Gemini CLI](#gemini-cli)** — extension + `SKILL.md` files in `gemini-cli/`
 - **[OpenCode](#opencode)** — `.md` agent files in `opencode/`
 - **[OpenClaw](#openclaw)** — `SOUL.md` + `AGENTS.md` + `IDENTITY.md` workspaces
+- **[Codex](#codex)** — `.toml` custom agents in `codex/`
 - **[Cursor](#cursor)** — `.mdc` rule files in `cursor/`
 - **[Aider](#aider)** — `CONVENTIONS.md` in `aider/`
 - **[Windsurf](#windsurf)** — `.windsurfrules` in `windsurf/`
@@ -36,6 +37,10 @@ supported agentic coding tools.
 # Qwen Code also needs generated SubAgent files on a fresh clone
 ./scripts/convert.sh --tool qwen
 ./scripts/install.sh --tool qwen
+
+# Codex also needs generated custom agent files on a fresh clone
+./scripts/convert.sh --tool codex
+./scripts/install.sh --tool codex
 ```
 
 If you install OpenClaw and the gateway is already running, restart it after installation:
@@ -159,6 +164,25 @@ cd /your/project && /path/to/agency-agents/scripts/install.sh --tool cursor
 ```
 
 See [cursor/README.md](cursor/README.md) for details.
+
+---
+
+## Codex
+
+Each agent becomes a Codex custom agent TOML file in `~/.codex/agents/`.
+From a fresh clone, generate the Codex files first:
+
+```bash
+./scripts/convert.sh --tool codex
+```
+
+Then install them:
+
+```bash
+./scripts/install.sh --tool codex
+```
+
+See [codex/README.md](codex/README.md) for details.
 
 ---
 

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -1,0 +1,51 @@
+# Codex Integration
+
+Codex custom agents are TOML files stored in `~/.codex/agents/`. Each Agency
+agent is converted into one Codex agent with `name`, `description`, and
+`developer_instructions`.
+
+## Generate
+
+From the repository root:
+
+```bash
+./scripts/convert.sh --tool codex
+```
+
+This writes generated agent files into:
+
+```text
+integrations/codex/agents/
+```
+
+## Install
+
+```bash
+./scripts/install.sh --tool codex
+```
+
+This copies the generated TOML files into:
+
+```text
+~/.codex/agents/
+```
+
+If you use a custom Codex home directory, set `CODEX_HOME`:
+
+```bash
+CODEX_HOME=/path/to/codex-home ./scripts/install.sh --tool codex
+```
+
+## Refresh in Codex
+
+After installation, restart Codex or open a new session so the agent list is
+reloaded.
+
+## Regenerate
+
+After modifying source agents:
+
+```bash
+./scripts/convert.sh --tool codex
+./scripts/install.sh --tool codex
+```

--- a/scripts/convert.sh
+++ b/scripts/convert.sh
@@ -17,6 +17,7 @@
 #   aider        — Single CONVENTIONS.md for Aider
 #   windsurf     — Single .windsurfrules for Windsurf
 #   openclaw     — OpenClaw workspaces (integrations/openclaw/<agent>/SOUL.md)
+#   codex        — Codex custom agents (~/.codex/agents/*.toml)
 #   qwen         — Qwen Code SubAgent files (~/.qwen/agents/*.md)
 #   kimi         — Kimi Code CLI agent files (~/.config/kimi/agents/)
 #   all          — All tools (default)
@@ -98,10 +99,33 @@ get_body() {
   awk 'BEGIN{fm=0} /^---$/{fm++; next} fm>=2{print}' "$1"
 }
 
+clean_text() {
+  LC_ALL=C tr -d '\000-\010\013\014\016-\037'
+}
+
 # Convert a human-readable agent name to a lowercase kebab-case slug.
 # "Frontend Developer" → "frontend-developer"
 slugify() {
   echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//'
+}
+
+strip_wrapping_quotes() {
+  local value="$1"
+  if [[ "$value" == \"*\" && "$value" == *\" ]]; then
+    value="${value#\"}"
+    value="${value%\"}"
+  elif [[ "$value" == \'*\' && "$value" == *\' ]]; then
+    value="${value#\'}"
+    value="${value%\'}"
+  fi
+  printf '%s' "$value"
+}
+
+toml_basic_string() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  printf '"%s"' "$value"
 }
 
 # --- Per-tool converters ---
@@ -113,7 +137,7 @@ convert_antigravity() {
   name="$(get_field "name" "$file")"
   description="$(get_field "description" "$file")"
   slug="agency-$(slugify "$name")"
-  body="$(get_body "$file")"
+  body="$(get_body "$file" | clean_text)"
 
   outdir="$OUT_DIR/antigravity/$slug"
   outfile="$outdir/SKILL.md"
@@ -139,7 +163,7 @@ convert_gemini_cli() {
   name="$(get_field "name" "$file")"
   description="$(get_field "description" "$file")"
   slug="$(slugify "$name")"
-  body="$(get_body "$file")"
+  body="$(get_body "$file" | clean_text)"
 
   outdir="$OUT_DIR/gemini-cli/skills/$slug"
   outfile="$outdir/SKILL.md"
@@ -207,7 +231,7 @@ convert_opencode() {
   description="$(get_field "description" "$file")"
   color="$(resolve_opencode_color "$(get_field "color" "$file")")"
   slug="$(slugify "$name")"
-  body="$(get_body "$file")"
+  body="$(get_body "$file" | clean_text)"
 
   outfile="$OUT_DIR/opencode/agents/${slug}.md"
   mkdir -p "$OUT_DIR/opencode/agents"
@@ -232,7 +256,7 @@ convert_cursor() {
   name="$(get_field "name" "$file")"
   description="$(get_field "description" "$file")"
   slug="$(slugify "$name")"
-  body="$(get_body "$file")"
+  body="$(get_body "$file" | clean_text)"
 
   outfile="$OUT_DIR/cursor/rules/${slug}.mdc"
   mkdir -p "$OUT_DIR/cursor/rules"
@@ -256,7 +280,7 @@ convert_openclaw() {
   name="$(get_field "name" "$file")"
   description="$(get_field "description" "$file")"
   slug="$(slugify "$name")"
-  body="$(get_body "$file")"
+  body="$(get_body "$file" | clean_text)"
 
   outdir="$OUT_DIR/openclaw/$slug"
   mkdir -p "$outdir"
@@ -348,7 +372,7 @@ convert_qwen() {
   description="$(get_field "description" "$file")"
   tools="$(get_field "tools" "$file")"
   slug="$(slugify "$name")"
-  body="$(get_body "$file")"
+  body="$(get_body "$file" | clean_text)"
 
   outfile="$OUT_DIR/qwen/agents/${slug}.md"
   mkdir -p "$(dirname "$outfile")"
@@ -382,7 +406,7 @@ convert_kimi() {
   name="$(get_field "name" "$file")"
   description="$(get_field "description" "$file")"
   slug="$(slugify "$name")"
-  body="$(get_body "$file")"
+  body="$(get_body "$file" | clean_text)"
 
   outdir="$OUT_DIR/kimi/$slug"
   agent_file="$outdir/agent.yaml"
@@ -405,6 +429,28 @@ HEREDOC
 ${description}
 
 ${body}
+HEREDOC
+}
+
+convert_codex() {
+  local file="$1"
+  local name description outfile body
+
+  name="$(strip_wrapping_quotes "$(get_field "name" "$file")")"
+  description="$(strip_wrapping_quotes "$(get_field "description" "$file")")"
+  body="$(get_body "$file" | clean_text)"
+
+  outfile="$OUT_DIR/codex/agents/$(basename "${file%.md}").toml"
+  mkdir -p "$(dirname "$outfile")"
+
+  # Codex custom agent format. The developer instructions use a TOML literal
+  # multi-line string so code samples with double quotes stay untouched.
+  cat > "$outfile" <<HEREDOC
+name = $(toml_basic_string "$name")
+description = $(toml_basic_string "$description")
+developer_instructions = '''
+${body}
+'''
 HEREDOC
 }
 
@@ -444,7 +490,7 @@ accumulate_aider() {
 
   name="$(get_field "name" "$file")"
   description="$(get_field "description" "$file")"
-  body="$(get_body "$file")"
+  body="$(get_body "$file" | clean_text)"
 
   cat >> "$AIDER_TMP" <<HEREDOC
 
@@ -464,7 +510,7 @@ accumulate_windsurf() {
 
   name="$(get_field "name" "$file")"
   description="$(get_field "description" "$file")"
-  body="$(get_body "$file")"
+  body="$(get_body "$file" | clean_text)"
 
   cat >> "$WINDSURF_TMP" <<HEREDOC
 
@@ -504,6 +550,7 @@ run_conversions() {
         opencode)    convert_opencode    "$file" ;;
         cursor)      convert_cursor      "$file" ;;
         openclaw)    convert_openclaw    "$file" ;;
+        codex)       convert_codex       "$file" ;;
         qwen)        convert_qwen        "$file" ;;
         kimi)        convert_kimi        "$file" ;;
         aider)       accumulate_aider    "$file" ;;
@@ -536,7 +583,7 @@ main() {
     esac
   done
 
-  local valid_tools=("antigravity" "gemini-cli" "opencode" "cursor" "aider" "windsurf" "openclaw" "qwen" "kimi" "all")
+  local valid_tools=("antigravity" "gemini-cli" "opencode" "cursor" "aider" "windsurf" "openclaw" "codex" "qwen" "kimi" "all")
   local valid=false
   for t in "${valid_tools[@]}"; do [[ "$t" == "$tool" ]] && valid=true && break; done
   if ! $valid; then
@@ -555,7 +602,7 @@ main() {
 
   local tools_to_run=()
   if [[ "$tool" == "all" ]]; then
-    tools_to_run=("antigravity" "gemini-cli" "opencode" "cursor" "aider" "windsurf" "openclaw" "qwen" "kimi")
+    tools_to_run=("antigravity" "gemini-cli" "opencode" "cursor" "aider" "windsurf" "openclaw" "codex" "qwen" "kimi")
   else
     tools_to_run=("$tool")
   fi
@@ -566,7 +613,7 @@ main() {
 
   if $use_parallel && [[ "$tool" == "all" ]]; then
     # Tools that write to separate dirs can run in parallel; buffer output so each tool's output stays together
-    local parallel_tools=(antigravity gemini-cli opencode cursor openclaw qwen)
+    local parallel_tools=(antigravity gemini-cli opencode cursor openclaw codex qwen kimi)
     local parallel_out_dir
     parallel_out_dir="$(mktemp -d)"
     info "Converting: ${#parallel_tools[@]}/${n_tools} tools in parallel (output buffered per tool)..."
@@ -578,7 +625,7 @@ main() {
       [[ -f "$parallel_out_dir/$t" ]] && cat "$parallel_out_dir/$t"
     done
     rm -rf "$parallel_out_dir"
-    local idx=7
+    local idx=$(( ${#parallel_tools[@]} + 1 ))
     for t in aider windsurf; do
       progress_bar "$idx" "$n_tools"
       printf "\n"

--- a/scripts/convert.sh
+++ b/scripts/convert.sh
@@ -121,6 +121,16 @@ strip_wrapping_quotes() {
   printf '%s' "$value"
 }
 
+codex_role_name() {
+  local name="$1"
+  name="$(strip_wrapping_quotes "$name")"
+  name="$(printf '%s' "$name" | sed 's/[^A-Za-z0-9 _-]/ /g' | sed 's/[[:space:]][[:space:]]*/ /g' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+  if [[ -z "$name" ]]; then
+    name="Agency Agent"
+  fi
+  printf '%s' "$name"
+}
+
 toml_basic_string() {
   local value="$1"
   value="${value//\\/\\\\}"
@@ -434,9 +444,10 @@ HEREDOC
 
 convert_codex() {
   local file="$1"
-  local name description outfile body
+  local name codex_name description outfile body
 
   name="$(strip_wrapping_quotes "$(get_field "name" "$file")")"
+  codex_name="$(codex_role_name "$name")"
   description="$(strip_wrapping_quotes "$(get_field "description" "$file")")"
   body="$(get_body "$file" | clean_text)"
 
@@ -446,9 +457,11 @@ convert_codex() {
   # Codex custom agent format. The developer instructions use a TOML literal
   # multi-line string so code samples with double quotes stay untouched.
   cat > "$outfile" <<HEREDOC
-name = $(toml_basic_string "$name")
+name = $(toml_basic_string "$codex_name")
 description = $(toml_basic_string "$description")
 developer_instructions = '''
+# ${name}
+
 ${body}
 '''
 HEREDOC

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -19,7 +19,9 @@
 #   aider        -- Copy CONVENTIONS.md to current directory
 #   windsurf     -- Copy .windsurfrules to current directory
 #   openclaw     -- Copy workspaces to ~/.openclaw/agency-agents/
+#   codex        -- Copy custom agents to ~/.codex/agents/
 #   qwen         -- Copy SubAgents to ~/.qwen/agents/ (user-wide) or .qwen/agents/ (project)
+#   kimi         -- Copy Kimi Code agents to ~/.config/kimi/agents/
 #   all          -- Install for all detected tools (default)
 #
 # Flags:
@@ -101,7 +103,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 INTEGRATIONS="$REPO_ROOT/integrations"
 
-ALL_TOOLS=(claude-code copilot antigravity gemini-cli opencode openclaw cursor aider windsurf qwen kimi)
+ALL_TOOLS=(claude-code copilot antigravity gemini-cli opencode openclaw codex cursor aider windsurf qwen kimi)
 
 # Standard agent category directories (keep sorted, sync with convert.sh / lint-agents.sh)
 AGENT_DIRS=(
@@ -146,6 +148,7 @@ detect_cursor()       { command -v cursor >/dev/null 2>&1 || [[ -d "${HOME}/.cur
 detect_opencode()     { command -v opencode >/dev/null 2>&1 || [[ -d "${HOME}/.config/opencode" ]]; }
 detect_aider()        { command -v aider >/dev/null 2>&1; }
 detect_openclaw()     { command -v openclaw >/dev/null 2>&1 || [[ -d "${HOME}/.openclaw" ]]; }
+detect_codex()        { command -v codex >/dev/null 2>&1 || [[ -d "${CODEX_HOME:-$HOME/.codex}" ]]; }
 detect_windsurf()     { command -v windsurf >/dev/null 2>&1 || [[ -d "${HOME}/.codeium" ]]; }
 detect_qwen()         { command -v qwen >/dev/null 2>&1 || [[ -d "${HOME}/.qwen" ]]; }
 detect_kimi()         { command -v kimi >/dev/null 2>&1; }
@@ -158,6 +161,7 @@ is_detected() {
     gemini-cli)  detect_gemini_cli  ;;
     opencode)    detect_opencode    ;;
     openclaw)    detect_openclaw    ;;
+    codex)       detect_codex       ;;
     cursor)      detect_cursor      ;;
     aider)       detect_aider       ;;
     windsurf)    detect_windsurf    ;;
@@ -176,6 +180,7 @@ tool_label() {
     gemini-cli)  printf "%-14s  %s" "Gemini CLI"   "(gemini extension)"      ;;
     opencode)    printf "%-14s  %s" "OpenCode"     "(opencode.ai)"           ;;
     openclaw)    printf "%-14s  %s" "OpenClaw"     "(~/.openclaw/agency-agents)" ;;
+    codex)       printf "%-14s  %s" "Codex"        "(~/.codex/agents)"       ;;
     cursor)      printf "%-14s  %s" "Cursor"       "(.cursor/rules)"         ;;
     aider)       printf "%-14s  %s" "Aider"        "(CONVENTIONS.md)"        ;;
     windsurf)    printf "%-14s  %s" "Windsurf"     "(.windsurfrules)"        ;;
@@ -436,6 +441,30 @@ install_openclaw() {
   fi
 }
 
+install_codex() {
+  local src="$INTEGRATIONS/codex/agents"
+  local dest="${CODEX_HOME:-$HOME/.codex}/agents"
+  local count=0
+
+  [[ -d "$src" ]] || { err "integrations/codex missing. Run ./scripts/convert.sh --tool codex first."; return 1; }
+
+  mkdir -p "$dest"
+
+  local f
+  while IFS= read -r -d '' f; do
+    cp "$f" "$dest/"
+    (( count++ )) || true
+  done < <(find "$src" -maxdepth 1 -name "*.toml" -print0)
+
+  if (( count == 0 )); then
+    err "integrations/codex contains no generated agents. Run ./scripts/convert.sh --tool codex first."
+    return 1
+  fi
+
+  ok "Codex: installed $count agents -> $dest"
+  warn "Codex: restart Codex or open a new session to refresh the agent list."
+}
+
 install_cursor() {
   local src="$INTEGRATIONS/cursor/rules"
   local dest="${PWD}/.cursor/rules"
@@ -526,6 +555,7 @@ install_tool() {
     gemini-cli)  install_gemini_cli  ;;
     opencode)    install_opencode    ;;
     openclaw)    install_openclaw    ;;
+    codex)       install_codex       ;;
     cursor)      install_cursor      ;;
     aider)       install_aider       ;;
     windsurf)    install_windsurf    ;;


### PR DESCRIPTION
## Summary
- add Codex as a supported conversion and install target
- generate Codex custom agent TOML under integrations/codex/agents
- document Codex setup in the main README and integrations docs

## Validation
- bash -n scripts/convert.sh scripts/install.sh
- ./scripts/convert.sh --tool codex
- ./scripts/convert.sh --tool all --parallel
- validated 184 generated Codex TOML files with Python tomllib
- CODEX_HOME=$(mktemp -d) ./scripts/install.sh --tool codex installed 184 agents