### PR TITLE
docs: add Korean (ko) + Japanese (ja-JP) community translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -914,6 +914,8 @@ Community-maintained translations and regional adaptations. These are independen
 | 🇷🇺 Русский (ru) | [@jnMetaCode](https://github.com/jnMetaCode) | [agency-agents-ru](https://github.com/jnMetaCode/agency-agents-ru) | 184 upstream agents translated; Russia-market PRs welcome |
 | 🇮🇩 Bahasa Indonesia (id) | [@jnMetaCode](https://github.com/jnMetaCode) | [agency-agents-id](https://github.com/jnMetaCode/agency-agents-id) | 184 upstream agents translated; Indonesia-market PRs welcome |
 | 🇸🇦 العربية (ar) | [@jnMetaCode](https://github.com/jnMetaCode) | [agency-agents-ar](https://github.com/jnMetaCode/agency-agents-ar) | 184 upstream agents translated; Arabic-market PRs welcome |
+| 🇰🇷 한국어 (ko) | [@jnMetaCode](https://github.com/jnMetaCode) | [agency-agents-ko](https://github.com/jnMetaCode/agency-agents-ko) | 184 upstream agents fully translated; Korea-specific PRs welcome |
+| 🇯🇵 日本語 (ja-JP) | [@sscodeai](https://github.com/sscodeai) | [agency-agents-ja](https://github.com/sscodeai/agency-agents-ja) | 281 Japan-localized agents + 97 Japan-market originals + 27 workflows |
 
 Want to add a translation? Open an issue and we'll link it here.
 


### PR DESCRIPTION
Adds two verified community translations to the Community Translations table.

| Language | Maintainer | Source |
|---|---|---|
| 🇰🇷 한국어 (ko) | @jnMetaCode | issue #547 |
| 🇯🇵 日本語 (ja-JP) | @sscodeai | PR #551 |

**Why this PR (and not #551 directly):** #551 conflicted on the translations table once #550 (pt-BR/ru/id/ar) merged. Rather than block on a rebase, @sscodeai's row is incorporated here with credit (Co-Authored-By). The Korean row comes from #547, where @jnMetaCode supplied the exact row.

**Verified:** both target repos exist with real translated content (`sscodeai/agency-agents-ja` confirmed genuinely Japanese with upstream tracking; `jnMetaCode/agency-agents-ko` from the established zh-CN maintainer).

Closes #545, #547, #551.

🤖 Generated with [Claude Code](https://claude.com/claude-code)