### PR TITLE
docs: document Codex GUI agent mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -945,6 +945,18 @@ Then reference the custom agent by name in Codex:
 Use the Frontend Developer agent to review this component.
 ```
 
+In the Codex GUI, you can mention an agent with `@<agent name>`:
+```
+Use @Frontend Developer to review this component.
+```
+
+You can also mention multiple agents in one prompt:
+```
+@Product Manager evaluate the current product maturity.
+@UI Designer audit whether the current mini program design is appropriate.
+@WeChat Mini Program Developer check whether the current mini program follows development standards.
+```
+
 See [integrations/codex/README.md](integrations/codex/README.md) for details.
 </details>
 

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -47,6 +47,20 @@ After installation, reference the custom agent by name in Codex:
 Use the Frontend Developer agent to review this component.
 ```
 
+In the Codex GUI, you can mention an agent with `@<agent name>`:
+
+```text
+Use @Frontend Developer to review this component.
+```
+
+You can also mention multiple agents in one prompt:
+
+```text
+@Product Manager evaluate the current product maturity.
+@UI Designer audit whether the current mini program design is appropriate.
+@WeChat Mini Program Developer check whether the current mini program follows development standards.
+```
+
 Codex uses the `name` field inside the TOML file as the source of truth, so the
 generated filename slug is only for filesystem safety.
 


### PR DESCRIPTION
## What does this PR do?

Documents how to mention Codex custom agents in the Codex GUI with `@<agent name>`.

This adds examples to:
- `README.md`
- `integrations/codex/README.md`

## Agent Information (if adding/modifying an agent)

N/A — documentation-only change.

## Checklist

- [x] Proofread and formatted correctly
- [x] Documentation-only change
- [x] No generated files committed
- [x] Ran `git diff --check`