### PR TITLE
fix(lint): stop SIGPIPE from faking missing recommended sections

### DIFF
--- a/scripts/lint-agents.sh
+++ b/scripts/lint-agents.sh
@@ -91,7 +91,7 @@ lint_file() {
 
   # 2. Check required frontmatter fields
   for field in "${REQUIRED_FRONTMATTER[@]}"; do
-    if ! echo "$frontmatter" | grep -qE "^${field}:"; then
+    if ! grep -qE -- "^${field}:" <<<"$frontmatter"; then
       echo "ERROR $file: missing frontmatter field '${field}'"
       errors=$((errors + 1))
     fi
@@ -101,8 +101,12 @@ lint_file() {
   local body
   body=$(awk 'BEGIN{n=0} /^---$/{n++; next} n>=2{print}' "$file")
 
+  # Feed grep from a herestring, not a pipe: `grep -q` exits at the first match
+  # without draining its input, which kills a piping `echo` with SIGPIPE. Under
+  # `set -o pipefail` that 141 becomes the pipeline's status and is indistinguishable
+  # from "no match", so a large body raced its way to a spurious WARN.
   for section in "${RECOMMENDED_SECTIONS[@]}"; do
-    if ! echo "$body" | grep -qi "$section"; then
+    if ! grep -qi -- "$section" <<<"$body"; then
       echo "WARN  $file: missing recommended section '${section}'"
       warnings=$((warnings + 1))
     fi


### PR DESCRIPTION
## What does this PR do?

Fixes #709 — `scripts/lint-agents.sh` reporting recommended sections as missing when they're present, with output that changes between identical runs.

`set -euo pipefail` is on (line 11), and both checks test with a pipe:

```bash
echo "$body" | grep -qi "$section"
```

`grep -q` exits at its first match without draining stdin. The `echo` is still writing, catches `SIGPIPE`, and dies with 141. `pipefail` promotes that 141 to the pipeline's status, which is indistinguishable from grep's "no match" 1 — so `!` flips it and a section that exists gets flagged missing. It's a race between the writer finishing and the reader bailing, so it only shows up on the larger agent files and varies run to run.

The fix is to feed `grep` from a herestring instead — no writer process, nothing to signal:

```bash
if ! grep -qi -- "$section" <<<"$body"; then
```

Applied at both call sites: the recommended-section check (line 106) and the required-frontmatter check (line 95). `<<<` is bash 3.2-compatible, so stock macOS bash is unaffected. No new dependencies.

## Evidence

Five consecutive runs of `./scripts/lint-agents.sh` over all 254 agent files.

**Before** — the count drifts:

```
Results: 0 error(s), 65 warning(s) in 254 files.
Results: 0 error(s), 71 warning(s) in 254 files.
Results: 0 error(s), 70 warning(s) in 254 files.
Results: 0 error(s), 65 warning(s) in 254 files.
Results: 0 error(s), 68 warning(s) in 254 files.
```

**After** — stable, and the 59 that remain are real (agents that genuinely lack the sections, e.g. `engineering-multi-agent-systems-architect.md` has `## Core Competencies` rather than a `Core Mission`):

```
Results: 0 error(s), 59 warning(s) in 254 files.
Results: 0 error(s), 59 warning(s) in 254 files.
Results: 0 error(s), 59 warning(s) in 254 files.
Results: 0 error(s), 59 warning(s) in 254 files.
Results: 0 error(s), 59 warning(s) in 254 files.
```

So 6–12 of the warnings on `main` today are fabricated, and which ones changes every run.

`./scripts/check-divisions.sh` still passes on this branch.

## Scope and impact

Warnings never gate the exit code (`lint-agents.sh:180-186` gates on `errors` only), so this was never breaking builds — it was producing unreproducible advice and a warning count that couldn't be trusted or compared. The frontmatter check at line 95 is on the merge-blocking ERROR path; its input is small enough that the race effectively never fires there, so that half is a latent fix rather than an observed failure. I didn't want to leave the same defect sitting on the blocking path.

## Note (not part of this PR)

Worth flagging: `lint-agents.yml` triggers on `pull_request` and is path-filtered to the agent directories, so `scripts/**` isn't covered — meaning **this PR gets no CI signal at all**, and the linter that guards the repo isn't itself exercised by CI. That's why the before/after output is pasted above rather than left to a check run. Happy to open a Discussion about CI coverage for `scripts/` if you'd like, per CONTRIBUTING's guidance on CI changes — deliberately keeping it out of this PR.
