### PR TITLE
fix(install): never rm -rf a shared Hermes plugins directory (#669)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1069,11 +1069,23 @@ install_hermes() {
   local src="$INTEGRATIONS/hermes/agency-agents-router"
   local hermes_home; hermes_home="$(hermes_home_dir)"
   local dest; dest="$(resolve_dest hermes "${hermes_home}/plugins/agency-agents-router")"
+  # HERMES_PLUGIN_DIR is ambiguous: its name invites setting it to the plugins
+  # parent (~/.hermes/plugins) rather than the full plugin path. Always target
+  # the agency-agents-router subdir so we never rm -rf a shared plugins dir that
+  # holds other plugins.
+  if [[ "$(basename "$dest")" != "agency-agents-router" ]]; then
+    dest="${dest%/}/agency-agents-router"
+  fi
   [[ -f "$src/plugin.yaml" && -f "$src/__init__.py" && -f "$src/data/agents.json" ]] || {
     err "integrations/hermes/agency-agents-router missing. Run ./scripts/convert.sh --tool hermes first."
     return 1
   }
   mkdir -p "$(dirname "$dest")"
+  # Safety net: only ever remove our own plugin directory, never a parent.
+  if [[ "$(basename "$dest")" != "agency-agents-router" ]]; then
+    err "Hermes: refusing to remove '$dest' — expected an agency-agents-router directory."
+    return 1
+  fi
   rm -rf "$dest"
   if $USE_LINK; then
     ln -s "$src" "$dest"


### PR DESCRIPTION
Fixes #669.

## The bug

`install_hermes()` resolved `dest` from `HERMES_PLUGIN_DIR` and then ran `rm -rf "$dest"`. The variable's name invites setting it to the plugins **parent** (`~/.hermes/plugins`) rather than the full plugin path — and in that case `rm -rf "$dest"` deleted the **entire plugins directory and every other plugin in it**.

```bash
dest="$(resolve_dest hermes "${hermes_home}/plugins/agency-agents-router")"
rm -rf "$dest"    # HERMES_PLUGIN_DIR=~/.hermes/plugins  ->  wipes ALL plugins
```

Thanks to the reporter for the precise diagnosis.

## The fix

1. **Normalize** — always target the `agency-agents-router` subdir: if the resolved `dest` doesn't already end in it, append it. So `HERMES_PLUGIN_DIR` works whether set to the plugin path or the plugins parent.
2. **Defensive guard** — refuse to `rm -rf` any path whose basename isn't `agency-agents-router`, so no future change can reintroduce a parent-directory wipe.

## Verified

Simulated the dangerous case — `HERMES_PLUGIN_DIR=~/.hermes/plugins` with a sibling plugin present:

| case | rm target | sibling plugin |
|---|---|---|
| parent dir (the bug) | `…/plugins/agency-agents-router` | ✅ survives, data intact |
| default full path | `…/plugins/agency-agents-router` | ✅ unchanged |
| full path via env | `…/agency-agents-router` | ✅ unchanged |

`bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)