### PR TITLE
docs: fix remaining stale antigravity skill paths in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,7 +668,7 @@ The Agency works natively with Claude Code, and ships conversion + install scrip
 
 - **[Claude Code](https://claude.ai/code)** — native `.md` agents, no conversion needed → `~/.claude/agents/`
 - **[GitHub Copilot](https://github.com/copilot)** — native `.md` agents, no conversion needed → `~/.github/agents/` + `~/.copilot/agents/`
-- **[Antigravity](https://github.com/google-gemini/antigravity)** — `SKILL.md` per agent → `~/.gemini/antigravity/skills/`
+- **[Antigravity](https://github.com/google-gemini/antigravity)** — `SKILL.md` per agent → `~/.gemini/config/skills/`
 - **[Gemini CLI](https://github.com/google-gemini/gemini-cli)** -- `.md` agent files -> `~/.gemini/agents/`
 - **[OpenCode](https://opencode.ai)** — `.md` agent files → `.opencode/agents/`
 - **[Cursor](https://cursor.sh)** — `.mdc` rule files → `.cursor/rules/`
@@ -792,7 +792,7 @@ See [integrations/github-copilot/README.md](integrations/github-copilot/README.m
 <details>
 <summary><strong>Antigravity (Gemini)</strong></summary>
 
-Each agent becomes a skill in `~/.gemini/antigravity/skills/agency-<slug>/`.
+Each agent becomes a skill in `~/.gemini/config/skills/agency-<slug>/`.
 
 ```bash
 ./scripts/install.sh --tool antigravity


### PR DESCRIPTION
Follow-up to #667. Two references in the top-level `README.md` still pointed at the old `~/.gemini/antigravity/skills/` path:
- L671 (Supported Tools list)
- L795 (Antigravity install details)

Per the current Antigravity spec — verified against Google's July 2026 docs — the canonical global skills path recognized by **all three flavors** (Antigravity, AGY CLI, AGY IDE, incl. 2.0) is **`~/.gemini/config/skills/`**. The older `~/.gemini/antigravity/skills/` is outdated; `~/.gemini/antigravity/builtin/skills` is a read-only built-in dir, not where user skills install.

#667 fixed `integrations/README.md`; this fixes the two that remained. **Now every antigravity path reference in the repo agrees** with `tools.json`, `convert.sh`, `install.sh`, and both integration READMEs.

Verified: `git grep 'gemini/antigravity/skills'` returns zero results repo-wide.

Sources: [Where does Antigravity look for Agent Skills? (Google Cloud, Jul 2026)](https://medium.com/google-cloud/where-does-antigravity-look-for-agent-skills-a703518d68c5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)