### PR TITLE
fix: remove stray heredoc artifact and quote YAML description field

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,4 +28,3 @@ This repository contains Markdown-based agent definitions and shell scripts for 
 - Never add executable code inside agent Markdown files
 - Shell scripts must be reviewed before merging
 - Report suspicious agent definitions that attempt prompt injection
-EOFcat SECURITY.md

--- a/specialized/zk-steward.md
+++ b/specialized/zk-steward.md
@@ -1,6 +1,6 @@
 ---
 name: ZK Steward
-description: Knowledge-base steward in the spirit of Niklas Luhmann's Zettelkasten. Default perspective: Luhmann; switches to domain experts (Feynman, Munger, Ogilvy, etc.) by task. Enforces atomic notes, connectivity, and validation loops. Use for knowledge-base building, note linking, complex task breakdown, and cross-domain decision support.
+description: "Knowledge-base steward in the spirit of Niklas Luhmann's Zettelkasten. Default perspective: Luhmann; switches to domain experts (Feynman, Munger, Ogilvy, etc.) by task. Enforces atomic notes, connectivity, and validation loops. Use for knowledge-base building, note linking, complex task breakdown, and cross-domain decision support."
 color: teal
 emoji: 🗃️
 vibe: Channels Luhmann's Zettelkasten to build connected, validated knowledge bases.


### PR DESCRIPTION
## Summary

Two small fixes:

1. **SECURITY.md**: Remove trailing literal text `EOFcat SECURITY.md` (heredoc terminator that leaked into the file during PR #410). Fixes #530.
2. **specialized/zk-steward.md**: Quote the `description` YAML field to fix parse error caused by colons in the description text. Fixes #473.

## Changes

- `SECURITY.md`: removed line 31 (the stray `EOFcat SECURITY.md` heredoc artifact)
- `specialized/zk-steward.md`: wrapped description value in double quotes

## Verification

```bash
# YAML validation - should exit cleanly
python3 -c "import yaml; yaml.safe_load(open('specialized/zk-steward.md').read().split('---')[2])"

# SECURITY.md should end with the prompt injection reporting line, no trailing artifact
tail -1 SECURITY.md
# Expected: "- Report suspicious agent definitions that attempt prompt injection"
```
