### PR TITLE
fix(install): derive division list from divisions.json — adds healthcare (#668)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -131,25 +131,31 @@ INTEGRATIONS="$REPO_ROOT/integrations"
 
 ALL_TOOLS=(claude-code copilot antigravity gemini-cli opencode openclaw cursor aider windsurf qwen kimi codex osaurus hermes vibe)
 
-# Directories scanned for installable agents. Intentionally includes strategy/
-# (its frontmatter-less NEXUS docs are filtered out by is_agent_file at scan time);
-# the selectable division list below is this set minus strategy. This is NOT the
-# same set as AGENT_DIRS in convert.sh / lint-agents.sh, which exclude strategy
-# entirely — see divisions.json (the source of truth) and scripts/check-divisions.sh.
-AGENT_DIRS=(
-  academic design engineering finance game-development gis marketing paid-media product project-management
-  sales security spatial-computing specialized strategy support testing
-)
+# The division set is derived from divisions.json (the single source of truth)
+# so the installer can never drift from the catalog — a hardcoded copy silently
+# dropped healthcare (#655/#668) and can't be seen by check-divisions.sh. Same
+# no-jq awk/grep/sed parse as scripts/check-divisions.sh (macOS + Linux).
+divisions_from_json() {
+  local json="$REPO_ROOT/divisions.json"
+  [[ -f "$json" ]] || { err "divisions.json not found at $json"; exit 1; }
+  awk '/"divisions"[[:space:]]*:[[:space:]]*\{/{f=1; next} f' "$json" \
+    | grep -oE '"[a-z0-9-]+"[[:space:]]*:[[:space:]]*\{' \
+    | sed -E 's/"([a-z0-9-]+)".*/\1/'
+}
+
+# Selectable divisions = exactly the divisions.json entries.
+ALL_DIVISIONS=()
+while IFS= read -r _div; do [[ -n "$_div" ]] && ALL_DIVISIONS+=("$_div"); done < <(divisions_from_json)
+[[ ${#ALL_DIVISIONS[@]} -gt 0 ]] || { err "no divisions parsed from divisions.json"; exit 1; }
+
+# Directories scanned for installable agents = the divisions plus strategy/.
+# strategy/ holds frontmatter-less NEXUS docs (filtered out by is_agent_file at
+# scan time), so it is scanned but selectable only via ALL_DIVISIONS above.
+AGENT_DIRS=("${ALL_DIVISIONS[@]}" strategy)
 
 # ---------------------------------------------------------------------------
 # Selection engine (team / agent / agents-file filtering)
 # ---------------------------------------------------------------------------
-# Selectable divisions = AGENT_DIRS minus strategy/ (NEXUS docs, not agents).
-ALL_DIVISIONS=(
-  academic design engineering finance game-development gis marketing paid-media
-  product project-management sales security spatial-computing specialized support testing
-)
-
 FILTER_DIVISIONS=()      # --division
 FILTER_AGENTS=()         # --agent
 AGENTS_FILE=""           # --agents-file


### PR DESCRIPTION
Fixes #668.

## The bug

`install.sh` hardcoded the division set in **two** lists — `AGENT_DIRS` and `ALL_DIVISIONS` — and both had gone stale, **missing `healthcare`** (merged in #655). `check-divisions.sh` only guards `convert.sh`/`lint-agents.sh`, so it never caught these copies. Impact:
- `--tool claude-code` / `copilot` silently **skipped healthcare's 2 agents**
- `--division healthcare` → **"Unknown division"**
- interactive team wizard omitted healthcare
- agent count low by 2

## The fix

Derive both lists from **`divisions.json`** (the single source of truth), reusing the exact no-jq `awk`/`grep`/`sed` parser from `check-divisions.sh`:
- `ALL_DIVISIONS` = exactly the `divisions.json` entries (selectable divisions).
- `AGENT_DIRS` = that set **+ `strategy/`**, preserving the intentional scan of its frontmatter-less NEXUS docs (`is_agent_file` filters them out).

Same pattern as #659 (`check-agent-originality.sh`) and #666 (`build-hermes-plugin.py`) — a **derived** list can't drift, so there's nothing left for `check-divisions.sh` to guard here. This was the last hardcoded division-list copy in the repo.

## Verified

- `ALL_DIVISIONS` resolves to **17** — healthcare in, strategy out; `AGENT_DIRS` still scans strategy.
- `./scripts/install.sh --tool claude-code --division healthcare --dry-run` → `Teams: healthcare / Agents: 2` (was "Unknown division").
- `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)