### PR TITLE
fix: remove stray EOFcat heredoc artifact from SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,4 +28,3 @@ This repository contains Markdown-based agent definitions and shell scripts for 
 - Never add executable code inside agent Markdown files
 - Shell scripts must be reviewed before merging
 - Report suspicious agent definitions that attempt prompt injection
-EOFcat SECURITY.md


### PR DESCRIPTION
## What does this PR do?

Removes the stray `EOFcat SECURITY.md` line at the end of SECURITY.md. The text is a heredoc terminator that leaked into the file when PR #410 first added the policy, and it renders verbatim on GitHub as the final line of the security policy page.

```
$ tail -1 SECURITY.md       # before
EOFcat SECURITY.md
$ tail -1 SECURITY.md       # after
- Report suspicious agent definitions that attempt prompt injection
```

One line delete. No other changes.

## Agent Information (if adding/modifying an agent)

N/A. Doc fix to SECURITY.md.

## Checklist

- [x] Follows the agent template structure from CONTRIBUTING.md (N/A, doc fix)
- [x] Includes YAML frontmatter with `name`, `description`, `color` (N/A, doc fix)
- [x] Has concrete code/template examples (for new agents) (N/A, doc fix)
- [x] Tested in real scenarios (`tail -1 SECURITY.md` before and after)
- [x] Proofread and formatted correctly

Closes #530
