### PR TITLE
fix(ci): guard check-agent-originality.sh's AGENT_DIRS in check-divisions.sh

### DIFF
--- a/scripts/check-divisions.sh
+++ b/scripts/check-divisions.sh
@@ -7,8 +7,9 @@
 #   1. The actual top-level agent directories on disk
 #   2. AGENT_DIRS in scripts/convert.sh
 #   3. AGENT_DIRS in scripts/lint-agents.sh
-#   4. The path filters in .github/workflows/lint-agents.yml
-#   5. Every divisions.json entry has label, icon, and color
+#   4. AGENT_DIRS in scripts/check-agent-originality.sh (a Python list)
+#   5. The path filters in .github/workflows/lint-agents.yml
+#   6. Every divisions.json entry has label, icon, and color
 #
 # Add a division: create its directory, add an entry to divisions.json, then
 # this script tells you every other place that must be updated. No deps beyond
@@ -65,6 +66,15 @@ agent_dirs_array() {
     | tr ' \t' '\n\n' | grep -E '^[a-z0-9-]+$' | sort -u
 }
 
+# Contents of a Python `AGENT_DIRS = ("a b c ...").split()` string list, one per
+# line. check-agent-originality.sh keeps its own copy of the division set as a
+# Python list (not a bash array), so it needs its own extractor — the bash
+# agent_dirs_array() above cannot see it, which is exactly how it silently drifted.
+python_agent_dirs() {
+  awk '/AGENT_DIRS[[:space:]]*=[[:space:]]*\(/{f=1} f{print; if(/\)\.split\(\)/)exit}' "$1" \
+    | grep -oE '[a-z0-9-]+' | grep -vxE 'split' | sort -u
+}
+
 # Compare canonical vs a candidate set; report both directions.
 compare() {
   local label="$1" candidate="$2" canon
@@ -87,6 +97,7 @@ compare() {
 compare "the agent directories on disk" "$(actual_dirs)"
 compare "scripts/convert.sh AGENT_DIRS" "$(agent_dirs_array scripts/convert.sh)"
 compare "scripts/lint-agents.sh AGENT_DIRS" "$(agent_dirs_array scripts/lint-agents.sh)"
+compare "scripts/check-agent-originality.sh AGENT_DIRS" "$(python_agent_dirs scripts/check-agent-originality.sh)"
 
 # Workflow path filters: every canonical division must appear as `<div>/` in
 # the lint workflow, or new divisions silently skip CI.


### PR DESCRIPTION
## What does this PR do?
Root-cause follow-up to #649. `scripts/check-divisions.sh` enforces that the `AGENT_DIRS` arrays in `convert.sh` and `lint-agents.sh` match `divisions.json` — but it does **not** check the (Python) `AGENT_DIRS` list in `check-agent-originality.sh`. That gap is exactly why that list was able to silently drift (see #649). This adds a Python-list extractor and compares it against `divisions.json` too, so the originality script's division set can no longer drift unnoticed.

## ⚠️ Depends on #649 — merge that first
This new guard *catches* the drift that #649 fixes, so on the current `main` `check-divisions.sh` will (correctly) fail here, reporting `missing: gis security` / `extra: strategy` against the not-yet-fixed originality list. **Merge #649 first; then this is green.** (Verified: with #649 applied, `check-divisions.sh` → `PASSED: 16 divisions consistent`.)

## Testing
- With #649 applied: `scripts/check-divisions.sh` → **PASSED** (16 divisions consistent across divisions.json, dirs, and all three scripts).
- Drift-catch proven: against the current originality list it reports the missing `gis`/`security` + extra `strategy`.
- `bash -n scripts/check-divisions.sh` clean.

## Notes
CI/tooling change — happy to fold this into #649 or move to a Discussion first if you'd prefer, per CONTRIBUTING. Kept separate so the fix and the guard-against-recurrence are reviewable independently.
