### PR TITLE
docs(install): list OSAURUS_SKILLS_DIR in the Env override header

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -47,7 +47,8 @@
 #   --help                Show this help
 #
 # Env: CLAUDE_CONFIG_DIR, COPILOT_AGENT_DIR, CURSOR_RULES_DIR, GEMINI_AGENTS_DIR,
-#      OPENCODE_AGENTS_DIR, OPENCLAW_DIR, QWEN_AGENTS_DIR, CODEX_AGENTS_DIR
+#      OPENCODE_AGENTS_DIR, OPENCLAW_DIR, QWEN_AGENTS_DIR, CODEX_AGENTS_DIR,
+#      OSAURUS_SKILLS_DIR
 #      override default install paths (checked before hardcoded defaults).
 #
 # --- USAGE-END ---  (sentinel for usage(); do not remove)


### PR DESCRIPTION
Tiny follow-up to #603. `resolve_dest` honors `OSAURUS_SKILLS_DIR` but the `install.sh` header's `Env:` line omitted it alongside the other `*_DIR` overrides. One-line doc add — caught by review on the osaurus merge.