### PR TITLE
docs: fix stale antigravity path; add Mistral Vibe to integrations index

### DIFF
--- a/integrations/README.md
+++ b/integrations/README.md
@@ -17,6 +17,7 @@ supported agentic coding tools.
 - **[Kimi Code](#kimi-code)** — YAML agent specs in `kimi/`
 - **[Qwen Code](#qwen-code)** — project-scoped `.md` SubAgents in `.qwen/agents/`
 - **[Codex](#codex)** — `.toml` custom agents in `codex/`
+- **[Mistral Vibe](vibe/README.md)** — `.toml` agents + prompt files generated in `vibe/`
 - **Osaurus** -- `SKILL.md` skills generated in `osaurus/`
 - **[Hermes](hermes/README.md)** -- lazy-router plugin generated in `hermes/`
 
@@ -95,7 +96,7 @@ See [github-copilot/README.md](github-copilot/README.md) for details.
 
 ## Antigravity
 
-Skills are installed to `~/.gemini/antigravity/skills/`. Each agent becomes
+Skills are installed to `~/.gemini/config/skills/`. Each agent becomes
 a separate skill prefixed with `agency-` to avoid naming conflicts.
 
 ```bash


### PR DESCRIPTION
## What's left in this PR (rebased on current main)

Originally this PR also derived the originality check's division set from `divisions.json` — that was implemented independently in #659 (nice!), so this PR is now docs-only:

- **Antigravity path corrected** in `integrations/README.md` to `~/.gemini/config/skills/` — every other source agrees (`integrations/antigravity/README.md:13`, `convert.sh`, `install.sh`); the index was the sole outlier still saying `~/.gemini/antigravity/skills/`.
- **Mistral Vibe added to the Supported Tools index** — it's first-class in both `convert.sh` and `install.sh` and has its own `integrations/vibe/README.md`, but was missing from the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)