### PR TITLE
ci: add check-tools.yml to enforce the tool contract

### DIFF
--- a/.github/workflows/check-tools.yml
+++ b/.github/workflows/check-tools.yml
@@ -1,0 +1,20 @@
+name: Check Tools Consistency
+
+# Runs on every PR (no path filter on purpose): a new or renamed tool must trip
+# this check even when nobody touched tools.json or the install/convert scripts.
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  check-tools:
+    name: tools.json is the single source of truth
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate tool set
+        run: |
+          chmod +x scripts/check-tools.sh
+          ./scripts/check-tools.sh


### PR DESCRIPTION
Mirrors `check-divisions.yml`. Runs `scripts/check-tools.sh` on every PR and on push to `main` (no path filter), so any change to `ALL_TOOLS` in install.sh, the converter set in convert.sh, or `tools.json` that breaks consistency fails the build — the same CI protection `divisions.json` already has. Follow-up to #606.