### PR TITLE
fix: scrub hardcoded test credentials (#477)

### DIFF
--- a/testing/testing-api-tester.md
+++ b/testing/testing-api-tester.md
@@ -74,7 +74,7 @@ describe('User API Comprehensive Testing', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         email: 'test@example.com',
-        password: 'secure_password'
+        password: process.env.TEST_USER_PASSWORD
       })
     });
     const data = await response.json();

--- a/testing/testing-performance-benchmarker.md
+++ b/testing/testing-performance-benchmarker.md
@@ -90,7 +90,7 @@ export default function () {
   // Test critical user journey
   const loginResponse = http.post(`${baseUrl}/api/auth/login`, {
     email: 'test@example.com',
-    password: 'password123'
+    password: __ENV.TEST_USER_PASSWORD
   });
   
   check(loginResponse, {


### PR DESCRIPTION
## What
Closes #477. Two testing agents had literal passwords in their example code:
- `testing/testing-api-tester.md` — `password: 'secure_password'`
- `testing/testing-performance-benchmarker.md` — `password: 'password123'`

## Fix
Replaced each with an environment-variable read — the secure, framework-idiomatic pattern (not just a placeholder string):
- Jest/Node example → `process.env.TEST_USER_PASSWORD`
- k6 load-test script → `__ENV.TEST_USER_PASSWORD`

This removes the weak-credential examples **and** models good secrets hygiene for anyone copying the snippets.

## Verification
- `grep secure_password|password123 testing/` → clean
- `lint-agents.sh` → PASS

Closes #477

🤖 Generated with [Claude Code](https://claude.com/claude-code)