### PR TITLE
fix(originality): include gis and security in check-agent-originality.sh AGENT_DIRS

### DIFF
--- a/scripts/check-agent-originality.sh
+++ b/scripts/check-agent-originality.sh
@@ -23,8 +23,8 @@
 #   ORIGINALITY_FAIL   default 40  — at/above this %, treated as a duplicate (exit 1)
 #   ORIGINALITY_WARN   default 20  — at/above this %, surfaced as a warning (no fail)
 #
-# Calibration: across the existing 184-agent library the worst same-pair
-# similarity is ~1.5% (median 0%). Anything in the double digits is a strong
+# Calibration: across the existing 233-agent library the worst same-pair
+# similarity is ~1.9% (median 0%). Anything in the double digits is a strong
 # anomaly; the defaults leave a wide safety margin against false positives.
 
 set -euo pipefail
@@ -47,9 +47,9 @@ REPO_ROOT = os.environ["REPO_ROOT"]
 FAIL = float(os.environ["ORIGINALITY_FAIL"])
 WARN = float(os.environ["ORIGINALITY_WARN"])
 
-AGENT_DIRS = ("academic design engineering finance game-development marketing "
-              "paid-media product project-management sales spatial-computing "
-              "specialized strategy support testing").split()
+AGENT_DIRS = ("academic design engineering finance game-development gis marketing "
+              "paid-media product project-management sales security spatial-computing "
+              "specialized support testing").split()
 
 # Proper nouns we neutralize so a find-replace re-skin (swap the country/platform
 # and little else) still scores as a near-duplicate. Extend as new markets appear.
@@ -156,7 +156,7 @@ for p in candidates:
 
 print()
 print(f"Thresholds: WARN >= {WARN:.0f}%, FAIL >= {FAIL:.0f}%  "
-      f"(existing-library baseline max ~1.5%)")
+      f"(existing-library baseline max ~1.9%)")
 
 if fails:
     print()


### PR DESCRIPTION
## What does this PR do?
`scripts/check-agent-originality.sh` builds its comparison corpus from a hardcoded `AGENT_DIRS` list that had drifted out of sync with the canonical division set in `divisions.json`. It was **missing `gis` and `security`**, and it listed the non-division `strategy/` (which has no agent frontmatter). As a result, every agent in the `gis` and `security` divisions was **silently never checked for near-duplicates**.

This aligns `AGENT_DIRS` to the canonical 16 divisions (matching `scripts/lint-agents.sh`), and refreshes the now-stale calibration note in the same file.

## Testing
- Audit run (`scripts/check-agent-originality.sh` with no args) now covers **233 agents**, including **23 gis/security agents that were previously excluded** — exit 0, worst same-pair similarity **~1.9%** (well under the WARN/FAIL thresholds). Updated the header/output baseline from the stale `184 agents / ~1.5%` to `233 / ~1.9%` accordingly.
- `bash -n scripts/check-agent-originality.sh` clean.

## Notes
This touches a CI/tooling script — happy to move it to an Issue/Discussion first if you'd prefer that per CONTRIBUTING. There is a small follow-up (guarding this list in `check-divisions.sh` so it can't drift again) which I've opened as a separate, stacked PR.
