### PR TITLE
fix(convert): make antigravity date_added deterministic

### DIFF
--- a/scripts/convert.sh
+++ b/scripts/convert.sh
@@ -63,6 +63,12 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 OUT_DIR="$REPO_ROOT/integrations"
 TODAY="$(date +%Y-%m-%d)"
 
+# Static date stamped into Antigravity skill frontmatter. Deliberately fixed (NOT
+# the convert-run date): a per-run TODAY made every regeneration produce different
+# bytes, which churns the gitignored output and breaks byte-reproducible rendering
+# downstream. Matches the documented example in integrations/antigravity/README.md.
+ANTIGRAVITY_DATE_ADDED="2026-03-08"
+
 # Shared helpers (get_field, get_body, slugify, ...)
 # shellcheck source=lib.sh
 . "$SCRIPT_DIR/lib.sh"
@@ -125,7 +131,7 @@ name: ${slug}
 description: ${description}
 risk: low
 source: community
-date_added: '${TODAY}'
+date_added: '${ANTIGRAVITY_DATE_ADDED}'
 ---
 ${body}
 HEREDOC


### PR DESCRIPTION
## Problem

`convert_antigravity()` stamped `date_added: '${TODAY}'` — the **convert-run date**. Every regeneration produced different bytes for every antigravity skill, churning the gitignored output and **blocking byte-reproducible rendering downstream** (the app can't implement a renderer for output it can't reproduce). Re-flagged by the app side today.

## Fix

Replace `${TODAY}` with a fixed constant `ANTIGRAVITY_DATE_ADDED="2026-03-08"` (matching the documented example in `integrations/antigravity/README.md`). The field stays — it's part of the Antigravity frontmatter format — it's just **stable** now.

## Verified

Two consecutive `convert.sh --tool antigravity` runs produce a **byte-identical** `SKILL.md` (same `shasum`); no convert-run date appears anywhere in the output. `bash -n` clean.

## Downstream

Unblocks the app from rendering antigravity (format `antigravity-skill` in `tools.json`) once it implements that renderer — no `tools.json` change needed; the format name is unchanged.