### PR TITLE
Add Vietnamese community translation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1012,6 +1012,7 @@ Community-maintained translations and regional adaptations. These are independen
 | 🇸🇦 العربية (ar) | [@jnMetaCode](https://github.com/jnMetaCode) | [agency-agents-ar](https://github.com/jnMetaCode/agency-agents-ar) | 184 upstream agents translated; Arabic-market PRs welcome |
 | 🇰🇷 한국어 (ko) | [@jnMetaCode](https://github.com/jnMetaCode) | [agency-agents-ko](https://github.com/jnMetaCode/agency-agents-ko) | 184 upstream agents fully translated; Korea-specific PRs welcome |
 | 🇯🇵 日本語 (ja-JP) | [@sscodeai](https://github.com/sscodeai) | [agency-agents-ja](https://github.com/sscodeai/agency-agents-ja) | 281 Japan-localized agents + 97 Japan-market originals + 27 workflows |
+| 🇻🇳 Tiếng Việt (vi-VN) | [@rodonguyen](https://github.com/rodonguyen) | [agency-agents](https://github.com/rodonguyen/agency-agents) | Starter Vietnamese localization focused on README, quick start, and high-use docs |
 
 Want to add a translation? Open an issue and we'll link it here.
 


### PR DESCRIPTION
Adds the Vietnamese community fork to the Community Translations & Localizations table.

Vietnamese fork: https://github.com/rodonguyen/agency-agents

The fork follows the existing localized-repo pattern: localized README.md, upstream link, translation scope, and UPSTREAM.md tracking.