### PR TITLE
Exclude integrations/ from the source-agent scan (it's convert.sh output)

### DIFF
--- a/.github/workflows/lint-agents.yml
+++ b/.github/workflows/lint-agents.yml
@@ -9,7 +9,6 @@ on:
       - "finance/**"
       - "game-development/**"
       - "gis/**"
-      - "integrations/**"
       - "marketing/**"
       - "paid-media/**"
       - "sales/**"
@@ -35,7 +34,7 @@ jobs:
         id: changed
         run: |
           FILES=$(git diff --name-only --diff-filter=ACMR origin/${{ github.base_ref }}...HEAD -- \
-            'academic/**/*.md' 'design/**/*.md' 'engineering/**/*.md' 'finance/**/*.md' 'game-development/**/*.md' 'gis/**/*.md' 'integrations/**/*.md' 'marketing/**/*.md' 'paid-media/**/*.md' 'sales/**/*.md' 'security/**/*.md' 'product/**/*.md' \
+            'academic/**/*.md' 'design/**/*.md' 'engineering/**/*.md' 'finance/**/*.md' 'game-development/**/*.md' 'gis/**/*.md' 'marketing/**/*.md' 'paid-media/**/*.md' 'sales/**/*.md' 'security/**/*.md' 'product/**/*.md' \
             'project-management/**/*.md' 'testing/**/*.md' 'support/**/*.md' \
             'spatial-computing/**/*.md' 'specialized/**/*.md' 'strategy/**/*.md')
           {

--- a/divisions.json
+++ b/divisions.json
@@ -1,5 +1,5 @@
 {
-  "_note": "Source of truth for the agent division set. Each division (a top-level agent directory) maps to a display label, a Lucide icon name (PascalCase), and a brand color (hex). Consumed by the Agency Agents app and any other catalog tooling. scripts/check-divisions.sh (CI: check-divisions.yml) fails the build if this list disagrees with the directories on disk, the AGENT_DIRS arrays in scripts/convert.sh and scripts/lint-agents.sh, or the path filters in lint-agents.yml. To add a division: create its directory, add an entry here, then run scripts/check-divisions.sh and update wherever it points.",
+  "_note": "Source of truth for the agent division set. Each division (a top-level agent directory) maps to a display label, a Lucide icon name (PascalCase), and a brand color (hex). Consumed by the Agency Agents app and any other catalog tooling. scripts/check-divisions.sh (CI: check-divisions.yml) fails the build if this list disagrees with the directories on disk, the AGENT_DIRS arrays in scripts/convert.sh and scripts/lint-agents.sh, or the path filters in lint-agents.yml. To add a division: create its directory, add an entry here, then run scripts/check-divisions.sh and update wherever it points. NOT every top-level directory is a division: integrations/ holds per-tool conversion OUTPUTS written by scripts/convert.sh (not source agents) and is excluded via NON_DIVISION_DIRS in check-divisions.sh; examples/ and scripts/ are likewise excluded.",
   "divisions": {
     "academic": { "label": "Academic", "icon": "GraduationCap", "color": "#8B5CF6" },
     "design": { "label": "Design", "icon": "PenTool", "color": "#EC4899" },
@@ -7,7 +7,6 @@
     "finance": { "label": "Finance", "icon": "DollarSign", "color": "#22C55E" },
     "game-development": { "label": "Game Development", "icon": "Gamepad2", "color": "#A855F7" },
     "gis": { "label": "GIS", "icon": "Map", "color": "#14B8A6" },
-    "integrations": { "label": "Integrations", "icon": "Workflow", "color": "#64748B" },
     "marketing": { "label": "Marketing", "icon": "Megaphone", "color": "#F97316" },
     "paid-media": { "label": "Paid Media", "icon": "Target", "color": "#EAB308" },
     "product": { "label": "Product", "icon": "Box", "color": "#D946EF" },

--- a/scripts/check-divisions.sh
+++ b/scripts/check-divisions.sh
@@ -25,7 +25,9 @@ JSON="divisions.json"
 # Top-level directories that are NOT divisions. Everything else at the repo
 # root that is a directory is treated as a division (so a new division dir is
 # caught even if nobody remembered to register it).
-NON_DIVISION_DIRS=(examples scripts)
+# integrations/ is convert.sh's OUTPUT tree (per-tool conversions written back
+# into the repo), not a source-agent category — it must never be scanned as one.
+NON_DIVISION_DIRS=(examples scripts integrations)
 
 errors=0
 fail() { echo "ERROR $*"; errors=$((errors + 1)); }

--- a/scripts/convert.sh
+++ b/scripts/convert.sh
@@ -67,7 +67,7 @@ TODAY="$(date +%Y-%m-%d)"
 . "$SCRIPT_DIR/lib.sh"
 
 AGENT_DIRS=(
-  academic design engineering finance game-development gis integrations marketing paid-media product project-management
+  academic design engineering finance game-development gis marketing paid-media product project-management
   sales security spatial-computing specialized strategy support testing
 )
 

--- a/scripts/lint-agents.sh
+++ b/scripts/lint-agents.sh
@@ -18,7 +18,6 @@ AGENT_DIRS=(
   finance
   game-development
   gis
-  integrations
   marketing
   paid-media
   product


### PR DESCRIPTION
## What

`#592` added `integrations` to `AGENT_DIRS` in `convert.sh` and `lint-agents.sh` and to the lint-workflow path filters, to make those lists match `divisions.json`. That was the wrong call.

**`integrations/` is not a source-agent category — it's convert.sh's *output* tree.** `convert.sh` writes per-tool conversions back into it (e.g. openclaw → `integrations/openclaw/<agent>/SOUL.md`). On disk:

| | count |
|---|---|
| Real source agents (17 categories) | 248 |
| `integrations/` conversion outputs | 957 (openclaw 427 · opencode 232 · qwen 143 · antigravity 143 · others ≤2) |

## Why it broke things

Scanning `integrations/` as source makes the toolchain re-convert its own outputs. The same agent shows up under every tool (`brand-guardian` appears 5×), output slugs collide, and `convert.sh`'s last-writer-wins corrupts the catalog — which is what broke downstream parity checks. `convert.sh` originally omitted `integrations` **on purpose**; #592 misread that deliberate exclusion as drift and "fixed" it.

## The fix

- Remove `integrations` from `AGENT_DIRS` in `convert.sh` and `lint-agents.sh`.
- Remove `integrations/**` from `lint-agents.yml` path filters.
- Remove `integrations` from `divisions.json` (it's not a division).
- Add `integrations` to `NON_DIVISION_DIRS` in `check-divisions.sh` (alongside `examples`, `scripts`) so the guard's canonical set is the real 17 categories — and document why in the `divisions.json` `_note`.

The `strategy` additions from #592 were correct and are retained.

`scripts/check-divisions.sh` now **PASSES at 17** divisions consistent across `divisions.json`, directories, scripts, and CI.

## Follow-up (not in this PR)

`integrations/mcp-memory/` holds 2 real source agents stranded in the output tree. Relocating them to a real category is left as a separate change.