### PR TITLE
Add Osaurus tool target + document the division contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ integrations/kimi/*/
 !integrations/openclaw/README.md
 !integrations/kimi/README.md
 integrations/codex/agents/*
+integrations/osaurus/agency-*/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,20 +31,34 @@ This project and everyone participating in it is governed by our Code of Conduct
 Have an idea for a specialized agent? Great! Here's how to add one:
 
 1. **Fork the repository**
-2. **Choose the appropriate category** (or propose a new one):
-   - `engineering/` - Software development specialists
+2. **Choose the appropriate division** (one of the 16 — or propose a new one):
+   - `academic/` - Research, scholarship, and domain-expert specialists
    - `design/` - UX/UI and creative specialists
+   - `engineering/` - Software development specialists
    - `finance/` - Financial planning, accounting, and investment specialists
    - `game-development/` - Game design and development specialists
+   - `gis/` - Geospatial, mapping, and spatial-analysis specialists
    - `marketing/` - Growth and marketing specialists
    - `paid-media/` - Paid acquisition and media specialists
    - `product/` - Product management specialists
    - `project-management/` - PM and coordination specialists
-   - `testing/` - QA and testing specialists
+   - `sales/` - Sales, revenue, and deal specialists
    - `security/` - Security architecture, AppSec, pentest, threat intel, and incident response
-   - `support/` - Operations and support specialists
    - `spatial-computing/` - AR/VR/XR specialists
    - `specialized/` - Unique specialists that don't fit elsewhere
+   - `support/` - Operations and support specialists
+   - `testing/` - QA and testing specialists
+
+   > **Divisions are defined by `divisions.json`** (repo root) — the single source of
+   > truth for the division set, validated in CI by `scripts/check-divisions.sh`.
+   > **Proposing a new division** means: create the directory, add an entry to
+   > `divisions.json` (label/icon/color), and add it to `AGENT_DIRS` in both
+   > `scripts/convert.sh` and `scripts/lint-agents.sh`. The check fails the build
+   > unless all of these agree and the directory contains at least one agent file.
+   >
+   > Note: `strategy/` (NEXUS playbooks/runbooks — no agent frontmatter) and
+   > `integrations/` (generated per-tool output from `convert.sh`) are **not**
+   > divisions and must never be added to the division lists.
 
 3. **Create your agent file** following the template below
 4. **Test your agent** in real scenarios

--- a/scripts/convert.sh
+++ b/scripts/convert.sh
@@ -20,6 +20,7 @@
 #   qwen         — Qwen Code SubAgent files (~/.qwen/agents/*.md)
 #   kimi         — Kimi Code CLI agent files (~/.config/kimi/agents/)
 #   codex        — Codex custom agent TOML files (~/.codex/agents/*.toml)
+#   osaurus      — Osaurus skill files (~/.osaurus/skills/<name>/SKILL.md)
 #   all          — All tools (default)
 #
 # Output is written to integrations/<tool>/ relative to the repo root.
@@ -73,7 +74,7 @@ AGENT_DIRS=(
 
 # --- Usage ---
 usage() {
-  sed -n '3,26p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '3,27p' "$0" | sed 's/^# \{0,1\}//'
   exit 0
 }
 
@@ -125,6 +126,33 @@ description: ${description}
 risk: low
 source: community
 date_added: '${TODAY}'
+---
+${body}
+HEREDOC
+}
+
+convert_osaurus() {
+  local file="$1"
+  local name description slug outdir outfile body
+
+  name="$(get_field "name" "$file")"
+  description="$(get_field "description" "$file")"
+  slug="agency-$(slugify "$name")"
+  body="$(get_body "$file")"
+
+  # Stage one dir per skill (install.sh copies into ~/.osaurus/skills/<name>/).
+  outdir="$OUT_DIR/osaurus/$slug"
+  outfile="$outdir/SKILL.md"
+  mkdir -p "$outdir"
+
+  # Osaurus skill format: the Anthropic "Agent Skills" SKILL.md — a directory
+  # named for the skill containing a SKILL.md with name + description frontmatter
+  # and the persona as the instruction body. Installs into ~/.osaurus/skills/.
+  # Kept to the standard fields so it stays compatible with any Agent-Skills host.
+  cat > "$outfile" <<HEREDOC
+---
+name: ${slug}
+description: ${description}
 ---
 ${body}
 HEREDOC
@@ -527,6 +555,7 @@ run_conversions() {
         openclaw)    convert_openclaw    "$file" ;;
         qwen)        convert_qwen        "$file" ;;
         kimi)        convert_kimi        "$file" ;;
+        osaurus)     convert_osaurus     "$file" ;;
         aider)       accumulate_aider    "$file" ;;
         windsurf)    accumulate_windsurf "$file" ;;
       esac
@@ -557,7 +586,7 @@ main() {
     esac
   done
 
-  local valid_tools=("antigravity" "gemini-cli" "opencode" "cursor" "aider" "windsurf" "openclaw" "qwen" "kimi" "codex" "all")
+  local valid_tools=("antigravity" "gemini-cli" "opencode" "cursor" "aider" "windsurf" "openclaw" "qwen" "kimi" "codex" "osaurus" "all")
   local valid=false
   for t in "${valid_tools[@]}"; do [[ "$t" == "$tool" ]] && valid=true && break; done
   if ! $valid; then
@@ -576,7 +605,7 @@ main() {
 
   local tools_to_run=()
   if [[ "$tool" == "all" ]]; then
-    tools_to_run=("antigravity" "gemini-cli" "opencode" "cursor" "aider" "windsurf" "openclaw" "qwen" "kimi" "codex")
+    tools_to_run=("antigravity" "gemini-cli" "opencode" "cursor" "aider" "windsurf" "openclaw" "qwen" "kimi" "codex" "osaurus")
   else
     tools_to_run=("$tool")
   fi
@@ -587,7 +616,7 @@ main() {
 
   if $use_parallel && [[ "$tool" == "all" ]]; then
     # Tools that write to separate dirs can run in parallel; buffer output so each tool's output stays together
-    local parallel_tools=(antigravity gemini-cli opencode cursor openclaw qwen codex)
+    local parallel_tools=(antigravity gemini-cli opencode cursor openclaw qwen codex osaurus)
     local parallel_out_dir
     parallel_out_dir="$(mktemp -d)"
     info "Converting: ${#parallel_tools[@]}/${n_tools} tools in parallel (output buffered per tool)..."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -23,6 +23,7 @@
 #   openclaw     -- Copy workspaces to ~/.openclaw/agency-agents/
 #   qwen         -- Copy SubAgents to ~/.qwen/agents/ (user-wide) or .qwen/agents/ (project)
 #   codex        -- Copy custom agent TOML files to ~/.codex/agents/
+#   osaurus      -- Copy skills to ~/.osaurus/skills/
 #   all          -- Install for all detected tools (default)
 #
 # Selection (compose freely; empty = everything):
@@ -125,9 +126,13 @@ INTEGRATIONS="$REPO_ROOT/integrations"
 # shellcheck source=lib.sh
 . "$SCRIPT_DIR/lib.sh"
 
-ALL_TOOLS=(claude-code copilot antigravity gemini-cli opencode openclaw cursor aider windsurf qwen kimi codex)
+ALL_TOOLS=(claude-code copilot antigravity gemini-cli opencode openclaw cursor aider windsurf qwen kimi codex osaurus)
 
-# Standard agent category directories (keep sorted, sync with convert.sh / lint-agents.sh)
+# Directories scanned for installable agents. Intentionally includes strategy/
+# (its frontmatter-less NEXUS docs are filtered out by is_agent_file at scan time);
+# the selectable division list below is this set minus strategy. This is NOT the
+# same set as AGENT_DIRS in convert.sh / lint-agents.sh, which exclude strategy
+# entirely — see divisions.json (the source of truth) and scripts/check-divisions.sh.
 AGENT_DIRS=(
   academic design engineering finance game-development gis marketing paid-media product project-management
   sales security spatial-computing specialized strategy support testing
@@ -255,6 +260,7 @@ resolve_dest() {
     openclaw)    var="OPENCLAW_DIR" ;;
     qwen)        var="QWEN_AGENTS_DIR" ;;
     codex)       var="CODEX_AGENTS_DIR" ;;
+    osaurus)     var="OSAURUS_SKILLS_DIR" ;;
   esac
   if [[ -n "$var" && -n "${!var:-}" ]]; then printf '%s' "${!var}"; else printf '%s' "$def"; fi
 }
@@ -267,6 +273,7 @@ resolve_tool_path() {
     opencode) bin="opencode" ;; openclaw) bin="openclaw" ;; cursor) bin="cursor" ;;
     aider) bin="aider" ;; windsurf) bin="windsurf" ;; qwen) bin="qwen" ;;
     kimi) bin="kimi" ;; codex) bin="codex" ;; antigravity) bin="" ;;
+    osaurus) bin="osaurus" ;;
   esac
   [[ -n "$bin" ]] && command -v "$bin" 2>/dev/null
 }
@@ -363,6 +370,7 @@ detect_windsurf()     { command -v windsurf >/dev/null 2>&1 || [[ -d "${HOME}/.c
 detect_qwen()         { command -v qwen >/dev/null 2>&1 || [[ -d "${HOME}/.qwen" ]]; }
 detect_kimi()         { command -v kimi >/dev/null 2>&1; }
 detect_codex()        { command -v codex >/dev/null 2>&1 || [[ -d "${HOME}/.codex" ]]; }
+detect_osaurus()      { command -v osaurus >/dev/null 2>&1 || [[ -d "${HOME}/.osaurus" ]]; }
 
 is_detected() {
   case "$1" in
@@ -378,6 +386,7 @@ is_detected() {
     qwen)        detect_qwen        ;;
     kimi)        detect_kimi        ;;
     codex)       detect_codex       ;;
+    osaurus)     detect_osaurus     ;;
     *)           return 1 ;;
   esac
 }
@@ -397,6 +406,7 @@ tool_label() {
     qwen)        printf "%-14s  %s" "Qwen Code"    "(~/.qwen/agents)"        ;;
     kimi)        printf "%-14s  %s" "Kimi Code"    "(~/.config/kimi/agents)" ;;
     codex)       printf "%-14s  %s" "Codex"        "(~/.codex/agents)"       ;;
+    osaurus)     printf "%-14s  %s" "Osaurus"      "(~/.osaurus/skills)"     ;;
   esac
 }
 
@@ -520,7 +530,7 @@ tool_simple_name() {
     claude-code) echo "Claude Code";; copilot) echo "Copilot";; antigravity) echo "Antigravity";;
     gemini-cli) echo "Gemini CLI";; opencode) echo "OpenCode";; openclaw) echo "OpenClaw";;
     cursor) echo "Cursor";; aider) echo "Aider";; windsurf) echo "Windsurf";;
-    qwen) echo "Qwen Code";; kimi) echo "Kimi Code";; codex) echo "Codex";; *) echo "$1";;
+    qwen) echo "Qwen Code";; kimi) echo "Kimi Code";; codex) echo "Codex";; osaurus) echo "Osaurus";; *) echo "$1";;
   esac
 }
 
@@ -719,6 +729,23 @@ install_antigravity() {
   ok "Antigravity: $count skills -> $dest"
 }
 
+install_osaurus() {
+  local src="$INTEGRATIONS/osaurus"
+  local dest; dest="$(resolve_dest osaurus "${HOME}/.osaurus/skills")"
+  local count=0
+  [[ -d "$src" ]] || { err "integrations/osaurus missing. Run convert.sh first."; return 1; }
+  mkdir -p "$dest"
+  local d
+  while IFS= read -r -d '' d; do
+    local name; name="$(basename "$d")"
+    slug_allowed "$name" || continue
+    mkdir -p "$dest/$name"
+    install_file "$d/SKILL.md" "$dest/$name/SKILL.md"
+    incr count
+  done < <(find "$src" -mindepth 1 -maxdepth 1 -type d -print0)
+  ok "Osaurus: $count skills -> $dest"
+}
+
 install_gemini_cli() {
   local src="$INTEGRATIONS/gemini-cli/agents"
   local dest; dest="$(resolve_dest gemini-cli "${HOME}/.gemini/agents")"
@@ -912,6 +939,7 @@ install_tool() {
     qwen)        install_qwen        ;;
     kimi)        install_kimi        ;;
     codex)       install_codex       ;;
+    osaurus)     install_osaurus     ;;
   esac
 }
 


### PR DESCRIPTION
## Tooling — new Osaurus target

Adds **Osaurus** (Anthropic Agent-Skills `SKILL.md` format, installs to `~/.osaurus/skills/`) as a conversion + install target:
- `convert.sh`: `convert_osaurus()` + wired into dispatch, valid-tools, all-tools, parallel-tools, and the `--osaurus` flag/usage line
- `install.sh`: `detect_osaurus` / label / dest (`OSAURUS_SKILLS_DIR`) / `install_osaurus()` + dispatch
- Generated output → `integrations/osaurus/agency-*/SKILL.md`, **gitignored** like every other tool's output (regenerate via `convert.sh osaurus`)

232 skills generated locally and verified; not committed (per the build-output convention).

## Docs / guardrails — make the division contract discoverable

The "what is a division" rule lived only in scattered script comments, which repeatedly tripped up contributors. This surfaces it:

- **`CONTRIBUTING.md`**: completes the division list to all **16** (was missing `academic`/`gis`/`sales`) and documents that `divisions.json` is the source of truth (CI-validated by `scripts/check-divisions.sh`), how to propose a new division, and that `strategy/` (NEXUS playbooks) and `integrations/` (generated output) are **not** divisions.
- **`install.sh`**: corrects the stale *"sync with convert.sh / lint-agents.sh"* comment — `install.sh` intentionally keeps `strategy/` in `AGENT_DIRS` (filtered at scan time via `is_agent_file`), so it is deliberately *not* the same set as the other two scripts.
- **`.gitignore`**: ignores `integrations/osaurus/agency-*/` — osaurus was the one tool whose generated files weren't excluded (exposed to accidental commit).

Guard green at 16 divisions; both scripts pass `bash -n`.