### PR TITLE
Derive originality check's division set from divisions.json

### DIFF
--- a/scripts/check-agent-originality.sh
+++ b/scripts/check-agent-originality.sh
@@ -41,15 +41,18 @@ ORIGINALITY_FAIL="${ORIGINALITY_FAIL:-40}" \
 ORIGINALITY_WARN="${ORIGINALITY_WARN:-20}" \
 REPO_ROOT="$REPO_ROOT" \
 python3 - "$@" <<'PYEOF'
-import os, re, sys, glob
+import os, re, sys, glob, json
 
 REPO_ROOT = os.environ["REPO_ROOT"]
 FAIL = float(os.environ["ORIGINALITY_FAIL"])
 WARN = float(os.environ["ORIGINALITY_WARN"])
 
-AGENT_DIRS = ("academic design engineering finance game-development marketing "
-              "paid-media product project-management sales spatial-computing "
-              "specialized strategy support testing").split()
+# Division set — divisions.json (repo root) is the single source of truth, and
+# scripts/check-divisions.sh (CI) enforces it against the directories on disk.
+# Read it directly rather than hardcoding the list here so this check can never
+# drift out of sync with the catalog the way a copied literal silently would.
+with open(os.path.join(REPO_ROOT, "divisions.json")) as _fh:
+    AGENT_DIRS = sorted(json.load(_fh)["divisions"].keys())
 
 # Proper nouns we neutralize so a find-replace re-skin (swap the country/platform
 # and little else) still scores as a near-duplicate. Extend as new markets appear.


### PR DESCRIPTION
## What

`scripts/check-agent-originality.sh` hardcoded its own copy of the division list in the Python heredoc (`AGENT_DIRS`). This was a **5th copy** of the division set — and the one place `scripts/check-divisions.sh` couldn't see, because its guard parses bash arrays, not a Python tuple.

So it drifted:
- **missing** `gis` and `security`
- still carried the **retired** `strategy` (not a division)

Practical effect: every `gis/` and `security/` agent — including newly added ones — **skipped the duplicate-detection scan entirely**.

## Fix

Read `divisions.json` (the catalog's single source of truth) directly instead of hardcoding:

```python
with open(os.path.join(REPO_ROOT, "divisions.json")) as _fh:
    AGENT_DIRS = sorted(json.load(_fh)["divisions"].keys())
```

Now this check can never drift from the catalog again.

## Verified

- Full-audit mode runs green (`PASSED`), deriving all **16** divisions.
- `gis/` and `security/` agents are now scanned (previously skipped).
- `strategy` correctly excluded.
- `scripts/check-divisions.sh` still green at 16.

## Supersedes #649 / #650

Those PRs patch the hardcoded constants (add gis/security). This removes the constants, fixing the root cause. Recommend closing #649/#650 as superseded once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)