### PR TITLE
fix: align local linter scope with CI workflow

### DIFF
--- a/scripts/lint-agents.sh
+++ b/scripts/lint-agents.sh
@@ -24,7 +24,6 @@ AGENT_DIRS=(
   sales
   spatial-computing
   specialized
-  strategy
   support
   testing
 )


### PR DESCRIPTION
## Summary
- Remove `strategy` from `AGENT_DIRS` in `scripts/lint-agents.sh`
- Align default local lint scope with existing CI workflow scope

## Why
Local full lint included strategy docs that are not agent files and are not part of CI lint paths, causing avoidable local hard failures.

## Validation
- `bash scripts/lint-agents.sh` now passes with 0 errors (warnings unchanged).
