### PR TITLE
docs: sync supported tool docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Each agent file contains:
 
 Browse the agents below and copy/adapt the ones you need!
 
-### Option 4: Use with Other Tools (GitHub Copilot, Antigravity, Gemini CLI, OpenCode, OpenClaw, Cursor, Aider, Windsurf, Kimi Code, Codex)
+### Option 4: Use with Other Tools (GitHub Copilot, Antigravity, Gemini CLI, OpenCode, OpenClaw, Cursor, Aider, Windsurf, Kimi Code, Codex, Osaurus, Hermes)
 
 ```bash
 # Step 1 -- generate integration files for all supported tools
@@ -86,6 +86,8 @@ Browse the agents below and copy/adapt the ones you need!
 ./scripts/install.sh --tool windsurf
 ./scripts/install.sh --tool kimi
 ./scripts/install.sh --tool codex
+./scripts/install.sh --tool osaurus
+./scripts/install.sh --tool hermes
 ```
 
 **Install only the teams you need** (not everyone wants all 16 divisions):
@@ -662,7 +664,7 @@ The Agency works natively with Claude Code, and ships conversion + install scrip
 - **[Claude Code](https://claude.ai/code)** — native `.md` agents, no conversion needed → `~/.claude/agents/`
 - **[GitHub Copilot](https://github.com/copilot)** — native `.md` agents, no conversion needed → `~/.github/agents/` + `~/.copilot/agents/`
 - **[Antigravity](https://github.com/google-gemini/antigravity)** — `SKILL.md` per agent → `~/.gemini/antigravity/skills/`
-- **[Gemini CLI](https://github.com/google-gemini/gemini-cli)** — extension + `SKILL.md` files → `~/.gemini/extensions/agency-agents/`
+- **[Gemini CLI](https://github.com/google-gemini/gemini-cli)** -- `.md` agent files -> `~/.gemini/agents/`
 - **[OpenCode](https://opencode.ai)** — `.md` agent files → `.opencode/agents/`
 - **[Cursor](https://cursor.sh)** — `.mdc` rule files → `.cursor/rules/`
 - **[Aider](https://aider.chat)** — single `CONVENTIONS.md` → `./CONVENTIONS.md`
@@ -671,6 +673,8 @@ The Agency works natively with Claude Code, and ships conversion + install scrip
 - **[Qwen Code](https://github.com/QwenLM/qwen-code)** — `.md` SubAgent files → `~/.qwen/agents/`
 - **[Kimi Code](https://github.com/MoonshotAI/kimi-cli)** — YAML agent specs → `~/.config/kimi/agents/`
 - **[Codex](https://developers.openai.com/codex/overview)** — TOML custom agents → `~/.codex/agents/`
+- **Osaurus** -- `SKILL.md` skills -> `~/.osaurus/skills/`
+- **[Hermes](integrations/hermes/README.md)** -- lazy-router plugin -> `~/.hermes/plugins/`
 
 ---
 
@@ -986,7 +990,7 @@ When you add new agents or edit existing ones, regenerate all integration files:
 
 - [ ] Interactive agent selector web tool
 - [x] Multi-agent workflow examples -- see [examples/](examples/)
-- [x] Multi-tool integration scripts (Claude Code, GitHub Copilot, Antigravity, Gemini CLI, OpenCode, OpenClaw, Cursor, Aider, Windsurf, Qwen Code, Kimi Code, Codex)
+- [x] Multi-tool integration scripts (Claude Code, GitHub Copilot, Antigravity, Gemini CLI, OpenCode, OpenClaw, Cursor, Aider, Windsurf, Qwen Code, Kimi Code, Codex, Osaurus, Hermes)
 - [ ] Video tutorials on agent design
 - [ ] Community agent marketplace
 - [ ] Agent "personality quiz" for project matching

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -17,6 +17,8 @@ supported agentic coding tools.
 - **[Kimi Code](#kimi-code)** — YAML agent specs in `kimi/`
 - **[Qwen Code](#qwen-code)** — project-scoped `.md` SubAgents in `.qwen/agents/`
 - **[Codex](#codex)** — `.toml` custom agents in `codex/`
+- **Osaurus** -- `SKILL.md` skills generated in `osaurus/`
+- **[Hermes](hermes/README.md)** -- lazy-router plugin generated in `hermes/`
 
 ## Quick Install
 
@@ -30,6 +32,8 @@ supported agentic coding tools.
 ./scripts/install.sh --tool openclaw
 ./scripts/install.sh --tool claude-code
 ./scripts/install.sh --tool codex
+./scripts/install.sh --tool osaurus
+./scripts/install.sh --tool hermes
 
 # Gemini CLI needs generated integration files on a fresh clone
 ./scripts/convert.sh --tool gemini-cli


### PR DESCRIPTION
## Summary

- Add Osaurus and Hermes to supported-tool documentation where the registry and scripts already support them.
- Update the Gemini CLI supported-tool summary to match the current `~/.gemini/agents` output path.
- Keep the change documentation-only and scoped to README files.

Fixes #624

## Validation

- `git diff --check`
- `./scripts/check-tools.sh`
- `./scripts/check-divisions.sh`
- `bash -n scripts/convert.sh scripts/install.sh scripts/check-tools.sh scripts/check-divisions.sh scripts/lint-agents.sh scripts/check-agent-originality.sh scripts/lib.sh`
- Added-line encoding check: 0 non-ASCII chars and 0 common mojibake tokens in new lines.
- Issue/PR text intentionally uses ASCII-only English to avoid mojibake.

## Review

Self-review passed: only `README.md` and `integrations/README.md` changed.