### PR TITLE
fix(install): correct Hermes plugins.enabled indentation (broken YAML)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -995,6 +995,27 @@ plugin = sys.argv[2]
 text = path.read_text() if path.exists() else ""
 lines = text.splitlines()
 
+# Detect the indentation Hermes uses for list items under `enabled:`.
+# Hermes writes config.yaml with `enabled:` at 2 spaces and its `- item`
+# entries at 4 spaces. If we insert at the wrong indent (e.g. 2 spaces), a
+# following existing entry gets nested as a child and YAML collapses both into
+# a single scalar ("agency-agents-router - ponytail"), silently disabling
+# every plugin. Default to 4 spaces to match Hermes' actual format.
+child_indent = 4
+_enabled_start = None
+for _i, _line in enumerate(lines):
+    if _line.strip() == "enabled:":
+        _enabled_start = _i
+        break
+if _enabled_start is not None:
+    for _line in lines[_enabled_start + 1:]:
+        if _line.strip().startswith(("- ", "-")) and _line.lstrip().startswith("-"):
+            child_indent = len(_line) - len(_line.lstrip(" "))
+            break
+        if _line and not _line[0].isspace():
+            break
+item_prefix = " " * child_indent + "- "
+
 # Already enabled?
 in_plugins = False
 in_enabled = False
@@ -1023,11 +1044,11 @@ for line in lines:
             in_enabled = False
 
 if not lines:
-    lines = ["plugins:", "  enabled:", f"  - {plugin}"]
+    lines = ["plugins:", "  enabled:", (item_prefix + plugin)]
 elif not any(line.startswith("plugins:") for line in lines):
     if lines and lines[-1].strip():
         lines.append("")
-    lines.extend(["plugins:", "  enabled:", f"  - {plugin}"])
+    lines.extend(["plugins:", "  enabled:", (item_prefix + plugin)])
 else:
     out = []
     in_plugins = False
@@ -1040,14 +1061,14 @@ else:
             continue
         if in_plugins and line and not line.startswith((" ", "\t")):
             if not saw_enabled and not inserted:
-                out.extend(["  enabled:", f"  - {plugin}"])
+                out.extend(["  enabled:", (item_prefix + plugin)])
                 inserted = True
             in_plugins = False
             out.append(line)
             continue
         if in_plugins and line.strip().startswith("enabled:") and "[]" in line:
             saw_enabled = True
-            out.extend(["  enabled:", f"  - {plugin}"])
+            out.extend(["  enabled:", (item_prefix + plugin)])
             inserted = True
             continue
         if in_plugins and line.strip() == "enabled:":
@@ -1055,12 +1076,12 @@ else:
             out.append(line)
             # Insert before the next sibling key or top-level key; if the list is
             # empty this still creates a valid block.
-            out.append(f"  - {plugin}")
+            out.append((item_prefix + plugin))
             inserted = True
             continue
         out.append(line)
     if in_plugins and not saw_enabled and not inserted:
-        out.extend(["  enabled:", f"  - {plugin}"])
+        out.extend(["  enabled:", (item_prefix + plugin)])
     lines = out
 path.write_text("\n".join(lines) + "\n")
 PY


### PR DESCRIPTION
## Summary

`./scripts/install.sh --tool hermes` can write **malformed YAML** into `~/.hermes/config.yaml`, silently disabling every plugin.

### Root cause

`ensure_hermes_plugin_enabled()` inserts the new plugin at a hardcoded **2-space** indent:

```sh
lines.extend(["  enabled:", f"  - {plugin}"])
```

Hermes writes `config.yaml` with `enabled:` at 2 spaces and its `- item` entries nested at **4 spaces**. When an existing entry (e.g. `ponytail`) follows the newly inserted 2-space entry, YAML nests it as a child of the new one, collapsing both into a single scalar:

```yaml
plugins:
  enabled:
  - agency-agents-router
        - ponytail
```

This parses as one string `"agency-agents-router - ponytail"` and disables **all** plugins — and it's invisible unless you parse the file.

### Fix

Detect the real child indent from existing `- ` items under `enabled:` (defaulting to 4 spaces to match Hermes' format) and insert at that indent.

### Verification

Reproduced against the actual function on three inputs:

| Input `plugins.enabled` | Before | After |
|---|---|---|
| `[ponytail]` (4-space items) | `"agency-agents-router - ponytail"` (broken) | `[agency-agents-router, ponytail]` ✅ |
| (no `plugins:` block) | `[agency-agents-router]` | `[agency-agents-router]` ✅ |
| `enabled: []` | `[agency-agents-router]` | `[agency-agents-router]` ✅ |

All three now produce a valid list that parses with `yaml.safe_load`.

🤖 Generated with [Hermes](https://hermes-agent.nousresearch.com)