### PR TITLE
docs: update README installer tool list

### DIFF
--- a/README.md
+++ b/README.md
@@ -713,8 +713,10 @@ The installer scans your system for installed tools, shows a checkbox UI, and le
   [ ] 10)  [ ]  Qwen Code       (~/.qwen/agents)
   [ ] 11)  [ ]  Kimi Code       (~/.config/kimi/agents)
   [ ] 12)  [ ]  Codex           (~/.codex/agents)
+  [ ] 13)  [ ]  Osaurus         (~/.osaurus/skills)
+  [ ] 14)  [ ]  Hermes          (~/.hermes/plugins)
 
-  [1-12] toggle   [a] all   [n] none   [d] detected
+  [1-14] toggle   [a] all   [n] none   [d] detected
   [Enter] install   [q] quit
 ```
 
@@ -725,6 +727,8 @@ The installer scans your system for installed tools, shows a checkbox UI, and le
 ./scripts/install.sh --tool openclaw
 ./scripts/install.sh --tool antigravity
 ./scripts/install.sh --tool codex
+./scripts/install.sh --tool osaurus
+./scripts/install.sh --tool hermes
 ```
 
 **Non-interactive (CI/scripts):**


### PR DESCRIPTION
## What does this PR do?

Updates the README installer example so the displayed interactive tool list includes the current Osaurus and Hermes entries, and adjusts the toggle range from 1-12 to 1-14.

Also adds direct install command examples for Osaurus and Hermes next to the existing tool-specific commands.

## Agent Information (if adding/modifying an agent)

- **Agent Name**: N/A
- **Category**: N/A
- **Specialty**: N/A

## Validation

- `./scripts/check-tools.sh`
- `./scripts/check-divisions.sh`
- `git diff --check`

## Checklist

- [x] Follows the agent template structure from CONTRIBUTING.md
- [x] Includes YAML frontmatter with `name`, `description`, `color`
- [x] Has concrete code/template examples (for new agents)
- [x] Tested in real scenarios
- [x] Proofread and formatted correctly

Note: checklist items about agent templates/frontmatter/examples are not applicable to this README-only documentation update.
