### PR TITLE
docs(readme): announce the native Agency Agents app

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://makeapullrequest.com)
 [![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-pink?logo=github)](https://github.com/sponsors/msitarzewski)
+[![Download the app](https://img.shields.io/github/v/release/msitarzewski/agency-agents-app?label=Download%20app&color=2563eb)](https://github.com/msitarzewski/agency-agents-app/releases/latest)
+
+> ### 🆕 There's an app now
+>
+> **[Agency Agents](https://agencyagents.app)** is a native app for **macOS, Linux & Windows** that browses the entire roster and installs it into Claude Code, Cursor, Codex, Gemini, Osaurus, and more — with a click. No clone, no scripts, and it auto-updates.
+>
+> **→ [Download the latest release](https://github.com/msitarzewski/agency-agents-app/releases/latest) · [agencyagents.app](https://agencyagents.app)**
 
 ---
 
@@ -24,7 +31,19 @@ Born from a Reddit thread and months of iteration, **The Agency** is a growing c
 
 ## ⚡ Quick Start
 
-### Option 1: Use with Claude Code (Recommended)
+### Option 1: Install the app (Recommended)
+
+The fastest way in — no clone, no terminal. [**Agency Agents**](https://agencyagents.app) is a native desktop app (macOS · Linux · Windows) that browses the whole roster and installs agents into Claude Code, Cursor, Codex, Gemini CLI, OpenCode, Qwen, and Osaurus for you, then keeps them up to date.
+
+**[⬇ Download the latest release](https://github.com/msitarzewski/agency-agents-app/releases/latest)** — or on a Mac:
+
+```bash
+brew install --cask msitarzewski/agency-agents/agency-agents
+```
+
+Prefer the command line? The script-based options below install the same agents.
+
+### Option 2: Use with Claude Code
 
 ```bash
 # Install all agents to your Claude Code directory
@@ -37,7 +56,7 @@ cp engineering/*.md ~/.claude/agents/
 # "Hey Claude, activate Frontend Developer mode and help me build a React component"
 ```
 
-### Option 2: Use as Reference
+### Option 3: Use as Reference
 
 Each agent file contains:
 - Identity & personality traits
@@ -47,7 +66,7 @@ Each agent file contains:
 
 Browse the agents below and copy/adapt the ones you need!
 
-### Option 3: Use with Other Tools (GitHub Copilot, Antigravity, Gemini CLI, OpenCode, OpenClaw, Cursor, Aider, Windsurf, Kimi Code, Codex)
+### Option 4: Use with Other Tools (GitHub Copilot, Antigravity, Gemini CLI, OpenCode, OpenClaw, Cursor, Aider, Windsurf, Kimi Code, Codex)
 
 ```bash
 # Step 1 -- generate integration files for all supported tools


### PR DESCRIPTION
## Announce the desktop app in the catalog README

The catalog now has a native **Agency Agents** app (macOS · Linux · Windows) — browse the whole roster and install it into Claude Code, Cursor, Codex, Gemini, Osaurus and more with a click. No clone, no scripts, auto-updating ([agencyagents.app](https://agencyagents.app) · [latest release](https://github.com/msitarzewski/agency-agents-app/releases/latest)).

### Changes
- **Top callout banner** after the badge row + a `Download app` release shield — for discovery (every visitor sees it).
- **Quick Start now leads with the app** as `Option 1: Install the app (Recommended)` — the functional decision point. The existing CLI paths shift down one and are unchanged:
  - Option 2: Use with Claude Code (was Option 1; "(Recommended)" moved to the app)
  - Option 3: Use as Reference (was 2)
  - Option 4: Use with Other Tools (was 3)

### Notes
- Kept it **text + shields only** to match the README's image-free house style; the banner links out to agencyagents.app where the screenshots live.
- Includes the `brew install --cask` one-liner for macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)