### PR TITLE
fix(convert): prune stale tool output before regenerating

### DIFF
--- a/scripts/convert.sh
+++ b/scripts/convert.sh
@@ -528,9 +528,21 @@ HEREDOC
 
 # --- Main loop ---
 
+# Remove a tool's previously-generated output before regenerating, so renamed or
+# deleted agents don't leave orphan files behind (convert.sh overwrites in place
+# but never pruned stale output). Preserves the committed README.md — the only
+# tracked file under integrations/<tool>/ for conversion targets.
+clean_tool_output() {
+  local dir="$OUT_DIR/$1"
+  [[ -d "$dir" ]] || return 0
+  find "$dir" -mindepth 1 -maxdepth 1 ! -name 'README.md' -exec rm -rf {} +
+}
+
 run_conversions() {
   local tool="$1"
   local count=0
+
+  clean_tool_output "$tool"
 
   for dir in "${AGENT_DIRS[@]}"; do
     local dirpath="$REPO_ROOT/$dir"


### PR DESCRIPTION
## Problem

`convert.sh` overwrites per-agent output in place but never removed files for agents that were **renamed or deleted** — so orphans accumulated in the gitignored `integrations/<tool>/` dirs. A sandboxed install pass surfaced it: `antigravity` and `openclaw` produced **233** outputs vs the catalog's **232**, the extra being `agency-security-engineer` (a slug no current source agent generates). `install.sh` would copy the orphan too.

## Fix

Add `clean_tool_output()`, called once at the top of `run_conversions` (the single choke point for serial, parallel, and single-file paths). It wipes the tool's generated output but **preserves the committed `README.md`** — the only tracked file under `integrations/<tool>/` for conversion targets.

## Verified

Regenerated `antigravity` → **232** (was 233), orphan `agency-security-engineer` gone, `README.md` preserved, `bash -n` clean. Both `check-tools.sh` and `check-divisions.sh` still green.