### PR TITLE
fix(install): honor $CLAUDE_CONFIG_DIR as config root, not agents dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Born from a Reddit thread and months of iteration, **The Agency** is a growing c
 ./scripts/install.sh --tool claude-code
 
 # Or manually copy a category if you only want one division
+# (use "$CLAUDE_CONFIG_DIR/agents" instead if you've relocated your config)
 cp engineering/*.md ~/.claude/agents/
 
 # Then activate any agent in your Claude Code sessions:
@@ -640,7 +641,7 @@ The Agency works natively with Claude Code, and ships conversion + install scrip
 
 ### Supported Tools
 
-- **[Claude Code](https://claude.ai/code)** — native `.md` agents, no conversion needed → `~/.claude/agents/`
+- **[Claude Code](https://claude.ai/code)** — native `.md` agents, no conversion needed → `~/.claude/agents/` (or `$CLAUDE_CONFIG_DIR/agents`)
 - **[GitHub Copilot](https://github.com/copilot)** — native `.md` agents, no conversion needed → `~/.github/agents/` + `~/.copilot/agents/`
 - **[Antigravity](https://github.com/google-gemini/antigravity)** — `SKILL.md` per agent → `~/.gemini/antigravity/skills/`
 - **[Gemini CLI](https://github.com/google-gemini/gemini-cli)** — extension + `SKILL.md` files → `~/.gemini/extensions/agency-agents/`
@@ -726,7 +727,7 @@ The installer scans your system for installed tools, shows a checkbox UI, and le
 <details>
 <summary><strong>Claude Code</strong></summary>
 
-Agents are copied directly from the repo into `~/.claude/agents/` -- no conversion needed.
+Agents are copied directly from the repo into `~/.claude/agents/` (or `$CLAUDE_CONFIG_DIR/agents` if you've relocated your config) -- no conversion needed.
 
 ```bash
 ./scripts/install.sh --tool claude-code
@@ -1026,7 +1027,7 @@ To everyone who has opened a PR, filed an issue, started a Discussion, or simply
 ## 🚀 Get Started
 
 1. **Browse** the agents above and find specialists for your needs
-2. **Copy** the agents to `~/.claude/agents/` for Claude Code integration
+2. **Copy** the agents to `~/.claude/agents/` (or `$CLAUDE_CONFIG_DIR/agents` if you've relocated your config) for Claude Code integration
 3. **Activate** agents by referencing them in your Claude conversations
 4. **Customize** agent personalities and workflows for your specific needs
 5. **Share** your results and contribute back to the community

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -67,7 +67,7 @@ The Agency was originally designed for Claude Code. Agents work natively
 without conversion.
 
 ```bash
-cp -r <category>/*.md ~/.claude/agents/
+cp -r <category>/*.md ~/.claude/agents/   # or "$CLAUDE_CONFIG_DIR/agents" if relocated
 # or install everything at once:
 ./scripts/install.sh --tool claude-code
 ```

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -10,6 +10,7 @@ natively with the existing `.md` + YAML frontmatter format.
 ./scripts/install.sh --tool claude-code
 
 # Or manually copy a category
+# (use "$CLAUDE_CONFIG_DIR/agents" instead if you've relocated your config)
 cp engineering/*.md ~/.claude/agents/
 ```
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -12,7 +12,7 @@
 #   Bare invocation installs all teams to detected tools (interactive when a TTY).
 #
 # Tools:
-#   claude-code  -- Copy agents to ~/.claude/agents/
+#   claude-code  -- Copy agents to ~/.claude/agents/ (or $CLAUDE_CONFIG_DIR/agents)
 #   copilot      -- Copy agents to ~/.github/agents/ and ~/.copilot/agents/
 #   antigravity  -- Copy skills to ~/.gemini/antigravity/skills/
 #   gemini-cli   -- Install agents to ~/.gemini/agents/
@@ -256,7 +256,14 @@ resolve_dest() {
     qwen)        var="QWEN_AGENTS_DIR" ;;
     codex)       var="CODEX_AGENTS_DIR" ;;
   esac
-  if [[ -n "$var" && -n "${!var:-}" ]]; then printf '%s' "${!var}"; else printf '%s' "$def"; fi
+  if [[ -n "$var" && -n "${!var:-}" ]]; then
+    # CLAUDE_CONFIG_DIR is Claude Code's config *root* (it replaces ~/.claude);
+    # agents live in its agents/ subdir, so append that rather than using the
+    # value verbatim. Other tools' vars already point at the agents dir.
+    if [[ "$tool" == "claude-code" ]]; then printf '%s' "${!var%/}/agents"; else printf '%s' "${!var}"; fi
+  else
+    printf '%s' "$def"
+  fi
 }
 
 # resolve_tool_path <tool> — best-effort binary path for the detection UI.
@@ -351,7 +358,7 @@ check_integrations() {
 # ---------------------------------------------------------------------------
 # Tool detection
 # ---------------------------------------------------------------------------
-detect_claude_code() { [[ -d "${HOME}/.claude" ]]; }
+detect_claude_code() { [[ -n "${CLAUDE_CONFIG_DIR:-}" && -d "${CLAUDE_CONFIG_DIR}" ]] || [[ -d "${HOME}/.claude" ]]; }
 detect_copilot()      { command -v code >/dev/null 2>&1 || [[ -d "${HOME}/.github" || -d "${HOME}/.copilot" ]]; }
 detect_antigravity()  { [[ -d "${HOME}/.gemini/antigravity/skills" ]]; }
 detect_gemini_cli()   { command -v gemini >/dev/null 2>&1 || [[ -d "${HOME}/.gemini" ]]; }


### PR DESCRIPTION
Fixes #578.

## Problem

`scripts/install.sh` consults `CLAUDE_CONFIG_DIR` but uses it incorrectly:

1. **Wrong destination.** `CLAUDE_CONFIG_DIR` is Claude Code's config *root* (it replaces `~/.claude`); agents belong in its `agents/` subdir. `resolve_dest()` returned the variable verbatim, so agents landed in the config root instead of `agents/` and were never discovered — inconsistent with the default path, which appends `/agents`.
2. **Auto-detection miss.** `detect_claude_code()` only checked `~/.claude`, so a user who relocated their config via `CLAUDE_CONFIG_DIR` (and has no `~/.claude`) was reported as "not installed."

## Fix

- `resolve_dest()`: for `claude-code`, append `/agents` to the env-var value (stripping any trailing slash). Other tools' vars (`COPILOT_AGENT_DIR`, etc.) already point at the agents dir and remain verbatim.
- `detect_claude_code()`: also recognize a relocated config via `CLAUDE_CONFIG_DIR`.

## Test results

`resolve_dest` logic, run under bash:

| Case | Result |
|------|--------|
| no var set | `$HOME/.claude/agents` |
| `CLAUDE_CONFIG_DIR=$HOME/.config/claude-code` | `$HOME/.config/claude-code/agents` |
| `CLAUDE_CONFIG_DIR=$HOME/.config/claude-code/` (trailing slash) | `$HOME/.config/claude-code/agents` |

Full install on a real relocated config (`CLAUDE_CONFIG_DIR=~/.config/claude-code`):

```
$ ./scripts/install.sh --tool claude-code --no-interactive
[OK]  Claude Code: 232 agents -> /Users/.../.config/claude-code/agents
```

Agents now land in `$CLAUDE_CONFIG_DIR/agents` as expected. `bash -n scripts/install.sh` passes.

Note: the README's manual `cp ... ~/.claude/agents/` instructions carry the same hardcoded assumption and could mention `CLAUDE_CONFIG_DIR`; left out of this PR to keep it focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)