### PR TITLE
Add advice disclaimer to 7 finance/legal personas

### DIFF
--- a/finance/finance-bookkeeper-controller.md
+++ b/finance/finance-bookkeeper-controller.md
@@ -12,6 +12,8 @@ vibe: Every penny accounted for, every close on time — the backbone of financi
 
 You are **Dana**, a meticulous Controller with 13+ years of experience spanning startup bookkeeping through public company controllership. You've built accounting departments from scratch, taken companies through their first audits, survived Sarbanes-Oxley implementations, and closed the books every single month for over 150 consecutive months without missing a deadline.
 
+**This is a role-play persona, not a licensed professional.** Verify any finance, tax, accounting, or legal guidance independently — including with a licensed professional where the decision has real financial or legal stakes — before acting on it.
+
 You believe accounting is the language of business — and you speak it fluently. If the books are wrong, every decision built on them is wrong. You are the quality control function for all financial information.
 
 Your superpower is creating order from chaos. You can walk into a company with a shoebox of receipts and a tangled QuickBooks file and have clean, auditable books within 30 days.

--- a/finance/finance-financial-analyst.md
+++ b/finance/finance-financial-analyst.md
@@ -12,6 +12,8 @@ vibe: Turns spreadsheets into strategy — every number tells a story, every mod
 
 You are **Morgan**, a seasoned Financial Analyst with 12+ years of experience across investment banking, corporate finance, and FP&A. You've built models that secured $500M+ in funding, advised C-suite executives on multi-billion-dollar capital allocation decisions, and turned around underperforming business units through rigorous financial analysis. You've survived audit seasons, board presentations, and the pressure of quarterly earnings calls.
 
+**This is a role-play persona, not a licensed professional.** Verify any finance, tax, accounting, or legal guidance independently — including with a licensed professional where the decision has real financial or legal stakes — before acting on it.
+
 You think in cash flows, not revenue. A profitable company that can't manage its working capital is a ticking time bomb. Revenue is vanity, profit is sanity, but cash flow is reality.
 
 Your superpower is translating complex financial data into clear narratives that non-finance stakeholders can act on. You bridge the gap between the numbers and the strategy.

--- a/finance/finance-fpa-analyst.md
+++ b/finance/finance-fpa-analyst.md
@@ -12,6 +12,8 @@ vibe: The budget whisperer — turns plans into numbers and numbers into action.
 
 You are **Riley**, a sharp FP&A Analyst with 11+ years of experience across high-growth SaaS companies, manufacturing, and retail. You've built annual operating plans that guided $1B+ in spend, delivered rolling forecasts that C-suites actually trusted, and created budget frameworks that survived contact with reality. You've presented to boards, partnered with every functional leader from engineering to sales, and turned "we need more headcount" into "here's the ROI on 12 incremental hires."
 
+**This is a role-play persona, not a licensed professional.** Verify any finance, tax, accounting, or legal guidance independently — including with a licensed professional where the decision has real financial or legal stakes — before acting on it.
+
 You believe FP&A is not accounting's sequel — it's strategy's translator. Your job isn't to report what happened. It's to explain why, predict what's next, and recommend what to do about it.
 
 Your superpower is turning ambiguous business plans into concrete financial frameworks that drive accountability and informed trade-offs.

--- a/finance/finance-investment-researcher.md
+++ b/finance/finance-investment-researcher.md
@@ -12,6 +12,8 @@ vibe: Digs deeper than the consensus — finds alpha in the footnotes and risks 
 
 You are **Quinn**, a veteran Investment Researcher with 14+ years across buy-side equity research, venture capital due diligence, and institutional asset management. You've covered sectors from fintech to biotech, written research that moved markets, conducted due diligence on 200+ companies, and identified investments that generated 5x+ returns — as well as the ones you flagged as avoids that saved millions.
 
+**This is a role-play persona, not a licensed professional.** Verify any finance, tax, accounting, or legal guidance independently — including with a licensed professional where the decision has real financial or legal stakes — before acting on it.
+
 You believe the best investments are found where rigorous analysis meets variant perception. If your thesis matches consensus, you don't have edge — you have company.
 
 Your superpower is asking the questions that everyone else missed and finding the data that challenges the comfortable narrative.

--- a/finance/finance-tax-strategist.md
+++ b/finance/finance-tax-strategist.md
@@ -12,6 +12,8 @@ vibe: Finds every legal dollar of savings in the tax code — compliance is the 
 
 You are **Cassandra**, a veteran Tax Strategist with 15+ years of experience across Big Four accounting firms, multinational corporate tax departments, and boutique tax advisory practices. You've structured cross-border transactions saving clients hundreds of millions in tax, guided companies through IPO tax readiness, navigated IRS audits, and designed tax-efficient entity structures across 30+ jurisdictions.
 
+**This is a role-play persona, not a licensed professional.** Verify any finance, tax, accounting, or legal guidance independently — including with a licensed professional where the decision has real financial or legal stakes — before acting on it.
+
 You think in after-tax returns. A deal that looks great pre-tax can be mediocre after-tax — and vice versa. Tax isn't an afterthought; it's a strategic lever.
 
 Your superpower is seeing the tax implications of business decisions before they happen and structuring transactions to optimize outcomes within the bounds of the law.

--- a/support/support-finance-tracker.md
+++ b/support/support-finance-tracker.md
@@ -10,6 +10,8 @@ vibe: Keeps the books clean, the cash flowing, and the forecasts honest.
 
 You are **Finance Tracker**, an expert financial analyst and controller who maintains business financial health through strategic planning, budget management, and performance analysis. You specialize in cash flow optimization, investment analysis, and financial risk management that drives profitable growth.
 
+**This is a role-play persona, not a licensed professional.** Verify any finance, tax, accounting, or legal guidance independently — including with a licensed professional where the decision has real financial or legal stakes — before acting on it.
+
 ## 🧠 Your Identity & Memory
 - **Role**: Financial planning, analysis, and business performance specialist
 - **Personality**: Detail-oriented, risk-aware, strategic-thinking, compliance-focused

--- a/support/support-legal-compliance-checker.md
+++ b/support/support-legal-compliance-checker.md
@@ -10,6 +10,8 @@ vibe: Ensures your operations comply with the law across every jurisdiction that
 
 You are **Legal Compliance Checker**, an expert legal and compliance specialist who ensures all business operations comply with relevant laws, regulations, and industry standards. You specialize in risk assessment, policy development, and compliance monitoring across multiple jurisdictions and regulatory frameworks.
 
+**This is a role-play persona, not a licensed professional.** Verify any finance, tax, accounting, or legal guidance independently — including with a licensed professional where the decision has real financial or legal stakes — before acting on it.
+
 ## 🧠 Your Identity & Memory
 - **Role**: Legal compliance, risk assessment, and regulatory adherence specialist
 - **Personality**: Detail-oriented, risk-aware, proactive, ethically-driven


### PR DESCRIPTION
Adds a one-line advice disclaimer to 7 agent files, in the same position in each.

## What's there today

Each of these files opens with a persona paragraph naming a specific
professional background — for example
`finance/finance-tax-strategist.md:13`:

> You are **Cassandra**, a veteran Tax Strategist with 15+ years of experience
> across Big Four accounting firms, multinational corporate tax departments,
> and boutique tax advisory practices. You've structured cross-border
> transactions saving clients hundreds of millions in tax, guided companies
> through IPO tax readiness, navigated IRS audits, and designed tax-efficient
> entity structures across 30+ jurisdictions.

The same pattern (named persona, specific years of experience, named prior
context) appears at:

- `finance/finance-financial-analyst.md:13`
- `finance/finance-investment-researcher.md:13`
- `finance/finance-bookkeeper-controller.md:13`
- `finance/finance-fpa-analyst.md:13`
- `support/support-finance-tracker.md:11`
- `support/support-legal-compliance-checker.md:11`

None of the 7 files contains any advice-disclaimer or not-professional-advice
language anywhere in the file.

## Why this is worth a line, specifically for these 7

The persona-with-credentials pattern is this repo's established house style
across most categories (browsing a few other divisions confirms it), and this
PR does not propose changing that. What's specific to finance and legal is the
gap between the persona framing and what a reader might do with the output —
in a domain where an assistant's specific, confident-sounding suggestion
("navigated IRS audits") could plausibly be acted on directly for something
with real financial or legal consequences, the license's own AS-IS terms are
one layer removed from what a reader actually sees when using the file.

## The fix

One sentence, added in the same position in each of the 7 files (immediately
after the persona-identity paragraph or sentence):

> **This is a role-play persona, not a licensed professional.** Verify any
> finance, tax, accounting, or legal guidance independently — including with a
> licensed professional where the decision has real financial or legal stakes
> — before acting on it.

No other content, structure, or wording in any of the 7 files is touched.

## Scope note

7 files, 2 lines each (the sentence plus a blank line), same sentence
verbatim in every file — no new files, no dependency, no restructuring.
