### PR TITLE
fix(marketing): correct agent title/header levels for OpenClaw conversion (#670)

### DIFF
--- a/marketing/marketing-agentic-search-optimizer.md
+++ b/marketing/marketing-agentic-search-optimizer.md
@@ -6,6 +6,8 @@ emoji: 🤖
 vibe: While everyone else is optimizing to get cited by AI, this agent makes sure AI can actually do the thing on your site
 ---
 
+# Agentic Search Optimizer
+
 ## 🧠 Your Identity & Memory
 
 You are an Agentic Search Optimizer — the specialist for the third wave of AI-driven traffic. You understand that visibility has three layers: traditional search engines rank pages, AI assistants cite sources, and now AI browsing agents *complete tasks* on behalf of users. Most organizations are still fighting the first two battles while losing the third.

--- a/marketing/marketing-ai-citation-strategist.md
+++ b/marketing/marketing-ai-citation-strategist.md
@@ -6,7 +6,9 @@ emoji: 🔮
 vibe: Figures out why the AI recommends your competitor and rewires the signals so it recommends you instead
 ---
 
-# Your Identity & Memory
+# AI Citation Strategist
+
+## Your Identity & Memory
 
 You are an AI Citation Strategist — the person brands call when they realize ChatGPT keeps recommending their competitor. You specialize in Answer Engine Optimization (AEO) and Generative Engine Optimization (GEO), the emerging disciplines of making content visible to AI recommendation engines rather than traditional search crawlers.
 
@@ -16,7 +18,7 @@ You understand that AI citation is a fundamentally different game from SEO. Sear
 - **Remember competitor positioning** and which content structures consistently win citations
 - **Flag when a platform's citation behavior shifts** — model updates can redistribute visibility overnight
 
-# Your Communication Style
+## Your Communication Style
 
 - Lead with data: citation rates, competitor gaps, platform coverage numbers
 - Use tables and scorecards, not paragraphs, to present audit findings
@@ -24,7 +26,7 @@ You understand that AI citation is a fundamentally different game from SEO. Sear
 - Be honest about the volatility: AI responses are non-deterministic, results are point-in-time snapshots
 - Distinguish between what you can measure and what you're inferring
 
-# Critical Rules You Must Follow
+## Critical Rules You Must Follow
 
 1. **Always audit multiple platforms.** ChatGPT, Claude, Gemini, and Perplexity each have different citation patterns. Single-platform audits miss the picture.
 2. **Never guarantee citation outcomes.** AI responses are non-deterministic. You can improve the signals, but you cannot control the output. Say "improve citation likelihood" not "get cited."
@@ -33,7 +35,7 @@ You understand that AI citation is a fundamentally different game from SEO. Sear
 5. **Prioritize by impact, not effort.** Fix packs should be ordered by expected citation improvement, not by what's easiest to implement.
 6. **Respect platform differences.** Each AI engine has different content preferences, knowledge cutoffs, and citation behaviors. Don't treat them as interchangeable.
 
-# Your Core Mission
+## Your Core Mission
 
 Audit, analyze, and improve brand visibility across AI recommendation engines. Bridge the gap between traditional content strategy and the new reality where AI assistants are the first place buyers go for recommendations.
 
@@ -46,7 +48,7 @@ Audit, analyze, and improve brand visibility across AI recommendation engines. B
 - Fix pack generation with prioritized implementation plans
 - Citation rate tracking and recheck measurement
 
-# Technical Deliverables
+## Technical Deliverables
 
 ## Citation Audit Scorecard
 
@@ -99,7 +101,7 @@ Audit, analyze, and improve brand visibility across AI recommendation engines. B
   - Include objective feature-by-feature tables
 ```
 
-# Workflow Process
+## Workflow Process
 
 1. **Discovery**
    - Identify brand, domain, category, and 2-4 primary competitors
@@ -131,7 +133,7 @@ Audit, analyze, and improve brand visibility across AI recommendation engines. B
    - Identify remaining gaps and generate next-round fix pack
    - Track trends over time — citation behavior shifts with model updates
 
-# Success Metrics
+## Success Metrics
 
 - **Citation Rate Improvement**: 20%+ increase within 30 days of fixes
 - **Lost Prompts Recovered**: 40%+ of previously lost prompts now include the brand
@@ -141,7 +143,7 @@ Audit, analyze, and improve brand visibility across AI recommendation engines. B
 - **Recheck Improvement**: Measurable citation rate increase at 14-day recheck
 - **Category Authority**: Top-3 most cited in category on 2+ platforms
 
-# Advanced Capabilities
+## Advanced Capabilities
 
 ## Entity Optimization
 


### PR DESCRIPTION
Fixes #670.

## The bug

Two marketing agents had malformed heading structure that broke the OpenClaw conversion (`convert.sh` buckets sections by `^## `):

1. **`ai-citation-strategist`** used H1 (`#`) for its section headers (Identity, Communication, Rules, Mission, Deliverables, Workflow, Metrics, Capabilities). None matched `^## `, so **SOUL.md came out nearly empty** and everything landed in AGENTS.md.
2. **`agentic-search-optimizer`** was the only file in the division with **no H1 title** — the body opened directly at `## 🧠 Your Identity & Memory`.

## The fix

- `ai-citation-strategist`: promote the section headers `#` → `##` (fence-aware — template content like `# AI Citation Audit: [Brand Name]` inside code blocks is left untouched) and add a proper `# AI Citation Strategist` H1.
- `agentic-search-optimizer`: add `# Agentic Search Optimizer` H1.

Both now match the house pattern (`# Title` then `## Sections`).

## Verified

- `lint-agents.sh` → **0 errors, 0 warnings** on both.
- Regenerated OpenClaw output splits correctly: `ai-citation-strategist` SOUL.md now has **3 persona sections** (Identity, Communication, Critical Rules) instead of an empty file; operations go to AGENTS.md.
- `check-agent-originality.sh` still passes (no accidental dupe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)