### PR TITLE
Add XDC Network to Solidity engineer's chain-specific quirks

### DIFF
--- a/engineering/engineering-solidity-smart-contract-engineer.md
+++ b/engineering/engineering-solidity-smart-contract-engineer.md
@@ -476,7 +476,7 @@ main().catch((error) => {
 Remember and build expertise in:
 - **Exploit post-mortems**: Every major hack teaches a pattern — reentrancy (The DAO), delegatecall misuse (Parity), price oracle manipulation (Mango Markets), logic bugs (Wormhole)
 - **Gas benchmarks**: Know the exact gas cost of SLOAD (2100 cold, 100 warm), SSTORE (20000 new, 5000 update), and how they affect contract design
-- **Chain-specific quirks**: Differences between Ethereum mainnet, Arbitrum, Optimism, Base, Polygon — especially around block.timestamp, gas pricing, and precompiles
+- **Chain-specific quirks**: Differences between Ethereum mainnet, Arbitrum, Optimism, Base, Polygon, XDC — especially around block.timestamp, gas pricing, and precompiles
 - **Solidity compiler changes**: Track breaking changes across versions, optimizer behavior, and new features like transient storage (EIP-1153)
 
 ### Pattern Recognition


### PR DESCRIPTION
## Summary

Adds **XDC Network** to the chain-specific-quirks knowledge list in `engineering/engineering-solidity-smart-contract-engineer.md`.

XDC is an EVM-compatible L1 (XDPoS 2.0 consensus, chain IDs 50 mainnet / 51 Apothem) worth listing alongside Arbitrum/Optimism/Base/Polygon. It supports EIP-1559 on both mainnet and the Apothem testnet (verified on-chain: blocks carry `baseFeePerGas`, and `eth_feeHistory`/`eth_maxPriorityFeePerGas` are served), so it behaves as a standard EVM target for gas estimation and tooling.

## Change

One line (L479) — XDC added to the enumerated chain list, consistent with the existing entries:

```diff
- **Chain-specific quirks**: Differences between Ethereum mainnet, Arbitrum, Optimism, Base, Polygon — especially around block.timestamp, gas pricing, and precompiles
+ **Chain-specific quirks**: Differences between Ethereum mainnet, Arbitrum, Optimism, Base, Polygon, XDC — especially around block.timestamp, gas pricing, and precompiles
```

Scoped intentionally to the one place the file enumerates specific chains; the rest of the doc is correctly chain-agnostic.
