### PR TITLE
check-divisions: enumerate git-tracked dirs, not a filesystem glob

### DIFF
--- a/scripts/check-divisions.sh
+++ b/scripts/check-divisions.sh
@@ -45,16 +45,18 @@ canonical() {
     | sed -E 's/"([a-z0-9-]+)".*/\1/' | sort -u
 }
 
-# Actual division directories on disk (top-level dirs minus the excludes and
-# anything dot-prefixed).
+# Actual division directories: top-level dirs that contain at least one
+# git-TRACKED file, minus the excludes and anything dot-prefixed. Using
+# `git ls-files` (not a filesystem glob) keeps this in lockstep with what CI's
+# clean checkout sees, so a local gitignored scratch dir (e.g. notes/) can't
+# produce a false failure.
 actual_dirs() {
-  local d base
-  for d in */; do
-    base="${d%/}"
+  local base
+  git ls-files | awk -F/ 'NF>1{print $1}' | sort -u | while IFS= read -r base; do
     [[ "$base" == .* ]] && continue
     case " ${NON_DIVISION_DIRS[*]} " in *" $base "*) continue ;; esac
     echo "$base"
-  done | sort -u
+  done
 }
 
 # Contents of a bash AGENT_DIRS=( ... ) array in the given file, one per line.


### PR DESCRIPTION
## What

`check-divisions.sh`'s `actual_dirs()` globbed the filesystem (`for d in */`), so it picked up **gitignored/untracked** top-level directories (e.g. a local `notes/` scratch dir) and reported them as `division(s) not in divisions.json`.

That's a false failure: CI uses a clean `actions/checkout` and never sees those dirs, so the check **passed in CI but failed locally** — undermining a guard whose whole point is to be run locally before pushing.

## Fix

Enumerate top-level dirs via `git ls-files` (only dirs containing a tracked file), keeping the existing dot-prefix and `NON_DIVISION_DIRS` filters. Local now matches CI exactly.

## Verified

- Passes at **16** divisions.
- An **untracked** dir is ignored (the `notes/` scenario).
- A **tracked** unregistered division dir still fails the check.