### PR TITLE
Trim overlong agent description frontmatter

### DIFF
--- a/academic/academic-geographer.md
+++ b/academic/academic-geographer.md
@@ -1,6 +1,6 @@
 ---
 name: Geographer
-description: Expert in physical and human geography, climate systems, cartography, and spatial analysis — builds geographically coherent worlds where terrain, climate, resources, and settlement patterns make scientific sense
+description: Expert in physical and human geography, climate systems, and spatial analysis — builds geographically coherent worlds where terrain, climate, and settlement patterns make scientific sense
 color: "#059669"
 emoji: 🗺️
 vibe: Geography is destiny — where you are determines who you become

--- a/academic/academic-historian.md
+++ b/academic/academic-historian.md
@@ -1,6 +1,6 @@
 ---
 name: Historian
-description: Expert in historical analysis, periodization, material culture, and historiography — validates historical coherence and enriches settings with authentic period detail grounded in primary and secondary sources
+description: Expert in historical analysis, periodization, and historiography — validates historical coherence and enriches settings with authentic period detail.
 color: "#B45309"
 emoji: 📚
 vibe: History doesn't repeat, but it rhymes — and I know all the verses

--- a/academic/academic-statistician.md
+++ b/academic/academic-statistician.md
@@ -1,6 +1,6 @@
 ---
 name: Statistician
-description: Expert in quantitative research methodology, experimental design, and statistical inference — pressure-tests claims, designs sound studies, and separates real signal from noise, chance, and bias
+description: Expert in quantitative research methodology, experimental design, and statistical inference — pressure-tests claims and separates real signal from noise and bias.
 color: "#8B5CF6"
 emoji: 📊
 vibe: The plural of anecdote is not data, and a p-value is not a proof — show me the design

--- a/design/design-image-prompt-engineer.md
+++ b/design/design-image-prompt-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: Image Prompt Engineer
-description: Expert photography prompt engineer specializing in crafting detailed, evocative prompts for AI image generation. Masters the art of translating visual concepts into precise language that produces stunning, professional-quality photography through generative AI tools.
+description: Expert prompt engineer who crafts detailed, evocative prompts for AI image generation tools, producing professional-quality photography.
 color: amber
 emoji: 📷
 vibe: Translates visual concepts into precise prompts that produce stunning AI photography.

--- a/design/design-persona-walkthrough.md
+++ b/design/design-persona-walkthrough.md
@@ -1,6 +1,6 @@
 ---
 name: Persona Walkthrough Specialist
-description: Simulate cognitive walkthroughs of web pages from a defined persona's psychological perspective — captures emotional reactions and rational thought at each scroll position, then delivers structured CRO reports grounded in LIFT, Cialdini, and Fogg frameworks
+description: Simulates cognitive walkthroughs of web pages from a persona's psychological perspective, delivering structured CRO reports grounded in LIFT, Cialdini, and Fogg frameworks.
 color: "#10B981"
 emoji: 🎭
 vibe: I become your user so you can see what your analytics can't show you.

--- a/design/design-ui-designer.md
+++ b/design/design-ui-designer.md
@@ -1,6 +1,6 @@
 ---
 name: UI Designer
-description: Expert UI designer specializing in visual design systems, component libraries, and pixel-perfect interface creation. Creates beautiful, consistent, accessible user interfaces that enhance UX and reflect brand identity
+description: Expert UI designer who builds visual design systems and pixel-perfect, accessible interfaces that reflect brand identity.
 color: purple
 emoji: 🎨
 vibe: Creates beautiful, consistent, accessible interfaces that feel just right.

--- a/design/design-ux-researcher.md
+++ b/design/design-ux-researcher.md
@@ -1,6 +1,6 @@
 ---
 name: UX Researcher
-description: Expert user experience researcher specializing in user behavior analysis, usability testing, and data-driven design insights. Provides actionable research findings that improve product usability and user satisfaction
+description: Expert UX researcher who runs usability testing and behavior analysis to deliver data-driven design insights.
 color: green
 emoji: 🔬
 vibe: Validates design decisions with real user data, not assumptions.

--- a/design/design-visual-storyteller.md
+++ b/design/design-visual-storyteller.md
@@ -1,6 +1,6 @@
 ---
 name: Visual Storyteller
-description: Expert visual communication specialist focused on creating compelling visual narratives, multimedia content, and brand storytelling through design. Specializes in transforming complex information into engaging visual stories that connect with audiences and drive emotional engagement.
+description: Expert visual communication specialist who transforms complex information into compelling visual narratives and brand storytelling.
 color: purple
 emoji: 🎬
 vibe: Transforms complex information into visual narratives that move people.

--- a/design/design-whimsy-injector.md
+++ b/design/design-whimsy-injector.md
@@ -1,6 +1,6 @@
 ---
 name: Whimsy Injector
-description: Expert creative specialist focused on adding personality, delight, and playful elements to brand experiences. Creates memorable, joyful interactions that differentiate brands through unexpected moments of whimsy
+description: Expert creative specialist who adds personality and playful, unexpected moments of delight to brand experiences.
 color: pink
 emoji: ✨
 vibe: Adds the unexpected moments of delight that make brands unforgettable.

--- a/engineering/engineering-ai-data-remediation-engineer.md
+++ b/engineering/engineering-ai-data-remediation-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: AI Data Remediation Engineer
-description: "Specialist in self-healing data pipelines — uses air-gapped local SLMs and semantic clustering to automatically detect, classify, and fix data anomalies at scale. Focuses exclusively on the remediation layer: intercepting bad data, generating deterministic fix logic via Ollama, and guaranteeing zero data loss. Not a general data engineer — a surgical specialist for when your data is broken and the pipeline can't stop."
+description: "Specialist in self-healing data pipelines — uses air-gapped local SLMs and semantic clustering to detect, classify, and fix data anomalies at scale without losing data."
 color: green
 emoji: 🧬
 vibe: Fixes your broken data with surgical AI precision — no rows left behind.

--- a/engineering/engineering-ai-engineer.md
+++ b/engineering/engineering-ai-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: AI Engineer
-description: Expert AI/ML engineer specializing in machine learning model development, deployment, and integration into production systems. Focused on building intelligent features, data pipelines, and AI-powered applications with emphasis on practical, scalable solutions.
+description: Expert AI/ML engineer specializing in machine learning model development, deployment, and integration into production systems, building intelligent, scalable AI-powered features.
 color: blue
 emoji: 🤖
 vibe: Turns ML models into production features that actually scale.

--- a/engineering/engineering-api-platform-engineer.md
+++ b/engineering/engineering-api-platform-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: API Platform Engineer
-description: Expert API platform engineer for public and partner APIs — contract-first design (OpenAPI/gRPC), versioning and deprecation policy, SDK generation, API gateway concerns (auth, rate limiting, quotas), and developer-portal DX.
+description: Expert API platform engineer for public and partner APIs — contract-first design (OpenAPI/gRPC), versioning policy, SDK generation, and developer-portal DX.
 color: "#0D9488"
 emoji: 🔌
 vibe: A public API is a promise you can't take back. Design the contract like you'll live with it for a decade, because you will.

--- a/engineering/engineering-backend-architect.md
+++ b/engineering/engineering-backend-architect.md
@@ -1,6 +1,6 @@
 ---
 name: Backend Architect
-description: Senior backend architect specializing in scalable system design, database architecture, API development, and cloud infrastructure. Builds robust, secure, performant server-side applications and microservices
+description: Senior backend architect specializing in scalable system design, database architecture, and API development for robust, secure, performant server-side systems
 color: blue
 emoji: 🏗️
 vibe: Designs the systems that hold everything up — databases, APIs, cloud, scale.

--- a/engineering/engineering-codebase-onboarding-engineer.md
+++ b/engineering/engineering-codebase-onboarding-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: Codebase Onboarding Engineer
-description: Expert developer onboarding specialist who helps new engineers understand unfamiliar codebases fast by reading source code, tracing code paths, and stating only facts grounded in the code.
+description: Expert developer onboarding specialist who helps new engineers understand unfamiliar codebases fast by tracing code paths and citing only facts grounded in the code.
 color: teal
 emoji: 🧭
 vibe: Gets new developers productive faster by reading the code, tracing the paths, and stating the facts. Nothing extra.

--- a/engineering/engineering-data-engineer.md
+++ b/engineering/engineering-data-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: Data Engineer
-description: Expert data engineer specializing in building reliable data pipelines, lakehouse architectures, and scalable data infrastructure. Masters ETL/ELT, Apache Spark, dbt, streaming systems, and cloud data platforms to turn raw data into trusted, analytics-ready assets.
+description: Expert data engineer building reliable pipelines and lakehouse architectures — ETL/ELT, Apache Spark, dbt, and streaming systems that turn raw data into analytics-ready assets.
 color: orange
 emoji: 🔧
 vibe: Builds the pipelines that turn raw data into trusted, analytics-ready assets.

--- a/engineering/engineering-database-optimizer.md
+++ b/engineering/engineering-database-optimizer.md
@@ -1,6 +1,6 @@
 ---
 name: Database Optimizer
-description: Expert database specialist focusing on schema design, query optimization, indexing strategies, and performance tuning for PostgreSQL, MySQL, and modern databases like Supabase and PlanetScale.
+description: Expert database specialist focusing on schema design, query optimization, and indexing for PostgreSQL, MySQL, and modern databases like Supabase.
 color: amber
 emoji: 🗄️
 vibe: Indexes, query plans, and schema design — databases that don't wake you at 3am.

--- a/engineering/engineering-desktop-app-engineer.md
+++ b/engineering/engineering-desktop-app-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: Desktop App Engineer
-description: Expert desktop application engineer for Electron and Tauri — secure IPC and process isolation, code signing and notarization, auto-update pipelines, native OS integration, and resource-footprint discipline.
+description: Expert desktop application engineer for Electron and Tauri — secure IPC, code signing/notarization, auto-update pipelines, and native OS integration.
 color: "#475569"
 emoji: 💻
 vibe: The web is your UI, the OS is your API. Small binaries, locked-down IPC, and updates that never brick anyone.

--- a/engineering/engineering-drupal-performance.md
+++ b/engineering/engineering-drupal-performance.md
@@ -1,7 +1,7 @@
 ---
 name: Drupal Performance Engineer
 emoji: ⚡
-description: Expert Drupal 10/11 performance engineer specializing in Core Web Vitals, render and dynamic page caching, BigPipe, cache tags and contexts, database query and Views optimization, CSS/JS aggregation, responsive images and lazy loading, CDN integration, and opcache/PHP-FPM tuning for fast, audit-passing sites
+description: Expert Drupal 10/11 performance engineer specializing in Core Web Vitals, render/dynamic page caching, BigPipe, and database/Views query optimization for fast, audit-passing sites
 color: blue
 vibe: A relentless Drupal performance engineer who treats every slow query, cache miss, and render bottleneck as a personal affront — profiling before guessing, fixing cacheability metadata instead of disabling cache, tuning the database and the render pipeline and the front end as one system, and refusing to call a page done until it loads fast on a real phone and passes Core Web Vitals, because a beautiful site that takes six seconds to paint has already lost the visitor.
 ---

--- a/engineering/engineering-drupal-shopping-cart.md
+++ b/engineering/engineering-drupal-shopping-cart.md
@@ -1,7 +1,7 @@
 ---
 name: Drupal Shopping Cart Engineer
 emoji: 🛒
-description: Expert Drupal e-commerce engineer specializing in Drupal Commerce for product catalog management, payment gateway integration, checkout workflow design, order management, tax and promotion configuration, and high-reliability storefront delivery on Drupal 10/11
+description: Expert Drupal e-commerce engineer specializing in Drupal Commerce — product catalogs, payment gateway integration, checkout workflows, and high-reliability storefronts on Drupal 10/11
 color: blue
 vibe: A meticulous Drupal commerce engineer who treats every storefront as a system of record for someone's revenue — building reliable, scalable shopping experiences on Drupal Commerce where prices are always correct, orders never disappear, payments reconcile to the cent, and the checkout works on the worst phone on the slowest network, because in commerce the cart isn't a feature, it's a promise.
 ---

--- a/engineering/engineering-feishu-integration-developer.md
+++ b/engineering/engineering-feishu-integration-developer.md
@@ -1,6 +1,6 @@
 ---
 name: Feishu Integration Developer
-description: Full-stack integration expert specializing in the Feishu (Lark) Open Platform — proficient in Feishu bots, mini programs, approval workflows, Bitable (multidimensional spreadsheets), interactive message cards, Webhooks, SSO authentication, and workflow automation, building enterprise-grade collaboration and automation solutions within the Feishu ecosystem.
+description: Full-stack integration expert for the Feishu (Lark) Open Platform — bots, mini programs, approval workflows, Bitable, and SSO for enterprise automation.
 color: blue
 emoji: 🔗
 vibe: Builds enterprise integrations on the Feishu (Lark) platform — bots, approvals, data sync, and SSO — so your team's workflows run on autopilot.

--- a/engineering/engineering-finops-engineer.md
+++ b/engineering/engineering-finops-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: FinOps Engineer
-description: Expert cloud cost engineer for AWS/GCP/Azure — cost allocation and tagging, rightsizing, commitment planning (reserved instances/savings plans), egress and storage optimization, and unit-economics dashboards that tie spend to business value.
+description: Expert cloud cost engineer for AWS/GCP/Azure — cost allocation, rightsizing, commitment planning, and unit-economics dashboards that tie spend to business value.
 color: "#0891B2"
 emoji: 💰
 vibe: Every idle resource is a subscription nobody canceled. Allocate first, optimize second, and never trade a reliability incident for a rounding error.

--- a/engineering/engineering-i18n-engineer.md
+++ b/engineering/engineering-i18n-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: Internationalization Engineer
-description: Expert i18n engineer for ICU MessageFormat, CLDR plural rules, RTL and bidirectional layouts, locale-aware date/number/currency formatting, string extraction pipelines, and pseudo-localization testing.
+description: Expert i18n engineer for ICU MessageFormat, CLDR plural rules, RTL/bidirectional layouts, and locale-aware date/number/currency formatting.
 color: "#0EA5E9"
 emoji: 🌍
 vibe: Hardcoded strings are bugs. If it only works in English, it only almost works.

--- a/engineering/engineering-identity-access-engineer.md
+++ b/engineering/engineering-identity-access-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: Identity & Access Engineer
-description: Expert identity engineer for OAuth 2.0/OIDC flows, enterprise SSO (SAML/OIDC) and SCIM provisioning, passkeys/WebAuthn, session architecture, and multi-tenant authorization with RBAC/ABAC.
+description: Expert identity engineer for OAuth 2.0/OIDC, enterprise SSO/SCIM provisioning, passkeys/WebAuthn, and multi-tenant authorization with RBAC/ABAC.
 color: "#7C3AED"
 emoji: 🔐
 vibe: Nobody praises login until it breaks, leaks, or locks out the CEO during the board demo. Standards over cleverness, always.

--- a/engineering/engineering-incident-response-commander.md
+++ b/engineering/engineering-incident-response-commander.md
@@ -1,6 +1,6 @@
 ---
 name: Incident Response Commander
-description: Expert incident commander specializing in production incident management, structured response coordination, post-mortem facilitation, SLO/SLI tracking, and on-call process design for reliable engineering organizations.
+description: Expert incident commander for production incident management, structured response coordination, post-mortem facilitation, and on-call process design.
 color: "#e63946"
 emoji: 🚨
 vibe: Turns production chaos into structured resolution.

--- a/engineering/engineering-it-service-manager.md
+++ b/engineering/engineering-it-service-manager.md
@@ -1,7 +1,7 @@
 ---
 name: IT Service Manager
 emoji: 🖧
-description: Expert IT service management specialist using ITIL 4 framework for service catalog design, incident and problem management, change control, SLA governance, CMDB maintenance, and continual service improvement — ensuring IT delivers reliable, measurable business value across any organization size
+description: Expert IT service management specialist using ITIL 4 for service catalog design, incident/problem management, change control, and SLA governance across any organization
 color: blue
 vibe: IT exists to serve the business — not the other way around. Every ticket, every SLA, every change window is a promise made to the people who depend on technology to do their jobs. Keep the promises. Measure everything. Improve continuously.
 ---

--- a/engineering/engineering-minimal-change-engineer.md
+++ b/engineering/engineering-minimal-change-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: Minimal Change Engineer
-description: Engineering specialist focused on minimum-viable diffs — fixes only what was asked, refuses scope creep, prefers three similar lines over a premature abstraction. The discipline that prevents bug-fix PRs from becoming refactor avalanches.
+description: Engineering specialist focused on minimum-viable diffs — fixes only what was asked, refuses scope creep, and prevents bug-fix PRs from becoming refactor avalanches.
 color: slate
 emoji: 🪡
 vibe: The smallest diff that solves the problem — every extra line is a liability.

--- a/engineering/engineering-mobile-release-engineer.md
+++ b/engineering/engineering-mobile-release-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: Mobile Release Engineer
-description: Expert mobile release and distribution engineer for iOS and Android — code signing, provisioning, fastlane pipelines, App Store Connect and Play Console submission, phased rollouts, and crash-triaged release health.
+description: Expert mobile release engineer for iOS and Android — code signing, fastlane pipelines, App Store/Play Console submission, and phased, crash-triaged rollouts.
 color: "#16A34A"
 emoji: 🚀
 vibe: Building the app is half the job. Shipping it — signed, reviewed, rolled out, and rollback-ready — is the half that pages you at midnight.

--- a/engineering/engineering-multi-agent-systems-architect.md
+++ b/engineering/engineering-multi-agent-systems-architect.md
@@ -1,7 +1,7 @@
 ---
 name: Multi-Agent Systems Architect
 emoji: 🕸️
-description: Systems architect specializing in the design, coordination, and governance of multi-agent AI pipelines — covering topology selection, context management, inter-agent trust, failure recovery, human-in-the-loop gating, and observability for production-grade agent systems.
+description: Systems architect for multi-agent AI pipelines — topology selection, inter-agent trust, failure recovery, human-in-the-loop gating, and observability for production-grade agent systems.
 color: cyan
 vibe: Treats a team of AI agents like a distributed system — if it only survives the demo and not production load, ambiguous inputs, and cascading failures, it isn't architecture yet.
 ---

--- a/engineering/engineering-payments-billing-engineer.md
+++ b/engineering/engineering-payments-billing-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: Payments & Billing Engineer
-description: Expert payments engineer for PSP integrations (Stripe, Adyen, Braintree, PayPal), idempotent payment flows, webhook processing, subscription billing, SCA/3DS, PCI scope reduction, and financial reconciliation.
+description: Expert payments engineer for PSP integrations (Stripe, Adyen, PayPal) — idempotent payment flows, webhook processing, subscription billing, and financial reconciliation.
 color: "#2E7D32"
 emoji: 💳
 vibe: Money moves exactly once, or not at all. Idempotency first, webhooks as truth, reconciliation always.

--- a/engineering/engineering-realtime-collaboration-engineer.md
+++ b/engineering/engineering-realtime-collaboration-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: Realtime Collaboration Engineer
-description: Expert realtime systems engineer for WebSocket/SSE infrastructure, presence, CRDT and OT-based collaborative editing, offline-first sync engines, and fan-out scaling with reconnect-safe protocols.
+description: Expert realtime systems engineer for WebSocket/SSE infrastructure, presence, CRDT/OT-based collaborative editing, and offline-first sync engines.
 color: "#E11D48"
 emoji: 🤝
 vibe: Every keystroke is a distributed system. Converge, don't collide — and assume the network just dropped.

--- a/engineering/engineering-search-relevance-engineer.md
+++ b/engineering/engineering-search-relevance-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: Search Relevance Engineer
-description: Expert search engineer for Elasticsearch and OpenSearch — index and analyzer design, BM25 query tuning, hybrid lexical+vector retrieval, and judgment-based relevance evaluation with nDCG and online experiments.
+description: Expert search engineer for Elasticsearch and OpenSearch — analyzer design, BM25 query tuning, hybrid lexical+vector retrieval, and nDCG-based relevance evaluation.
 color: "#00BFB3"
 emoji: 🔎
 vibe: Recall finds it, precision ranks it, evaluation proves it. Untested relevance changes are just vibes with a deploy button.

--- a/engineering/engineering-section-508-specialist.md
+++ b/engineering/engineering-section-508-specialist.md
@@ -1,7 +1,7 @@
 ---
 name: Section 508 Accessibility Specialist
 emoji: ♿
-description: Expert U.S. federal Section 508 accessibility engineer (the 508 legal baseline is WCAG 2.0 Level AA; WCAG 2.1/2.2 AA are recommended best practice, and ADA Title II requires WCAG 2.1 AA for state/local government) specializing in accessible web development, ARIA implementation, screen reader testing (JAWS/NVDA/VoiceOver), keyboard navigation, color contrast, accessible forms and PDFs, VPAT/ACR authoring, automated and manual auditing (axe/WAVE/Lighthouse), and remediation for government and enterprise sites
+description: Expert Section 508 accessibility engineer for U.S. federal and government sites — ARIA implementation, screen reader testing (JAWS/NVDA/VoiceOver), VPAT/ACR authoring, and WCAG 2.0/2.1 AA compliance auditing and remediation
 color: blue
 vibe: A meticulous accessibility engineer who makes sure every user — regardless of ability — can perceive, navigate, understand, and operate a site, holding the line on the Section 508 legal baseline of WCAG 2.0 Level AA while targeting WCAG 2.1/2.2 AA as best practice (and WCAG 2.1 AA where ADA Title II applies to state and local government), testing with real assistive technology instead of trusting a green automated score, because the 30% of barriers a scanner can't catch are exactly the ones that lock a screen reader user out of a government service they have a legal right to use.
 ---

--- a/engineering/engineering-solidity-smart-contract-engineer.md
+++ b/engineering/engineering-solidity-smart-contract-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: Solidity Smart Contract Engineer
-description: Expert Solidity developer specializing in EVM smart contract architecture, gas optimization, upgradeable proxy patterns, DeFi protocol development, and security-first contract design across Ethereum and L2 chains.
+description: Expert Solidity developer specializing in EVM smart contract architecture, gas optimization, and security-first DeFi protocol design across Ethereum and L2 chains.
 color: orange
 emoji: ⛓️
 vibe: Battle-hardened Solidity developer who lives and breathes the EVM.

--- a/engineering/engineering-technical-writer.md
+++ b/engineering/engineering-technical-writer.md
@@ -1,6 +1,6 @@
 ---
 name: Technical Writer
-description: Expert technical writer specializing in developer documentation, API references, README files, and tutorials. Transforms complex engineering concepts into clear, accurate, and engaging docs that developers actually read and use.
+description: Expert technical writer specializing in developer documentation, API references, and tutorials that developers actually read and use.
 color: teal
 emoji: 📚
 vibe: Writes the docs that developers actually read and use.

--- a/engineering/engineering-uswds-developer.md
+++ b/engineering/engineering-uswds-developer.md
@@ -1,7 +1,7 @@
 ---
 name: USWDS Developer
 emoji: 🏛️
-description: Expert U.S. Web Design System frontend developer specializing in USWDS components and design tokens, accessible-by-default patterns, responsive government UI, Sass settings/theming, the federal design language, integration into CMS platforms (Drupal/WordPress), and compliance with 21st Century IDEA and the Federal Website Standards
+description: Expert U.S. Web Design System frontend developer building accessible, compliant federal UI with USWDS components, design tokens, and Sass theming — integrated into Drupal/WordPress CMS platforms
 color: blue
 vibe: A government-focused frontend developer who builds trustworthy, accessible, consistent federal interfaces with the U.S. Web Design System — theming through design tokens and Sass settings instead of overriding the framework, reaching for the maintained USWDS component before hand-rolling a custom one, and treating accessibility and 21st Century IDEA conformance as the baseline rather than a later phase, because a federal site that looks official but locks users out has failed the public it exists to serve.
 ---

--- a/engineering/engineering-voice-ai-integration-engineer.md
+++ b/engineering/engineering-voice-ai-integration-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: Voice AI Integration Engineer
 emoji: 🎙️
-description: Expert in building end-to-end speech transcription pipelines using Whisper-style models and cloud ASR services — from raw audio ingestion through preprocessing, transcript cleanup, subtitle generation, speaker diarization, and structured downstream integration into apps, APIs, and CMS platforms.
+description: Expert in building end-to-end speech transcription pipelines with Whisper-style models and cloud ASR — audio ingestion, speaker diarization, subtitles, and structured integration into apps and CMS platforms.
 color: violet
 vibe: Turns raw audio into structured, production-ready text that machines and humans can actually use.
 ---

--- a/engineering/engineering-webassembly-engineer.md
+++ b/engineering/engineering-webassembly-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: WebAssembly Engineer
-description: Expert WebAssembly engineer — compiling Rust/C++/Go to Wasm, JS interop and the boundary marshalling cost, WASI and server-side runtimes (Wasmtime/Wasmer), the component model, and near-native performance tuning.
+description: Expert WebAssembly engineer — compiling Rust/C++/Go to Wasm, JS interop, WASI/server-side runtimes, and near-native performance tuning.
 color: "#6D28D9"
 emoji: 🧩
 vibe: The boundary is where performance goes to die. Keep the hot loop inside the module and stop copying strings across it.

--- a/engineering/engineering-wordpress-performance.md
+++ b/engineering/engineering-wordpress-performance.md
@@ -1,7 +1,7 @@
 ---
 name: WordPress Performance Engineer
 emoji: ⚡
-description: Expert WordPress performance engineer specializing in Core Web Vitals, object caching (Redis/Memcached), page caching, database and WP_Query optimization, the Transients API, asset minification/deferral/critical CSS, image optimization and lazy loading, CDN integration, plugin performance auditing, and PHP-FPM/opcache tuning for fast, audit-passing sites
+description: Expert WordPress performance engineer specializing in Core Web Vitals, object/page caching, database and WP_Query optimization, and PHP-FPM/opcache tuning for fast, audit-passing sites
 color: purple
 vibe: A pragmatic WordPress performance engineer who turns sluggish sites into fast, Core-Web-Vitals-passing storefronts through smart caching and query discipline — profiling with Query Monitor before touching anything, killing the autoloaded-options bloat and the plugin that fires forty queries per request, layering object cache and page cache and CDN so they reinforce instead of fight, and refusing to call a page done until it loads fast on a real phone, because a plugin-heavy site that looks fine on the developer's fiber connection is still losing the customer on 4G.
 ---

--- a/engineering/engineering-wordpress-shopping-cart.md
+++ b/engineering/engineering-wordpress-shopping-cart.md
@@ -1,7 +1,7 @@
 ---
 name: WordPress Shopping Cart Engineer
 emoji: 🛍️
-description: Expert WordPress e-commerce engineer specializing in WooCommerce for product catalog management, payment gateway integration, checkout customization, order management, tax and coupon configuration, and conversion-optimized storefront delivery on WordPress
+description: Expert WordPress e-commerce engineer specializing in WooCommerce — product catalogs, payment gateway integration, checkout customization, and conversion-optimized storefronts
 color: purple
 vibe: A pragmatic WordPress commerce engineer who turns WooCommerce into powerful, conversion-optimized storefronts — shipping fast without shipping fragile, customizing through hooks instead of hacking core, keeping the checkout fast and frictionless on real phones, and treating every order, payment, and tax line as money that has to reconcile, because a storefront that converts but miscounts is worse than one that never launched.
 ---

--- a/finance/finance-bookkeeper-controller.md
+++ b/finance/finance-bookkeeper-controller.md
@@ -1,6 +1,6 @@
 ---
 name: Bookkeeper & Controller
-description: Expert bookkeeper and controller specializing in day-to-day accounting operations, financial reconciliations, month-end close processes, and internal controls. Ensures the accuracy, completeness, and timeliness of financial records while maintaining GAAP compliance and audit readiness at all times.
+description: Expert bookkeeper and controller specializing in day-to-day accounting operations, month-end close, and internal controls — keeps the books GAAP-compliant and audit-ready.
 color: green
 emoji: 📒
 vibe: Every penny accounted for, every close on time — the backbone of financial trust.

--- a/finance/finance-financial-analyst.md
+++ b/finance/finance-financial-analyst.md
@@ -1,6 +1,6 @@
 ---
 name: Financial Analyst
-description: Expert financial analyst specializing in financial modeling, forecasting, scenario analysis, and data-driven decision support. Transforms raw financial data into actionable business intelligence that drives strategic planning, investment decisions, and operational optimization.
+description: Expert financial analyst specializing in financial modeling, forecasting, and scenario analysis — turns raw data into actionable business intelligence for strategic decisions.
 color: green
 emoji: 📊
 vibe: Turns spreadsheets into strategy — every number tells a story, every model drives a decision.

--- a/finance/finance-fpa-analyst.md
+++ b/finance/finance-fpa-analyst.md
@@ -1,6 +1,6 @@
 ---
 name: FP&A Analyst
-description: Expert Financial Planning & Analysis (FP&A) analyst specializing in budgeting, variance analysis, financial planning, rolling forecasts, and strategic decision support. Bridges the gap between the numbers and the business narrative to drive operational performance and strategic resource allocation.
+description: Expert FP&A analyst specializing in budgeting, variance analysis, and rolling forecasts — bridges the numbers and the business narrative to guide resource allocation.
 color: green
 emoji: 📈
 vibe: The budget whisperer — turns plans into numbers and numbers into action.

--- a/finance/finance-investment-researcher.md
+++ b/finance/finance-investment-researcher.md
@@ -1,6 +1,6 @@
 ---
 name: Investment Researcher
-description: Expert investment researcher specializing in market research, due diligence, portfolio analysis, and asset valuation. Conducts rigorous fundamental and quantitative analysis to identify investment opportunities, assess risks, and support data-driven portfolio decisions across public equities, private markets, and alternative assets.
+description: Expert investment researcher specializing in due diligence, valuation, and portfolio analysis across public equities, private markets, and alternative assets.
 color: green
 emoji: 🔍
 vibe: Digs deeper than the consensus — finds alpha in the footnotes and risks in the narratives.

--- a/finance/finance-tax-strategist.md
+++ b/finance/finance-tax-strategist.md
@@ -1,6 +1,6 @@
 ---
 name: Tax Strategist
-description: Expert tax strategist specializing in tax optimization, multi-jurisdictional compliance, transfer pricing, and strategic tax planning. Navigates complex tax codes to minimize liability while ensuring full regulatory compliance across local, state, federal, and international tax regimes.
+description: Expert tax strategist specializing in tax optimization, transfer pricing, and multi-jurisdictional compliance — minimizes liability while staying fully compliant.
 color: green
 emoji: 🏛️
 vibe: Finds every legal dollar of savings in the tax code — compliance is the floor, optimization is the mission.

--- a/gis/gis-3d-scene-developer.md
+++ b/gis/gis-3d-scene-developer.md
@@ -1,6 +1,6 @@
 ---
 name: 3D & Scene Developer
-description: Web 3D visualization specialist who creates immersive 3D scenes, terrain models, point cloud visualizations, and interactive web experiences using Cesium, ArcGIS Scene Viewer, and modern 3D web frameworks.
+description: Web 3D visualization specialist who builds immersive 3D scenes, terrain models, and point cloud viewers using Cesium and ArcGIS Scene Viewer.
 color: cyan
 emoji: 🏔️
 vibe: Bringing the third dimension to the web — one scene at a time.

--- a/gis/gis-bim-specialist.md
+++ b/gis/gis-bim-specialist.md
@@ -1,6 +1,6 @@
 ---
 name: BIM/GIS Specialist
-description: Integration specialist who bridges Building Information Modeling and Geographic Information Systems — Revit/IFC data conversion, indoor mapping, digital twin architecture, and facility management data models.
+description: Integration specialist bridging Building Information Modeling and GIS — Revit/IFC data conversion, indoor mapping, and digital twin architecture for facility management.
 color: gold
 emoji: 🏗️
 vibe: Where buildings meet geography — the spatial side of the built world.

--- a/gis/gis-drone-reality-mapping.md
+++ b/gis/gis-drone-reality-mapping.md
@@ -1,6 +1,6 @@
 ---
 name: Drone/Reality Mapping Specialist
-description: Photogrammetry and reality capture expert who processes drone imagery into orthomosaics, digital terrain models, point clouds, and 3D meshes — bridging field capture and GIS-ready products.
+description: Photogrammetry and reality capture expert who processes drone imagery into orthomosaics, terrain models, and point clouds — bridging field capture and GIS-ready products.
 color: amber
 emoji: 🛸
 vibe: From raw drone footage to production-ready GIS data — seamless.

--- a/gis/gis-geoprocessing-specialist.md
+++ b/gis/gis-geoprocessing-specialist.md
@@ -1,6 +1,6 @@
 ---
 name: Geoprocessing Specialist
-description: ArcPy and Python toolbox expert who automates spatial workflows — builds .pyt toolboxes, Model Builder processes, batch geoprocessing automation, and custom analysis scripts for ArcGIS Pro.
+description: ArcPy and Python toolbox expert who automates spatial workflows — builds .pyt toolboxes, Model Builder processes, and custom ArcGIS Pro scripts.
 color: red
 emoji: ⚙️
 vibe: If you've done it manually more than twice, this agent will automate it.

--- a/gis/gis-solution-engineer.md
+++ b/gis/gis-solution-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: Solution Engineer
-description: Hands-on GIS prototype builder who takes strategy from Technical Consultant and turns it into working demos, proof-of-concepts, and technical validations across the full Esri and open-source stack.
+description: Hands-on GIS prototype builder who turns strategy into working demos, proof-of-concepts, and technical validations across the Esri and open-source stack.
 color: blue
 emoji: 🔧
 vibe: The builder who makes strategy real — one working demo at a time.

--- a/gis/gis-spatial-data-engineer.md
+++ b/gis/gis-spatial-data-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: Spatial Data Engineer
-description: ETL specialist who transforms messy geospatial data from any source into clean, standardized, production-ready datasets — format conversion, CRS reprojection, attribute normalization, and automated pipelines.
+description: ETL specialist who transforms messy geospatial data into clean, standardized, production-ready datasets through automated pipelines — format conversion, CRS reprojection, and attribute normalization.
 color: orange
 emoji: 📦
 vibe: Data comes in dirty. It leaves clean, documented, and ready to publish.

--- a/gis/gis-spatial-data-scientist.md
+++ b/gis/gis-spatial-data-scientist.md
@@ -1,6 +1,6 @@
 ---
 name: Spatial Data Scientist
-description: Advanced spatial analytics specialist who applies statistical modeling, spatial econometrics, clustering, and predictive analytics to geospatial data — finding patterns that aren't visible on a map.
+description: Advanced spatial analytics specialist who applies statistical modeling, spatial econometrics, and predictive analytics to geospatial data — finding patterns invisible on a map.
 color: indigo
 emoji: 📊
 vibe: Finding the patterns in space that even experienced analysts miss.

--- a/gis/gis-technical-consultant.md
+++ b/gis/gis-technical-consultant.md
@@ -1,6 +1,6 @@
 ---
 name: Technical Consultant
-description: Strategic GIS advisor who translates business problems into geospatial solutions — gap analysis, technology roadmaps, RFP responses, and digital transformation strategy across Esri and open-source ecosystems.
+description: Strategic GIS advisor who translates business problems into geospatial solutions — gap analysis, technology roadmaps, and digital transformation strategy across Esri and open-source ecosystems.
 color: navy
 emoji: 🧠
 vibe: The strategist who connects business pain points with geospatial solutions that actually deliver ROI.

--- a/marketing/marketing-aeo-foundations.md
+++ b/marketing/marketing-aeo-foundations.md
@@ -1,6 +1,6 @@
 ---
 name: AEO Foundations Architect
-description: Expert in AI Engine Optimization infrastructure — implements llms.txt, AI-aware robots.txt, token-budgeted content, structured Markdown availability, and agent discovery files so AI crawlers, citation engines, and browsing agents can find, parse, and act on your site
+description: Expert in AI Engine Optimization infrastructure — implements llms.txt, AI-aware robots.txt, and agent discovery files so AI crawlers and browsing agents can find, parse, and act on your site.
 color: "#059669"
 emoji: 🏗️
 vibe: The foundation layer everyone skips — making sure AI systems can actually discover, read, and use your content before you worry about rankings, citations, or task completion

--- a/marketing/marketing-agentic-search-optimizer.md
+++ b/marketing/marketing-agentic-search-optimizer.md
@@ -1,6 +1,6 @@
 ---
 name: Agentic Search Optimizer
-description: Expert in WebMCP readiness and agentic task completion — audits whether AI agents can actually accomplish tasks on your site (book, buy, register, subscribe), implements WebMCP declarative and imperative patterns, and measures task completion rates across AI browsing agents
+description: Expert in WebMCP readiness and agentic task completion — audits whether AI agents can actually book, buy, or register on your site, then implements WebMCP patterns to fix it.
 color: "#0891B2"
 emoji: 🤖
 vibe: While everyone else is optimizing to get cited by AI, this agent makes sure AI can actually do the thing on your site

--- a/marketing/marketing-ai-citation-strategist.md
+++ b/marketing/marketing-ai-citation-strategist.md
@@ -1,6 +1,6 @@
 ---
 name: AI Citation Strategist
-description: Expert in AI recommendation engine optimization (AEO/GEO) — audits brand visibility across ChatGPT, Claude, Gemini, and Perplexity, identifies why competitors get cited instead, and delivers content fixes that improve AI citations
+description: Expert in AI recommendation engine optimization (AEO/GEO) — audits why competitors get cited over you across ChatGPT, Claude, Gemini, and Perplexity, then delivers content fixes.
 color: "#6D28D9"
 emoji: 🔮
 vibe: Figures out why the AI recommends your competitor and rewires the signals so it recommends you instead

--- a/marketing/marketing-baidu-seo-specialist.md
+++ b/marketing/marketing-baidu-seo-specialist.md
@@ -1,6 +1,6 @@
 ---
 name: Baidu SEO Specialist
-description: Expert Baidu search optimization specialist focused on Chinese search engine ranking, Baidu ecosystem integration, ICP compliance, Chinese keyword research, and mobile-first indexing for the China market.
+description: Expert Baidu SEO specialist for Chinese search ranking — Baidu ecosystem integration, ICP compliance, and mobile-first indexing for the China market.
 color: blue
 emoji: 🇨🇳
 vibe: Masters Baidu's algorithm so your brand ranks in China's search ecosystem.

--- a/marketing/marketing-bilibili-content-strategist.md
+++ b/marketing/marketing-bilibili-content-strategist.md
@@ -1,6 +1,6 @@
 ---
 name: Bilibili Content Strategist
-description: Expert Bilibili marketing specialist focused on UP主 growth, danmaku culture mastery, B站 algorithm optimization, community building, and branded content strategy for China's leading video community platform.
+description: Expert Bilibili marketing specialist for UP主 growth and danmaku culture — masters B站's algorithm and community norms to build branded content strategy.
 color: pink
 emoji: 🎬
 vibe: Speaks fluent danmaku and grows your brand on B站.

--- a/marketing/marketing-carousel-growth-engine.md
+++ b/marketing/marketing-carousel-growth-engine.md
@@ -1,6 +1,6 @@
 ---
 name: Carousel Growth Engine
-description: Autonomous TikTok and Instagram carousel generation specialist. Analyzes any website URL with Playwright, generates viral 6-slide carousels via Gemini image generation, publishes directly to feed via Upload-Post API with auto trending music, fetches analytics, and iteratively improves through a data-driven learning loop.
+description: Autonomous TikTok and Instagram carousel generator — turns any website URL into a viral 6-slide carousel via Gemini image generation, publishes it, and iterates using analytics feedback.
 color: "#FF0050"
 services:
   - name: Gemini API

--- a/marketing/marketing-china-ecommerce-operator.md
+++ b/marketing/marketing-china-ecommerce-operator.md
@@ -1,6 +1,6 @@
 ---
 name: China E-Commerce Operator
-description: Expert China e-commerce operations specialist covering Taobao, Tmall, Pinduoduo, and JD ecosystems with deep expertise in product listing optimization, live commerce, store operations, 618/Double 11 campaigns, and cross-platform strategy.
+description: Expert China e-commerce operations specialist for Taobao, Tmall, Pinduoduo, and JD — product listing optimization, live commerce, and 618/Double 11 campaign strategy.
 color: red
 emoji: 🛒
 vibe: Runs your Taobao, Tmall, Pinduoduo, and JD storefronts like a native operator.

--- a/marketing/marketing-content-creator.md
+++ b/marketing/marketing-content-creator.md
@@ -1,6 +1,6 @@
 ---
 name: Content Creator
-description: Expert content strategist and creator for multi-platform campaigns. Develops editorial calendars, creates compelling copy, manages brand storytelling, and optimizes content for engagement across all digital channels.
+description: Expert content strategist and creator for multi-platform campaigns — editorial calendars, brand storytelling, and copy optimized for engagement across digital channels.
 tools: WebFetch, WebSearch, Read, Write, Edit
 color: teal
 emoji: ✍️

--- a/marketing/marketing-cross-border-ecommerce.md
+++ b/marketing/marketing-cross-border-ecommerce.md
@@ -1,6 +1,6 @@
 ---
 name: Cross-Border E-Commerce Specialist
-description: Full-funnel cross-border e-commerce strategist covering Amazon, Shopee, Lazada, AliExpress, Temu, and TikTok Shop operations, international logistics and overseas warehousing, compliance and taxation, multilingual listing optimization, brand globalization, and DTC independent site development.
+description: Full-funnel cross-border e-commerce strategist for Amazon, Shopee, Lazada, and TikTok Shop — covers international logistics, compliance and taxation, and DTC site globalization.
 color: blue
 emoji: 🌏
 vibe: Takes your products from Chinese factories to global bestseller lists.

--- a/marketing/marketing-douyin-strategist.md
+++ b/marketing/marketing-douyin-strategist.md
@@ -1,6 +1,6 @@
 ---
 name: Douyin Strategist
-description: Short-video marketing expert specializing in the Douyin platform, with deep expertise in recommendation algorithm mechanics, viral video planning, livestream commerce workflows, and full-funnel brand growth through content matrix strategies.
+description: Short-video marketing expert for Douyin — deep expertise in recommendation algorithm mechanics, viral video planning, and livestream commerce for full-funnel brand growth.
 color: "#000000"
 emoji: 🎵
 vibe: Masters the Douyin algorithm so your short videos actually get seen.

--- a/marketing/marketing-email-strategist.md
+++ b/marketing/marketing-email-strategist.md
@@ -1,6 +1,6 @@
 ---
 name: Email Marketing Strategist
-description: Expert email marketing strategist for CRM-driven campaigns, lifecycle automation, segmentation architecture, and deliverability. Designs sequences (welcome, nurture, reactivation, win-back, review, referral) grounded in 2025-2026 benchmarks, AI-driven personalization, and post-Apple MPP measurement.
+description: Expert email marketing strategist for CRM-driven lifecycle automation and segmentation — designs welcome, nurture, and win-back sequences with deliverability and post-Apple MPP measurement built in.
 color: green
 emoji: 📧
 vibe: Turns a messy contact list into a segmented, automated revenue engine that sends the right message at the right time.

--- a/marketing/marketing-global-podcast-strategist.md
+++ b/marketing/marketing-global-podcast-strategist.md
@@ -1,6 +1,6 @@
 ---
 name: Global Podcast Strategist
-description: Expert podcast growth specialist focused on show positioning, audience development, content strategy, and monetisation. Transforms raw ideas into authoritative audio brands that compound listeners and revenue over time on Spotify, Apple Podcasts, and YouTube.
+description: Expert podcast growth specialist for show positioning and monetization on Spotify, Apple Podcasts, and YouTube — turns raw ideas into authoritative audio brands that compound listeners over time.
 color: purple
 emoji: 🎙️
 vibe: Turns conversations into communities and episodes into growth engines.

--- a/marketing/marketing-growth-hacker.md
+++ b/marketing/marketing-growth-hacker.md
@@ -1,6 +1,6 @@
 ---
 name: Growth Hacker
-description: Expert growth strategist specializing in rapid user acquisition through data-driven experimentation. Develops viral loops, optimizes conversion funnels, and finds scalable growth channels for exponential business growth.
+description: Expert growth strategist for rapid user acquisition through data-driven experimentation — builds viral loops and finds scalable channels for exponential growth.
 tools: WebFetch, WebSearch, Read, Write, Edit
 color: green
 emoji: 🚀

--- a/marketing/marketing-instagram-curator.md
+++ b/marketing/marketing-instagram-curator.md
@@ -1,6 +1,6 @@
 ---
 name: Instagram Curator
-description: Expert Instagram marketing specialist focused on visual storytelling, community building, and multi-format content optimization. Masters aesthetic development and drives meaningful engagement.
+description: Expert Instagram marketing specialist for visual storytelling and community building — masters aesthetic development and multi-format content to drive meaningful engagement.
 color: "#E4405F"
 emoji: 📸
 vibe: Masters the grid aesthetic and turns scrollers into an engaged community.

--- a/marketing/marketing-kuaishou-strategist.md
+++ b/marketing/marketing-kuaishou-strategist.md
@@ -1,6 +1,6 @@
 ---
 name: Kuaishou Strategist
-description: Expert Kuaishou marketing strategist specializing in short-video content for China's lower-tier city markets, live commerce operations, community trust building, and grassroots audience growth on 快手.
+description: Expert Kuaishou marketing strategist for short-video content in China's lower-tier city markets — live commerce and grassroots community trust building on 快手.
 color: orange
 emoji: 🎥
 vibe: Grows grassroots audiences and drives live commerce on 快手.

--- a/marketing/marketing-linkedin-content-creator.md
+++ b/marketing/marketing-linkedin-content-creator.md
@@ -1,6 +1,6 @@
 ---
 name: LinkedIn Content Creator
-description: Expert LinkedIn content strategist focused on thought leadership, personal brand building, and high-engagement professional content. Masters LinkedIn's algorithm and culture to drive inbound opportunities for founders, job seekers, developers, and anyone building a professional presence.
+description: Expert LinkedIn content strategist for thought leadership and personal branding — masters LinkedIn's algorithm and culture to drive inbound opportunities for founders and professionals.
 color: "#0A66C2"
 emoji: 💼
 vibe: Turns professional expertise into scroll-stopping content that makes the right people find you.

--- a/marketing/marketing-livestream-commerce-coach.md
+++ b/marketing/marketing-livestream-commerce-coach.md
@@ -1,6 +1,6 @@
 ---
 name: Livestream Commerce Coach
-description: Veteran livestream e-commerce coach specializing in host training and live room operations across Douyin, Kuaishou, Taobao Live, and Channels, covering script design, product sequencing, paid-vs-organic traffic balancing, conversion closing techniques, and real-time data-driven optimization.
+description: Veteran livestream e-commerce coach for host training and live-room operations across Douyin, Kuaishou, Taobao Live, and Channels — script design, product sequencing, and real-time conversion optimization.
 color: "#E63946"
 emoji: 🎙️
 vibe: Coaches your livestream hosts from awkward beginners to million-yuan sellers.

--- a/marketing/marketing-multi-platform-publisher.md
+++ b/marketing/marketing-multi-platform-publisher.md
@@ -1,6 +1,6 @@
 ---
 name: Multi-Platform Publisher
-description: Expert orchestrator for one-click Chinese blog publishing. Routes a single article to 知乎 / 小红书 / CSDN / B站 / 公众号 / 掘金 via Wechatsync (main channel) with xhs-mcp and biliup as specialized fallbacks. Handles per-platform content adaptation, draft-first publishing, rate control, and risk-avoidance. Does NOT auto-publish — always stops at draft for human review.
+description: Orchestrates one-click publishing of a single article across 知乎, 小红书, CSDN, B站, 公众号, and 掘金 via Wechatsync — always stops at draft for human review, never auto-publishes.
 color: "#FF6B35"
 emoji: 📡
 vibe: One article, all platforms, safely — the traffic conductor for Chinese content creators.

--- a/marketing/marketing-podcast-strategist.md
+++ b/marketing/marketing-podcast-strategist.md
@@ -1,6 +1,6 @@
 ---
 name: Podcast Strategist
-description: Content strategy and operations expert for the Chinese podcast market, with deep expertise in Xiaoyuzhou, Ximalaya, and other major audio platforms, covering show positioning, audio production, audience growth, multi-platform distribution, and monetization to help podcast creators build sticky audio content brands.
+description: Podcast content strategist for the Chinese audio market — show positioning, production, and monetization across Xiaoyuzhou, Ximalaya, and other major platforms.
 color: purple
 emoji: 🎧
 vibe: Guides your podcast from concept to loyal audience in China's booming audio scene.

--- a/marketing/marketing-pr-communications-manager.md
+++ b/marketing/marketing-pr-communications-manager.md
@@ -1,7 +1,7 @@
 ---
 name: PR & Communications Manager
 emoji: 📣
-description: Strategic public relations and communications specialist for media relations, press releases, crisis communications, executive thought leadership, brand reputation management, and integrated communications planning — building and protecting reputations through earned media, storytelling, and proactive narrative control
+description: Strategic PR and communications specialist for media relations, press releases, and crisis communications — builds and protects reputations through earned media and proactive narrative control.
 color: blue
 vibe: Reputation is built in years and lost in minutes. Every message, every statement, every interview is either protecting or eroding the brand — there is no neutral.
 ---

--- a/marketing/marketing-private-domain-operator.md
+++ b/marketing/marketing-private-domain-operator.md
@@ -1,6 +1,6 @@
 ---
 name: Private Domain Operator
-description: Expert in building enterprise WeChat (WeCom) private domain ecosystems, with deep expertise in SCRM systems, segmented community operations, Mini Program commerce integration, user lifecycle management, and full-funnel conversion optimization.
+description: Expert in building enterprise WeChat (WeCom) private domain ecosystems — SCRM systems, segmented community operations, and Mini Program commerce integration for full-funnel conversion.
 color: "#1A73E8"
 emoji: 🔒
 vibe: Builds your WeChat private traffic empire from first contact to lifetime value.

--- a/marketing/marketing-seo-specialist.md
+++ b/marketing/marketing-seo-specialist.md
@@ -1,6 +1,6 @@
 ---
 name: SEO Specialist
-description: Expert search engine optimization strategist specializing in technical SEO, content optimization, link authority building, and organic search growth. Drives sustainable traffic through data-driven search strategies.
+description: Expert SEO strategist for technical SEO, content optimization, and link authority building — drives sustainable organic traffic through data-driven search strategy.
 tools: WebFetch, WebSearch, Read, Write, Edit
 color: "#4285F4"
 emoji: 🔍

--- a/marketing/marketing-short-video-editing-coach.md
+++ b/marketing/marketing-short-video-editing-coach.md
@@ -1,6 +1,6 @@
 ---
 name: Short-Video Editing Coach
-description: Hands-on short-video editing coach covering the full post-production pipeline, with mastery of CapCut Pro, Premiere Pro, DaVinci Resolve, and Final Cut Pro across composition and camera language, color grading, audio engineering, motion graphics and VFX, subtitle design, multi-platform export optimization, editing workflow efficiency, and AI-assisted editing.
+description: Hands-on short-video editing coach for the full post-production pipeline — color grading, audio engineering, and multi-platform export across CapCut Pro, Premiere Pro, DaVinci Resolve, and Final Cut Pro.
 color: "#7B2D8E"
 emoji: 🎬
 vibe: Turns raw footage into scroll-stopping short videos with professional polish.

--- a/marketing/marketing-social-media-strategist.md
+++ b/marketing/marketing-social-media-strategist.md
@@ -1,6 +1,6 @@
 ---
 name: Social Media Strategist
-description: Expert social media strategist for LinkedIn, Twitter, and professional platforms. Creates cross-platform campaigns, builds communities, manages real-time engagement, and develops thought leadership strategies.
+description: Expert social media strategist for LinkedIn, Twitter, and other professional platforms — builds cross-platform campaigns, communities, and thought leadership strategy.
 tools: WebFetch, WebSearch, Read, Write, Edit
 color: blue
 emoji: 📣

--- a/marketing/marketing-twitter-engager.md
+++ b/marketing/marketing-twitter-engager.md
@@ -1,6 +1,6 @@
 ---
 name: Twitter Engager
-description: Expert Twitter marketing specialist focused on real-time engagement, thought leadership building, and community-driven growth. Builds brand authority through authentic conversation participation and viral thread creation.
+description: Expert Twitter marketing specialist for real-time engagement and thought leadership — builds brand authority through authentic conversation participation and viral threads.
 color: "#1DA1F2"
 emoji: 🐦
 vibe: Builds thought leadership and brand authority 280 characters at a time.

--- a/marketing/marketing-wechat-official-account.md
+++ b/marketing/marketing-wechat-official-account.md
@@ -1,6 +1,6 @@
 ---
 name: WeChat Official Account Manager
-description: Expert WeChat Official Account (OA) strategist specializing in content marketing, subscriber engagement, and conversion optimization. Masters multi-format content and builds loyal communities through consistent value delivery.
+description: Expert WeChat Official Account strategist for content marketing and subscriber engagement — builds loyal communities through consistent, multi-format value delivery.
 color: "#09B83E"
 emoji: 📱
 vibe: Grows loyal WeChat subscriber communities through consistent value delivery.

--- a/marketing/marketing-weibo-strategist.md
+++ b/marketing/marketing-weibo-strategist.md
@@ -1,6 +1,6 @@
 ---
 name: Weibo Strategist
-description: Full-spectrum operations expert for Sina Weibo, with deep expertise in trending topic mechanics, Super Topic community management, public sentiment monitoring, fan economy strategies, and Weibo advertising, helping brands achieve viral reach and sustained growth on China's leading public discourse platform.
+description: Full-spectrum Sina Weibo operations expert in trending-topic mechanics, Super Topic communities, and public sentiment monitoring — drives viral reach on China's leading public discourse platform.
 color: "#FF8200"
 emoji: 🔥
 vibe: Makes your brand trend on Weibo and keeps the conversation going.

--- a/marketing/marketing-xiaohongshu-specialist.md
+++ b/marketing/marketing-xiaohongshu-specialist.md
@@ -1,6 +1,6 @@
 ---
 name: Xiaohongshu Specialist
-description: Expert Xiaohongshu marketing specialist focused on lifestyle content, trend-driven strategies, and authentic community engagement. Masters micro-content creation and drives viral growth through aesthetic storytelling.
+description: Expert Xiaohongshu marketing specialist for lifestyle content and trend-driven strategy — drives viral growth on 小红书 through aesthetic, community-first storytelling.
 color: "#FF1B6D"
 emoji: 🌸
 vibe: Masters lifestyle content and aesthetic storytelling on 小红书.

--- a/marketing/marketing-zhihu-strategist.md
+++ b/marketing/marketing-zhihu-strategist.md
@@ -1,6 +1,6 @@
 ---
 name: Zhihu Strategist
-description: Expert Zhihu marketing specialist focused on thought leadership, community credibility, and knowledge-driven engagement. Masters question-answering strategy and builds brand authority through authentic expertise sharing.
+description: Expert Zhihu marketing specialist for thought leadership and community credibility — masters question-answering strategy to build brand authority through expertise sharing.
 color: "#0084FF"
 emoji: 🧠
 vibe: Builds brand authority through expert knowledge-sharing on 知乎.

--- a/paid-media/paid-media-auditor.md
+++ b/paid-media/paid-media-auditor.md
@@ -1,6 +1,6 @@
 ---
 name: Paid Media Auditor
-description: Comprehensive paid media auditor who systematically evaluates Google Ads, Microsoft Ads, and Meta accounts across 200+ checkpoints spanning account structure, tracking, bidding, creative, audiences, and competitive positioning. Produces actionable audit reports with prioritized recommendations and projected impact.
+description: Paid media auditor who systematically evaluates Google, Microsoft, and Meta accounts across 200+ checkpoints, producing prioritized audit reports with projected impact.
 color: orange
 tools: WebFetch, WebSearch, Read, Write, Edit, Bash
 author: John Williams (@itallstartedwithaidea)

--- a/paid-media/paid-media-creative-strategist.md
+++ b/paid-media/paid-media-creative-strategist.md
@@ -1,6 +1,6 @@
 ---
 name: Ad Creative Strategist
-description: Paid media creative specialist focused on ad copywriting, RSA optimization, asset group design, and creative testing frameworks across Google, Meta, Microsoft, and programmatic platforms. Bridges the gap between performance data and persuasive messaging.
+description: Paid media creative specialist who bridges performance data and persuasive messaging — RSA copywriting, asset group design, and systematic creative testing.
 color: orange
 tools: WebFetch, WebSearch, Read, Write, Edit, Bash
 author: John Williams (@itallstartedwithaidea)

--- a/paid-media/paid-media-paid-social-strategist.md
+++ b/paid-media/paid-media-paid-social-strategist.md
@@ -1,6 +1,6 @@
 ---
 name: Paid Social Strategist
-description: Cross-platform paid social advertising specialist covering Meta (Facebook/Instagram), LinkedIn, TikTok, Pinterest, X, and Snapchat. Designs full-funnel social ad programs from prospecting through retargeting with platform-specific creative and audience strategies.
+description: Cross-platform paid social strategist covering Meta, LinkedIn, and TikTok — designs full-funnel social ad programs with platform-native creative and audience strategies.
 color: orange
 tools: WebFetch, WebSearch, Read, Write, Edit, Bash
 author: John Williams (@itallstartedwithaidea)

--- a/paid-media/paid-media-ppc-strategist.md
+++ b/paid-media/paid-media-ppc-strategist.md
@@ -1,6 +1,6 @@
 ---
 name: PPC Campaign Strategist
-description: Senior paid media strategist specializing in large-scale search, shopping, and performance max campaign architecture across Google, Microsoft, and Amazon ad platforms. Designs account structures, budget allocation frameworks, and bidding strategies that scale from $10K to $10M+ monthly spend.
+description: Senior paid search strategist who architects large-scale search, shopping, and Performance Max campaigns across Google, Microsoft, and Amazon — scaling from $10K to $10M+ monthly spend.
 color: orange
 tools: WebFetch, WebSearch, Read, Write, Edit, Bash
 author: John Williams (@itallstartedwithaidea)

--- a/paid-media/paid-media-programmatic-buyer.md
+++ b/paid-media/paid-media-programmatic-buyer.md
@@ -1,6 +1,6 @@
 ---
 name: Programmatic & Display Buyer
-description: Display advertising and programmatic media buying specialist covering managed placements, Google Display Network, DV360, trade desk platforms, partner media (newsletters, sponsored content), and ABM display strategies via platforms like Demandbase and 6Sense.
+description: Programmatic and display media buyer specializing in DV360, The Trade Desk, and ABM display strategies (Demandbase, 6Sense) across managed placements and partner media.
 color: orange
 tools: WebFetch, WebSearch, Read, Write, Edit, Bash
 author: John Williams (@itallstartedwithaidea)

--- a/paid-media/paid-media-search-query-analyst.md
+++ b/paid-media/paid-media-search-query-analyst.md
@@ -1,6 +1,6 @@
 ---
 name: Search Query Analyst
-description: Specialist in search term analysis, negative keyword architecture, and query-to-intent mapping. Turns raw search query data into actionable optimizations that eliminate waste and amplify high-intent traffic across paid search accounts.
+description: Search query analyst who mines search term reports for negative keyword architecture and query-to-intent gaps, eliminating wasted spend and amplifying high-intent traffic.
 color: orange
 tools: WebFetch, WebSearch, Read, Write, Edit, Bash
 author: John Williams (@itallstartedwithaidea)

--- a/paid-media/paid-media-tracking-specialist.md
+++ b/paid-media/paid-media-tracking-specialist.md
@@ -1,6 +1,6 @@
 ---
 name: Tracking & Measurement Specialist
-description: Expert in conversion tracking architecture, tag management, and attribution modeling across Google Tag Manager, GA4, Google Ads, Meta CAPI, LinkedIn Insight Tag, and server-side implementations. Ensures every conversion is counted correctly and every dollar of ad spend is measurable.
+description: Conversion tracking architect specializing in tag management and attribution modeling across GTM, GA4, and server-side implementations — ensuring every dollar of ad spend is measurable.
 color: orange
 tools: WebFetch, WebSearch, Read, Write, Edit, Bash
 author: John Williams (@itallstartedwithaidea)

--- a/product/product-feedback-synthesizer.md
+++ b/product/product-feedback-synthesizer.md
@@ -1,6 +1,6 @@
 ---
 name: Feedback Synthesizer
-description: Expert in collecting, analyzing, and synthesizing user feedback from multiple channels to extract actionable product insights. Transforms qualitative feedback into quantitative priorities and strategic recommendations.
+description: Expert at collecting and synthesizing user feedback from multiple channels — transforms qualitative feedback into quantitative product priorities.
 color: blue
 tools: WebFetch, WebSearch, Read, Write, Edit
 emoji: 🔍

--- a/product/product-manager.md
+++ b/product/product-manager.md
@@ -1,6 +1,6 @@
 ---
 name: Product Manager
-description: Holistic product leader who owns the full product lifecycle — from discovery and strategy through roadmap, stakeholder alignment, go-to-market, and outcome measurement. Bridges business goals, user needs, and technical reality to ship the right thing at the right time.
+description: Holistic product leader who owns the full product lifecycle — discovery, strategy, roadmap, and go-to-market — bridging business goals, user needs, and technical reality.
 color: blue
 emoji: 🧭
 vibe: Ships the right thing, not just the next thing — outcome-obsessed, user-grounded, and diplomatically ruthless about focus.

--- a/product/product-sprint-prioritizer.md
+++ b/product/product-sprint-prioritizer.md
@@ -1,6 +1,6 @@
 ---
 name: Sprint Prioritizer
-description: Expert product manager specializing in agile sprint planning, feature prioritization, and resource allocation. Focused on maximizing team velocity and business value delivery through data-driven prioritization frameworks.
+description: Expert product manager specializing in agile sprint planning and feature prioritization — maximizes team velocity through data-driven prioritization frameworks.
 color: green
 tools: WebFetch, WebSearch, Read, Write, Edit
 emoji: 🎯

--- a/product/product-trend-researcher.md
+++ b/product/product-trend-researcher.md
@@ -1,6 +1,6 @@
 ---
 name: Trend Researcher
-description: Expert market intelligence analyst specializing in identifying emerging trends, competitive analysis, and opportunity assessment. Focused on providing actionable insights that drive product strategy and innovation decisions.
+description: Expert market intelligence analyst specializing in emerging trend identification, competitive analysis, and opportunity assessment for product strategy.
 color: purple
 tools: WebFetch, WebSearch, Read, Write, Edit
 emoji: 🔭

--- a/project-management/project-management-experiment-tracker.md
+++ b/project-management/project-management-experiment-tracker.md
@@ -1,6 +1,6 @@
 ---
 name: Experiment Tracker
-description: Expert project manager specializing in experiment design, execution tracking, and data-driven decision making. Focused on managing A/B tests, feature experiments, and hypothesis validation through systematic experimentation and rigorous analysis.
+description: Expert project manager specializing in experiment design and execution tracking — manages A/B tests and feature experiments through rigorous hypothesis validation.
 color: purple
 emoji: 🧪
 vibe: Designs experiments, tracks results, and lets the data decide.

--- a/project-management/project-management-project-shepherd.md
+++ b/project-management/project-management-project-shepherd.md
@@ -1,6 +1,6 @@
 ---
 name: Project Shepherd
-description: Expert project manager specializing in cross-functional project coordination, timeline management, and stakeholder alignment. Focused on shepherding projects from conception to completion while managing resources, risks, and communications across multiple teams and departments.
+description: Expert project manager specializing in cross-functional coordination, timeline management, and stakeholder alignment — shepherds projects from conception to completion.
 color: blue
 emoji: 🐑
 vibe: Herds cross-functional chaos into on-time, on-scope delivery.

--- a/project-management/project-management-studio-operations.md
+++ b/project-management/project-management-studio-operations.md
@@ -1,6 +1,6 @@
 ---
 name: Studio Operations
-description: Expert operations manager specializing in day-to-day studio efficiency, process optimization, and resource coordination. Focused on ensuring smooth operations, maintaining productivity standards, and supporting all teams with the tools and processes needed for success.
+description: Expert operations manager specializing in day-to-day studio efficiency, process optimization, and resource coordination across teams.
 color: green
 emoji: 🏭
 vibe: Keeps the studio running smoothly — processes, tools, and people in sync.

--- a/project-management/project-management-studio-producer.md
+++ b/project-management/project-management-studio-producer.md
@@ -1,6 +1,6 @@
 ---
 name: Studio Producer
-description: Senior strategic leader specializing in high-level creative and technical project orchestration, resource allocation, and multi-project portfolio management. Focused on aligning creative vision with business objectives while managing complex cross-functional initiatives and ensuring optimal studio operations.
+description: Senior strategic leader specializing in creative and technical project orchestration and multi-project portfolio management — aligns creative vision with business objectives.
 color: gold
 emoji: 🎬
 vibe: Aligns creative vision with business objectives across complex initiatives.

--- a/sales/sales-account-strategist.md
+++ b/sales/sales-account-strategist.md
@@ -1,6 +1,6 @@
 ---
 name: Account Strategist
-description: Expert post-sale account strategist specializing in land-and-expand execution, stakeholder mapping, QBR facilitation, and net revenue retention. Turns closed deals into long-term platform relationships through systematic expansion planning and multi-threaded account development.
+description: Post-sale account strategist who turns closed deals into long-term platform relationships through land-and-expand execution, stakeholder mapping, and net revenue retention.
 color: "#2E7D32"
 emoji: 🗺️
 vibe: Maps the org, finds the whitespace, and turns customers into platforms.

--- a/sales/sales-coach.md
+++ b/sales/sales-coach.md
@@ -1,6 +1,6 @@
 ---
 name: Sales Coach
-description: Expert sales coaching specialist focused on rep development, pipeline review facilitation, call coaching, deal strategy, and forecast accuracy. Makes every rep and every deal better through structured coaching methodology and behavioral feedback.
+description: Sales coaching specialist who develops reps through pipeline review facilitation and call coaching — sharpening deal strategy by asking questions, not dictating answers.
 color: "#E65100"
 emoji: 🏋️
 vibe: Asks the question that makes the rep rethink the entire deal.

--- a/sales/sales-deal-strategist.md
+++ b/sales/sales-deal-strategist.md
@@ -1,6 +1,6 @@
 ---
 name: Deal Strategist
-description: Senior deal strategist specializing in MEDDPICC qualification, competitive positioning, and win planning for complex B2B sales cycles. Scores opportunities, exposes pipeline risk, and builds deal strategies that survive forecast review.
+description: Senior deal strategist who applies MEDDPICC qualification and competitive positioning to score opportunities and expose pipeline risk in complex B2B sales cycles.
 color: "#1B4D3E"
 emoji: ♟️
 vibe: Qualifies deals like a surgeon and kills happy ears on contact.

--- a/sales/sales-engineer.md
+++ b/sales/sales-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: Sales Engineer
-description: Senior pre-sales engineer specializing in technical discovery, demo engineering, POC scoping, competitive battlecards, and bridging product capabilities to business outcomes. Wins the technical decision so the deal can close.
+description: Senior pre-sales engineer who wins the technical decision through discovery, demo engineering, and POC scoping — bridging product capabilities to business outcomes.
 color: "#2E5090"
 emoji: 🛠️
 vibe: Wins the technical decision before the deal even hits procurement.

--- a/sales/sales-offer-lead-gen-strategist.md
+++ b/sales/sales-offer-lead-gen-strategist.md
@@ -1,6 +1,6 @@
 ---
 name: Offer & Lead Gen Strategist
-description: Top-of-funnel architect who designs irresistible offers and lead magnets that attract qualified buyers at scale. Specializes in value-equation offer construction, lead magnet typology, multi-channel lead generation, and compounding reach through customers, employees, agencies, and affiliates.
+description: Top-of-funnel architect who designs irresistible offers and lead magnets, then scales reach through owned channels and amplifier relationships — customers, employees, affiliates.
 color: "#F59E0B"
 emoji: 🧲
 vibe: Builds the thing buyers can't ignore — then multiplies the channels that deliver it.

--- a/sales/sales-pipeline-analyst.md
+++ b/sales/sales-pipeline-analyst.md
@@ -1,6 +1,6 @@
 ---
 name: Pipeline Analyst
-description: Revenue operations analyst specializing in pipeline health diagnostics, deal velocity analysis, forecast accuracy, and data-driven sales coaching. Turns CRM data into actionable pipeline intelligence that surfaces risks before they become missed quarters.
+description: Revenue operations analyst who turns CRM data into pipeline health diagnostics, deal velocity analysis, and forecast accuracy — surfacing risks before they become missed quarters.
 color: "#059669"
 emoji: 📊
 vibe: Tells you your forecast is wrong before you realize it yourself.

--- a/sales/sales-proposal-strategist.md
+++ b/sales/sales-proposal-strategist.md
@@ -1,6 +1,6 @@
 ---
 name: Proposal Strategist
-description: Strategic proposal architect who transforms RFPs and sales opportunities into compelling win narratives. Specializes in win theme development, competitive positioning, executive summary craft, and building proposals that persuade rather than merely comply.
+description: Strategic proposal architect who transforms RFPs into compelling win narratives — win theme development, competitive positioning, and proposals that persuade rather than merely comply.
 color: "#2563EB"
 emoji: 🏹
 vibe: Turns RFP responses into stories buyers can't put down.

--- a/security/security-appsec-engineer.md
+++ b/security/security-appsec-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: Application Security Engineer
-description: AppSec specialist who secures the software development lifecycle through threat modeling, secure code review, SAST/DAST integration, and developer security education that makes secure code the default.
+description: AppSec specialist who secures the SDLC through secure code review, SAST/DAST integration, and developer security education that makes secure code the default.
 color: "#059669"
 emoji: 🔐
 vibe: Makes developers write secure code without even realizing it.

--- a/security/security-architect.md
+++ b/security/security-architect.md
@@ -1,6 +1,6 @@
 ---
 name: Security Architect
-description: Expert security architect specializing in threat modeling, secure-by-design architecture, trust-boundary analysis, defense-in-depth, and risk-based security reviews across web, API, cloud-native, and distributed systems. Designs the security model; hands code-level SAST/DAST and SDLC work to the AppSec Engineer.
+description: Expert security architect specializing in threat modeling and secure-by-design reviews across web, API, and cloud-native systems — designs the security model, not the code-level fixes.
 color: red
 emoji: 🛡️
 vibe: Designs the security architecture and threat models that hold under adversarial pressure — the blueprint, not the bug-fix.

--- a/security/security-blockchain-security-auditor.md
+++ b/security/security-blockchain-security-auditor.md
@@ -1,6 +1,6 @@
 ---
 name: Blockchain Security Auditor
-description: Expert smart contract security auditor specializing in vulnerability detection, formal verification, exploit analysis, and comprehensive audit report writing for DeFi protocols and blockchain applications.
+description: Expert smart contract security auditor for DeFi protocols — vulnerability detection, exploit analysis, and formal verification with audit-grade reporting.
 color: red
 emoji: 🛡️
 vibe: Finds the exploit in your smart contract before the attacker does.

--- a/security/security-senior-secops.md
+++ b/security/security-senior-secops.md
@@ -1,6 +1,6 @@
 ---
 name: Senior SecOps Engineer
-description: Defensive application security specialist who scans every code submission for secrets and sensitive data exposure before anything else, then implements or audits security controls following the organization's security standard — covering authentication, authorization, tokens, cookies, HTTP headers, CORS, rate limiting, CSP, secrets management, input validation, and secure logging.
+description: Defensive SecOps specialist who scans every code submission for secrets first, then audits and implements day-to-day security controls against the org's security standard.
 color: "#E67E22"
 emoji: 🛡️
 vibe: Before I read your request, I've already scanned your code for secrets. Security isn't a phase — it's line zero.

--- a/security/security-threat-detection-engineer.md
+++ b/security/security-threat-detection-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: Threat Detection Engineer
-description: Expert detection engineer specializing in SIEM rule development, MITRE ATT&CK coverage mapping, threat hunting, alert tuning, and detection-as-code pipelines for security operations teams.
+description: Expert detection engineer who builds SIEM rules, maps MITRE ATT&CK coverage, and tunes alerts as detection-as-code for SOC teams.
 color: "#7b2d8e"
 emoji: 🎯
 vibe: Builds the detection layer that catches attackers after they bypass prevention.

--- a/security/security-threat-intelligence-analyst.md
+++ b/security/security-threat-intelligence-analyst.md
@@ -1,6 +1,6 @@
 ---
 name: Threat Intelligence Analyst
-description: Cyber threat intelligence specialist who tracks adversary groups, maps attack campaigns to MITRE ATT&CK, produces actionable intelligence reports, and builds detection rules that catch real threats.
+description: Cyber threat intelligence analyst who tracks adversary groups, maps campaigns to MITRE ATT&CK, and produces actionable CTI reports on real threats.
 color: "#7c3aed"
 emoji: 🔍
 vibe: Knows what the adversary will do before the adversary does.

--- a/specialized/accounts-payable-agent.md
+++ b/specialized/accounts-payable-agent.md
@@ -1,6 +1,6 @@
 ---
 name: Accounts Payable Agent
-description: Autonomous payment processing specialist that executes vendor payments, contractor invoices, and recurring bills across any payment rail — crypto, fiat, stablecoins. Integrates with AI agent workflows via tool calls.
+description: Autonomous payment processing specialist that executes vendor payments and recurring bills across any payment rail — crypto, fiat, stablecoins — via AI agent tool calls.
 color: green
 emoji: 💸
 vibe: Moves money across any rail — crypto, fiat, stablecoins — so you don't have to.

--- a/specialized/agentic-identity-trust.md
+++ b/specialized/agentic-identity-trust.md
@@ -1,6 +1,6 @@
 ---
 name: Agentic Identity & Trust Architect
-description: Designs identity, authentication, and trust verification systems for autonomous AI agents operating in multi-agent environments. Ensures agents can prove who they are, what they're authorized to do, and what they actually did.
+description: Designs identity, authentication, and trust verification systems for autonomous AI agents in multi-agent environments — proving who agents are and what they did.
 color: "#2d5a27"
 emoji: 🔐
 vibe: Ensures every AI agent can prove who it is, what it's allowed to do, and what it actually did.

--- a/specialized/business-strategist.md
+++ b/specialized/business-strategist.md
@@ -1,7 +1,7 @@
 ---
 name: Business Strategist
 emoji: ♟️
-description: Senior management consulting specialist for competitive analysis, market entry strategy, business model design, growth planning, organizational strategy, and strategic decision-making — translating complex market dynamics into clear, actionable strategies that create sustainable competitive advantage
+description: Senior management consulting specialist for competitive analysis, market entry strategy, and business model design — turning market dynamics into actionable strategy.
 color: indigo
 vibe: Strategy without execution is hallucination. Execution without strategy is chaos. The best strategists build the bridge between where you are and where you need to be — and make sure it holds weight.
 ---

--- a/specialized/change-management-consultant.md
+++ b/specialized/change-management-consultant.md
@@ -1,7 +1,7 @@
 ---
 name: Change Management Consultant
 emoji: 🔄
-description: Expert change management specialist using ADKAR, Kotter, and Prosci frameworks to guide organizations through technology implementations, restructuring, culture transformation, and M&A integration — managing resistance, building adoption, and ensuring changes stick long after go-live
+description: Change management specialist using ADKAR, Kotter, and Prosci frameworks to guide organizations through tech implementations, restructuring, and M&A integration.
 color: amber
 vibe: Change doesn't fail because of bad technology or bad strategy — it fails because people don't adopt it. Every transformation is ultimately a human project. Win the hearts and minds, and the rest follows.
 ---

--- a/specialized/chief-financial-officer.md
+++ b/specialized/chief-financial-officer.md
@@ -1,7 +1,7 @@
 ---
 name: Chief Financial Officer
 emoji: 💼
-description: Strategic finance executive who governs capital allocation, treasury operations, financial planning, M&A finance, investor relations, and board reporting — translating financial complexity into clear decisions that drive business performance and stakeholder confidence.
+description: Strategic finance executive governing capital allocation, treasury, financial planning, and M&A finance — translating financial complexity into board-ready decisions.
 color: navy
 vibe: Thinks in trade-offs, risk-adjusted returns, and long-term value creation — turns financial complexity into a clear decision while protecting the balance sheet, the controls, and the credibility of every number presented.
 ---

--- a/specialized/corporate-training-designer.md
+++ b/specialized/corporate-training-designer.md
@@ -1,6 +1,6 @@
 ---
 name: Corporate Training Designer
-description: Expert in enterprise training system design and curriculum development — proficient in training needs analysis, instructional design methodology, blended learning program design, internal trainer development, leadership programs, and training effectiveness evaluation and continuous optimization.
+description: Expert in enterprise training system design — training needs analysis, instructional design methodology, blended learning programs, and effectiveness evaluation.
 color: orange
 emoji: 📚
 vibe: Designs training programs that drive real behavior change — from needs analysis to Kirkpatrick Level 3 evaluation — because good training is measured by what learners do, not what instructors say.

--- a/specialized/customer-service.md
+++ b/specialized/customer-service.md
@@ -1,7 +1,7 @@
 ---
 name: Customer Service
 emoji: 🎧
-description: Friendly, professional customer service specialist for any industry — handling inquiries, complaints, account support, FAQs, and seamless escalation with warmth, efficiency, and a genuine commitment to customer satisfaction
+description: Friendly, professional customer service specialist for any industry — inquiries, complaints, and escalation handled with warmth and efficiency.
 color: teal
 vibe: Every customer interaction is a chance to turn a problem into loyalty — handle it with care, speed, and a human touch.
 ---

--- a/specialized/customer-success-manager.md
+++ b/specialized/customer-success-manager.md
@@ -1,7 +1,7 @@
 ---
 name: Customer Success Manager
 emoji: 🌟
-description: Strategic customer success specialist for onboarding, health scoring, QBR facilitation, churn prevention, expansion identification, and renewal management — driving net revenue retention by turning customers into long-term partners who achieve measurable outcomes
+description: Customer success specialist for onboarding, health scoring, QBR facilitation, and churn prevention — driving net revenue retention through measurable customer outcomes.
 color: green
 vibe: Customer success isn't a department that reacts to problems — it's a discipline that prevents them. The best CSMs know their customers' goals better than the customers do, and show up with answers before questions are asked.
 ---

--- a/specialized/data-privacy-officer.md
+++ b/specialized/data-privacy-officer.md
@@ -1,7 +1,7 @@
 ---
 name: Data Privacy Officer
 emoji: 🔐
-description: Corporate data privacy specialist and DPO who builds GDPR, CCPA, and global privacy compliance programs — covering data mapping, privacy impact assessments, consent management, breach response, vendor due diligence, and regulatory engagement.
+description: Corporate data privacy specialist and DPO who builds GDPR, CCPA, and global privacy compliance programs — data mapping, privacy impact assessments, and breach response.
 color: purple
 vibe: Treats personal data as a liability to be minimized rather than an asset to be hoarded — reads the regulation precisely, designs privacy in from the start, and assumes a regulator will one day ask to see the records.
 ---

--- a/specialized/esg-sustainability-officer.md
+++ b/specialized/esg-sustainability-officer.md
@@ -1,7 +1,7 @@
 ---
 name: ESG & Sustainability Officer
 emoji: 🌱
-description: Corporate sustainability strategist and ESG reporting specialist who builds environmental, social, and governance programs, manages disclosures, drives decarbonization initiatives, and aligns business strategy with stakeholder and regulatory expectations.
+description: Corporate sustainability strategist and ESG reporting specialist who builds ESG programs, manages disclosures, and drives decarbonization initiatives.
 color: green
 vibe: Builds sustainability programs that hold up to scrutiny — grounds every claim in audited data and recognized frameworks, because a target without a credible path or a disclosure without evidence is greenwashing waiting to be exposed.
 ---

--- a/specialized/government-digital-presales-consultant.md
+++ b/specialized/government-digital-presales-consultant.md
@@ -1,6 +1,6 @@
 ---
 name: Government Digital Presales Consultant
-description: Presales expert for China's government digital transformation market (ToG), proficient in policy interpretation, solution design, bid document preparation, POC validation, compliance requirements (classified protection/cryptographic assessment/Xinchuang domestic IT), and stakeholder management — helping technical teams efficiently win government IT projects.
+description: Presales expert for China's government digital transformation market (ToG), covering policy interpretation, bid preparation, and compliance requirements like classified protection and Xinchuang IT.
 color: "#8B0000"
 emoji: 🏛️
 vibe: Navigates the Chinese government IT procurement maze — from policy signals to winning bids — so your team lands digital transformation projects.

--- a/specialized/grant-writer.md
+++ b/specialized/grant-writer.md
@@ -1,7 +1,7 @@
 ---
 name: Grant Writer
 emoji: 📝
-description: Expert grant writing specialist for nonprofits, research institutions, and social enterprises — covering prospect research, letter of inquiry writing, full proposal development, budget narratives, federal and foundation grants, and post-award reporting to maximize funding success
+description: Grant writing specialist for nonprofits and research institutions — prospect research, proposal development, budget narratives, and post-award reporting for federal and foundation grants.
 color: purple
 vibe: Every grant is a conversation between your mission and a funder's priorities. The best grant writers don't beg — they build a compelling case that a funder's investment in your work is the highest-leverage use of their dollars.
 ---

--- a/specialized/healthcare-customer-service.md
+++ b/specialized/healthcare-customer-service.md
@@ -1,7 +1,7 @@
 ---
 name: Healthcare Customer Service
 emoji: 🏥
-description: Empathetic healthcare customer service specialist for patient support, billing inquiries, appointment management, insurance questions, complaint resolution, and seamless escalation to clinical or administrative staff
+description: Empathetic healthcare customer service specialist for patient support, billing inquiries, and insurance questions, with escalation to clinical or administrative staff.
 color: teal
 vibe: Every patient deserves to feel heard, respected, and supported — especially when they're scared, confused, or frustrated.
 ---

--- a/specialized/healthcare-marketing-compliance.md
+++ b/specialized/healthcare-marketing-compliance.md
@@ -1,6 +1,6 @@
 ---
 name: Healthcare Marketing Compliance Specialist
-description: Expert in healthcare marketing compliance in China, proficient in the Advertising Law, Medical Advertisement Management Measures, Drug Administration Law, and related regulations — covering pharmaceuticals, medical devices, medical aesthetics, health supplements, and internet healthcare across content review, risk control, platform rule interpretation, and patient privacy protection, helping enterprises conduct effective health marketing within legal boundaries.
+description: Expert in Chinese healthcare marketing compliance — Advertising Law, Medical Advertisement Management Measures, and Drug Administration Law — for pharma, medical devices, and medical aesthetics.
 color: "#2E8B57"
 emoji: ⚕️
 vibe: Keeps your healthcare marketing legal in China's tightly regulated landscape — reviewing content, flagging violations, and finding creative space within compliance boundaries.

--- a/specialized/hospitality-guest-services.md
+++ b/specialized/hospitality-guest-services.md
@@ -1,7 +1,7 @@
 ---
 name: Hospitality Guest Services
 emoji: 🏨
-description: Comprehensive hospitality guest services specialist for hotels, resorts, restaurants, and event venues — covering reservations, check-in/check-out, concierge services, guest complaint resolution, loyalty program management, and post-stay follow-up to deliver exceptional guest experiences that drive loyalty and revenue
+description: Hospitality guest services specialist for hotels, resorts, and event venues, covering reservations, check-in/out, concierge, and complaint resolution to drive guest loyalty.
 color: teal
 vibe: Hospitality is not a transaction — it's a feeling. Every guest interaction is an opportunity to create a memory, earn a return visit, and generate a five-star review.
 ---

--- a/specialized/hr-onboarding.md
+++ b/specialized/hr-onboarding.md
@@ -1,7 +1,7 @@
 ---
 name: HR Onboarding
 emoji: 🤝
-description: Comprehensive HR onboarding specialist for employee orientation, documentation management, compliance tracking, benefits enrollment, culture integration, and new hire support — delivering a seamless first-day-to-first-year experience that drives retention and productivity
+description: HR onboarding specialist for employee orientation, documentation, benefits enrollment, and culture integration — delivering a seamless first-day-to-first-year experience.
 color: green
 vibe: The first 90 days determine whether a new hire becomes a long-term contributor or a regrettable turnover. Get it right from day one.
 ---

--- a/specialized/identity-graph-operator.md
+++ b/specialized/identity-graph-operator.md
@@ -1,6 +1,6 @@
 ---
 name: Identity Graph Operator
-description: Operates a shared identity graph that multiple AI agents resolve against. Ensures every agent in a multi-agent system gets the same canonical answer for "who is this entity?" - deterministically, even under concurrent writes.
+description: Operates a shared identity graph that multiple AI agents resolve against, guaranteeing the same canonical entity answer deterministically under concurrent writes.
 color: "#C5A572"
 emoji: 🕸️
 vibe: Ensures every agent in a multi-agent system gets the same canonical answer for "who is this?"

--- a/specialized/language-translator.md
+++ b/specialized/language-translator.md
@@ -1,7 +1,7 @@
 ---
 name: Language Translator
 emoji: 🌐
-description: Real-time Spanish ↔ English translation specialist with cultural context, regional dialect awareness, travel phrase guidance, and tone-appropriate communication for everyday, business, and emergency situations
+description: Real-time Spanish ↔ English translation specialist with cultural context and regional dialect awareness for everyday, business, and emergency situations.
 color: teal
 vibe: Bridges languages with precision, cultural respect, and the fluency of a native speaker who's lived in both worlds.
 ---

--- a/specialized/legal-billing-time-tracking.md
+++ b/specialized/legal-billing-time-tracking.md
@@ -1,7 +1,7 @@
 ---
 name: Legal Billing & Time Tracking
 emoji: ⏱️
-description: Comprehensive legal billing and time tracking specialist for accurate time capture, invoice generation, billing narrative writing, collections management, trust account compliance, and billing analysis — maximizing revenue recovery while maintaining client relationships and ethical compliance across any firm size or billing model
+description: Legal billing and time tracking specialist for time capture, invoice generation, trust account compliance, and collections — maximizing revenue recovery across any firm size or billing model.
 color: green
 vibe: Every six minutes of unbilled time is money left on the table. Every unclear billing narrative is a client dispute waiting to happen. Capture it all. Describe it clearly. Collect it professionally.
 ---

--- a/specialized/legal-client-intake.md
+++ b/specialized/legal-client-intake.md
@@ -1,7 +1,7 @@
 ---
 name: Legal Client Intake
 emoji: 📋
-description: Comprehensive legal client intake specialist for qualifying prospects, collecting case information, scheduling consultations, managing conflict checks, and delivering attorney-ready intake summaries across any practice area and firm size
+description: Legal client intake specialist for qualifying prospects, conflict checks, and attorney-ready intake summaries across any practice area and firm size.
 color: blue
 vibe: The first conversation with a potential client sets the tone for the entire attorney-client relationship. Get it right — warm, professional, and thorough — from the very first touch.
 ---

--- a/specialized/legal-document-review.md
+++ b/specialized/legal-document-review.md
@@ -1,7 +1,7 @@
 ---
 name: Legal Document Review
 emoji: ⚖️
-description: Comprehensive legal document review specialist for contracts, litigation documents, and real estate agreements — summarizing documents, flagging risk clauses, comparing contract versions, and checking compliance across any law firm size or practice area
+description: Legal document review specialist for contracts, litigation documents, and real estate agreements — summarizing documents, flagging risk clauses, and checking compliance.
 color: blue
 vibe: Every word in a legal document matters. Every missed clause is a liability. Every risk caught early is a client protected.
 ---

--- a/specialized/loan-officer-assistant.md
+++ b/specialized/loan-officer-assistant.md
@@ -1,7 +1,7 @@
 ---
 name: Loan Officer Assistant
 emoji: 🏦
-description: Comprehensive loan officer assistant for mortgage and lending professionals — covering borrower intake, pre-qualification, document collection, pipeline management, compliance tracking, rate quoting, and closing coordination across residential, commercial, and consumer lending
+description: Loan officer assistant for mortgage and lending professionals — borrower intake, pre-qualification, pipeline management, and closing coordination across residential and commercial lending.
 color: blue
 vibe: Every loan is someone's dream — a home, a business, a fresh start. Move it through the pipeline with precision, compliance, and genuine care for the person behind the application.
 ---

--- a/specialized/ma-integration-manager.md
+++ b/specialized/ma-integration-manager.md
@@ -1,7 +1,7 @@
 ---
 name: M&A Integration Manager
 emoji: 🤝
-description: Mergers and acquisitions integration specialist who designs and executes post-merger integration programs — covering Day 1 readiness, 100-day planning, synergy tracking, cultural integration, functional workstream coordination, and transition service agreement management.
+description: M&A integration specialist who designs post-merger integration programs — Day 1 readiness, 100-day planning, synergy tracking, and cultural integration.
 color: indigo
 vibe: Treats the signed deal as the starting line, not the finish — runs post-merger integration like a program with a clock on it, because synergy value erodes every day Day 1 readiness slips and culture is left to chance.
 ---

--- a/specialized/medical-billing-coding-specialist.md
+++ b/specialized/medical-billing-coding-specialist.md
@@ -1,7 +1,7 @@
 ---
 name: Medical Billing & Coding Specialist
 emoji: 🏥
-description: Expert medical billing and coding specialist for ICD-10-CM/PCS, CPT, and HCPCS coding, claim submission, denial management, revenue cycle optimization, compliance auditing, and payer contract analysis — maximizing clean claim rates and revenue recovery for healthcare providers of all sizes
+description: Medical billing and coding specialist for ICD-10-CM/PCS, CPT, and HCPCS coding, claim submission, and denial management — maximizing clean claim rates for providers of any size.
 color: blue
 vibe: Every unsubmitted claim is lost revenue. Every unchallenged denial is money left on the table. Every compliance gap is a liability waiting to surface. The revenue cycle never stops — and neither do we.
 ---

--- a/specialized/operations-manager.md
+++ b/specialized/operations-manager.md
@@ -1,7 +1,7 @@
 ---
 name: Operations Manager
 emoji: ⚙️
-description: Business operations specialist who applies Lean, Six Sigma, and systems thinking to process mapping, capacity planning, KPI governance, vendor management, and organizational efficiency — turning operational complexity into repeatable, measurable performance.
+description: Business operations specialist applying Lean, Six Sigma, and systems thinking to process mapping, capacity planning, and KPI governance.
 color: slate
 vibe: Sees every business as a system of processes and treats waste, variation, and undocumented dependencies as defects to be measured and removed — because what isn't standardized and measured can't be scaled reliably.
 ---

--- a/specialized/organizational-psychologist.md
+++ b/specialized/organizational-psychologist.md
@@ -1,7 +1,7 @@
 ---
 name: Organizational Psychologist
 emoji: 🧠
-description: Applied organizational psychologist who diagnoses team dynamics, psychological safety, burnout risk, and culture health — using evidence-based frameworks to help leaders build high-performing, resilient, and psychologically safe organizations.
+description: Applied organizational psychologist who diagnoses team dynamics, psychological safety, and burnout risk using evidence-based frameworks.
 color: teal
 vibe: Treats team dysfunction like a clinician reads symptoms — grounds every diagnosis and intervention in peer-reviewed evidence, names the invisible pattern leaders can't see, and never mistakes pop psychology for the real thing.
 ---

--- a/specialized/real-estate-buyer-seller.md
+++ b/specialized/real-estate-buyer-seller.md
@@ -1,7 +1,7 @@
 ---
 name: Real Estate Buyer & Seller
 emoji: 🏠
-description: Comprehensive real estate agent assistant for buyer representation, seller representation, listing management, offer negotiation, transaction coordination, and closing support — delivering a world-class client experience from first showing to final closing across residential and investment real estate
+description: Real estate agent assistant for buyer and seller representation, listing management, offer negotiation, and transaction coordination from first showing to closing.
 color: teal
 vibe: Every transaction is someone's biggest financial decision. Every client deserves an agent who is organized, responsive, and genuinely invested in their outcome — not just the commission check.
 ---

--- a/specialized/recruitment-specialist.md
+++ b/specialized/recruitment-specialist.md
@@ -1,6 +1,6 @@
 ---
 name: Recruitment Specialist
-description: Expert recruitment operations and talent acquisition specialist — skilled in China's major hiring platforms, talent assessment frameworks, and labor law compliance. Helps companies efficiently attract, screen, and retain top talent while building a competitive employer brand.
+description: Recruitment operations and talent acquisition specialist skilled in China's major hiring platforms, assessment frameworks, and labor law compliance.
 color: blue
 emoji: 🎯
 vibe: Builds your full-cycle recruiting engine across China's hiring platforms, from sourcing to onboarding to compliance.

--- a/specialized/retail-customer-returns.md
+++ b/specialized/retail-customer-returns.md
@@ -1,7 +1,7 @@
 ---
 name: Retail Customer Returns
 emoji: 🛒
-description: Comprehensive retail customer returns specialist for processing returns, exchanges, and refunds across in-store, online, and omnichannel retail — handling policy enforcement, fraud prevention, customer retention, vendor returns, and returns analytics to maximize recovery while preserving customer loyalty
+description: Retail returns specialist handling exchanges and refunds across in-store, online, and omnichannel retail — policy enforcement, fraud prevention, and returns analytics.
 color: amber
 vibe: A return is not a failure — it's an opportunity. Handle it with speed, fairness, and genuine care, and you'll turn a disappointed customer into a loyal one.
 ---

--- a/specialized/sales-outreach.md
+++ b/specialized/sales-outreach.md
@@ -1,7 +1,7 @@
 ---
 name: Sales Outreach
 emoji: 🎯
-description: Consultative B2B sales outreach specialist for cold prospecting, lead follow-up, objection handling, proposal writing, and pipeline management — combining data-driven targeting with genuine relationship-building to open doors and close deals
+description: Consultative B2B sales outreach specialist for cold prospecting, objection handling, and pipeline management — combining data-driven targeting with relationship-building.
 color: amber
 vibe: The best salespeople don't sell — they help people buy. Every outreach is a conversation starter, not a pitch.
 ---

--- a/specialized/specialized-civil-engineer.md
+++ b/specialized/specialized-civil-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: Civil Engineer
-description: Expert civil and structural engineer with global standards coverage — Eurocode, DIN, ACI, AISC, ASCE, AS/NZS, CSA, GB, IS, AIJ, and more. Specializes in structural analysis, geotechnical design, construction documentation, building code compliance, and multi-standard international projects.
+description: Expert civil and structural engineer with global standards coverage (Eurocode, ACI, AISC, GB) — structural analysis, geotechnical design, and code compliance for multi-standard projects.
 color: yellow
 emoji: 🏗️
 vibe: Designs structures that stand across borders — from seismic Tokyo to wind-swept Dubai, always code-compliant and constructible.

--- a/specialized/specialized-developer-advocate.md
+++ b/specialized/specialized-developer-advocate.md
@@ -1,6 +1,6 @@
 ---
 name: Developer Advocate
-description: Expert developer advocate specializing in building developer communities, creating compelling technical content, optimizing developer experience (DX), and driving platform adoption through authentic engineering engagement. Bridges product and engineering teams with external developers.
+description: Developer advocate specializing in developer communities, technical content, and DX optimization — bridging product/engineering teams with external developers.
 color: purple
 emoji: 🗣️
 vibe: Bridges your product team and the developer community through authentic engagement.

--- a/specialized/specialized-fedramp-rmf-compliance.md
+++ b/specialized/specialized-fedramp-rmf-compliance.md
@@ -1,7 +1,7 @@
 ---
 name: FedRAMP & RMF Compliance Engineer
 emoji: 🛡️
-description: Expert FedRAMP and NIST Risk Management Framework compliance engineer specializing in both FedRAMP authorization pathways — the traditional Rev5 path (NIST 800-53 Rev 5 control implementation, System Security Plans, 3PAO assessment, agency authorization) and the modernized FedRAMP 20x path (Key Security Indicators, automated machine-readable validation, compliance-as-code) — plus the ATO process, continuous monitoring (ConMon), POA&M management, FIPS 199 categorization, authorization boundary diagrams, OSCAL machine-readable packages, and cloud security compliance for government and regulated industries
+description: Expert FedRAMP and NIST Risk Management Framework compliance engineer covering both the traditional Rev5 authorization path and the modernized FedRAMP 20x path, including ATO, ConMon, and OSCAL packages.
 color: red
 vibe: A disciplined compliance engineer who guides systems through both FedRAMP authorization pathways — traditional Rev5 and the modernized, KSI-driven 20x — and the full NIST RMF lifecycle, turning abstract control requirements into concrete, auditable, ATO-ready evidence whether that evidence is a narrative implementation statement or a machine-validated Key Security Indicator, categorizing honestly, drawing the authorization boundary before writing a word of the SSP, treating every control as something that must be both implemented and provable, and refusing to paper over a gap with prose when a 3PAO — or an automated validation — is going to test the actual system, because in federal compliance an unproven control is an open finding waiting to happen.
 ---

--- a/specialized/specialized-model-qa.md
+++ b/specialized/specialized-model-qa.md
@@ -1,6 +1,6 @@
 ---
 name: Model QA Specialist
-description: Independent model QA expert who audits ML and statistical models end-to-end - from documentation review and data reconstruction to replication, calibration testing, interpretability analysis, performance monitoring, and audit-grade reporting.
+description: Independent model QA expert who audits ML and statistical models end-to-end — documentation review, replication, calibration testing, and audit-grade reporting.
 color: "#B22222"
 emoji: 🔬
 vibe: Audits ML models end-to-end — from data reconstruction to calibration testing.

--- a/specialized/specialized-pricing-analyst.md
+++ b/specialized/specialized-pricing-analyst.md
@@ -1,6 +1,6 @@
 ---
 name: Pricing Analyst
-description: Specialized pricing analyst who develops optimal pricing models through market research, competitor analysis, cost structure evaluation, and margin optimization — turning pricing from guesswork into a data-driven competitive advantage.
+description: Pricing analyst who develops optimal pricing models through market research and margin optimization — turning pricing into a data-driven competitive advantage.
 color: gold
 emoji: 💰
 vibe: Finds the price point where value captured meets value delivered — then proves it with data.

--- a/specialized/specialized-workflow-architect.md
+++ b/specialized/specialized-workflow-architect.md
@@ -1,6 +1,6 @@
 ---
 name: Workflow Architect
-description: Workflow design specialist who maps complete workflow trees for every system, user journey, and agent interaction — covering happy paths, all branch conditions, failure modes, recovery paths, handoff contracts, and observable states to produce build-ready specs that agents can implement against and QA can test against.
+description: Workflow design specialist who maps complete workflow trees — happy paths, branch conditions, failure modes, and handoff contracts — into build-ready specs for agents to implement and QA to test.
 color: orange
 emoji: "🗺️"
 vibe: Every path the system can take — mapped, named, and specified before a single line is written.

--- a/specialized/study-abroad-advisor.md
+++ b/specialized/study-abroad-advisor.md
@@ -1,6 +1,6 @@
 ---
 name: Study Abroad Advisor
-description: Full-spectrum study abroad planning expert covering the US, UK, Canada, Australia, Europe, Hong Kong, and Singapore — proficient in undergraduate, master's, and PhD application strategy, school selection, essay coaching, profile enhancement, standardized test planning, visa preparation, and overseas life adaptation, helping Chinese students craft personalized end-to-end study abroad plans.
+description: Full-spectrum study abroad planning expert for the US, UK, Canada, Australia, Europe, Hong Kong, and Singapore, guiding Chinese students through school selection, essay coaching, and visa prep.
 color: "#1B4D3E"
 emoji: 🎓
 vibe: Guides Chinese students through the entire study abroad journey — from school selection and essays to visas — with data-driven advice and zero anxiety selling.

--- a/specialized/supply-chain-strategist.md
+++ b/specialized/supply-chain-strategist.md
@@ -1,6 +1,6 @@
 ---
 name: Supply Chain Strategist
-description: Expert supply chain management and procurement strategy specialist — skilled in supplier development, strategic sourcing, quality control, and supply chain digitalization. Grounded in China's manufacturing ecosystem, helps companies build efficient, resilient, and sustainable supply chains.
+description: Supply chain management and procurement strategy specialist grounded in China's manufacturing ecosystem — supplier development, strategic sourcing, and quality control.
 color: blue
 emoji: 🔗
 vibe: Builds your procurement engine and supply chain resilience across China's manufacturing ecosystem, from supplier sourcing to risk management.

--- a/specialized/zk-steward.md
+++ b/specialized/zk-steward.md
@@ -1,6 +1,6 @@
 ---
 name: ZK Steward
-description: "Knowledge-base steward in the spirit of Niklas Luhmann's Zettelkasten. Default perspective: Luhmann; switches to domain experts (Feynman, Munger, Ogilvy, etc.) by task. Enforces atomic notes, connectivity, and validation loops. Use for knowledge-base building, note linking, complex task breakdown, and cross-domain decision support."
+description: "Knowledge-base steward in the spirit of Niklas Luhmann's Zettelkasten, enforcing atomic notes and connectivity — switches to domain-expert perspectives (Feynman, Munger, Ogilvy) by task."
 color: teal
 emoji: 🗃️
 vibe: Channels Luhmann's Zettelkasten to build connected, validated knowledge bases.

--- a/support/support-analytics-reporter.md
+++ b/support/support-analytics-reporter.md
@@ -1,6 +1,6 @@
 ---
 name: Analytics Reporter
-description: Expert data analyst transforming raw data into actionable business insights. Creates dashboards, performs statistical analysis, tracks KPIs, and provides strategic decision support through data visualization and reporting.
+description: Expert data analyst who turns raw data into actionable insights through dashboards, statistical analysis, and KPI tracking.
 color: teal
 emoji: 📊
 vibe: Transforms raw data into the insights that drive your next decision.

--- a/support/support-executive-summary-generator.md
+++ b/support/support-executive-summary-generator.md
@@ -1,6 +1,6 @@
 ---
 name: Executive Summary Generator
-description: Consultant-grade AI specialist trained to think and communicate like a senior strategy consultant. Transforms complex business inputs into concise, actionable executive summaries using McKinsey SCQA, BCG Pyramid Principle, and Bain frameworks for C-suite decision-makers.
+description: Consultant-grade specialist who turns complex business inputs into concise, C-suite-ready executive summaries using McKinsey SCQA and BCG Pyramid Principle frameworks.
 color: purple
 emoji: 📝
 vibe: Thinks like a McKinsey consultant, writes for the C-suite.

--- a/support/support-finance-tracker.md
+++ b/support/support-finance-tracker.md
@@ -1,6 +1,6 @@
 ---
 name: Finance Tracker
-description: Expert financial analyst and controller specializing in financial planning, budget management, and business performance analysis. Maintains financial health, optimizes cash flow, and provides strategic financial insights for business growth.
+description: Expert financial analyst and controller who manages budgets, cash flow, and financial planning to drive sustainable business growth.
 color: green
 emoji: 💰
 vibe: Keeps the books clean, the cash flowing, and the forecasts honest.

--- a/support/support-infrastructure-maintainer.md
+++ b/support/support-infrastructure-maintainer.md
@@ -1,6 +1,6 @@
 ---
 name: Infrastructure Maintainer
-description: Expert infrastructure specialist focused on system reliability, performance optimization, and technical operations management. Maintains robust, scalable infrastructure supporting business operations with security, performance, and cost efficiency.
+description: Expert infrastructure specialist who maintains reliable, scalable systems — balancing uptime, performance, security, and cost efficiency.
 color: orange
 emoji: 🏢
 vibe: Keeps the lights on, the servers humming, and the alerts quiet.

--- a/support/support-legal-compliance-checker.md
+++ b/support/support-legal-compliance-checker.md
@@ -1,6 +1,6 @@
 ---
 name: Legal Compliance Checker
-description: Expert legal and compliance specialist ensuring business operations, data handling, and content creation comply with relevant laws, regulations, and industry standards across multiple jurisdictions.
+description: Expert legal and compliance specialist who ensures operations, data handling, and content comply with laws and regulations across multiple jurisdictions.
 color: red
 emoji: ⚖️
 vibe: Ensures your operations comply with the law across every jurisdiction that matters.

--- a/support/support-support-responder.md
+++ b/support/support-support-responder.md
@@ -1,6 +1,6 @@
 ---
 name: Support Responder
-description: Expert customer support specialist delivering exceptional customer service, issue resolution, and user experience optimization. Specializes in multi-channel support, proactive customer care, and turning support interactions into positive brand experiences.
+description: Expert customer support specialist who resolves issues across multi-channel support and turns interactions into positive brand experiences.
 color: blue
 emoji: 💬
 vibe: Turns frustrated users into loyal advocates, one interaction at a time.

--- a/testing/testing-accessibility-auditor.md
+++ b/testing/testing-accessibility-auditor.md
@@ -1,6 +1,6 @@
 ---
 name: Accessibility Auditor
-description: Expert accessibility specialist who audits interfaces against WCAG standards, tests with assistive technologies, and ensures inclusive design. Defaults to finding barriers — if it's not tested with a screen reader, it's not accessible.
+description: Expert accessibility specialist who audits interfaces against WCAG standards and tests with assistive technologies — defaults to finding barriers, not clearing them.
 color: "#0077B6"
 emoji: ♿
 vibe: If it's not tested with a screen reader, it's not accessible.


### PR DESCRIPTION
## Summary
- Trims the `description:` frontmatter field on 155 agent files (of 242 total) whose descriptions had ballooned to 200-620 characters into comma/em-dash-separated laundry lists of sub-skills, rather than the one-line specialty summary called for in CONTRIBUTING.md.
- Each rewritten description keeps the core role plus the one thing that distinguishes it from sibling agents, so routing between near-duplicate agents (Drupal vs WordPress performance/shopping-cart pairs, the China social-platform family, security-division specialists, sales/paid-media siblings, etc.) stays unambiguous.
- Only `description:` values changed — no other frontmatter fields (`name`, `color`, `emoji`, `vibe`) or body content were touched.
- Longest description went from 623 chars (FedRAMP & RMF Compliance Engineer) down to 216; most trimmed files landed in the 130-190 char range.

## Test plan
- [x] `./scripts/lint-agents.sh` run repo-wide: 0 errors, 254 files scanned (only pre-existing warnings remain, unrelated to this change)
- [x] `git diff` confirms exactly one line (`description:`) changed per touched file
- [x] Spot-checked several diffs by hand to confirm no drift into body content or other frontmatter fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)