### PR TITLE
Note: sensitive-attribute inference and engagement-design framing

### DIFF
--- a/product/product-behavioral-nudge-engine.md
+++ b/product/product-behavioral-nudge-engine.md
@@ -37,7 +37,13 @@ Concrete examples of what you produce:
 ```typescript
 // Behavioral Engine: Generating a Time-Boxed Sprint Nudge
 export function generateSprintNudge(pendingTasks: Task[], userProfile: UserPsyche) {
-  if (userProfile.tendencies.includes('ADHD') || userProfile.status === 'Overwhelmed') {
+  // userProfile.tendencies may include a self-disclosed accessibility/attention
+  // preference such as 'ADHD'. In EU deployments this is special category data
+  // under GDPR Art. 9, which requires an explicit legal basis (typically
+  // explicit consent) beyond what ordinary personal data needs — set this
+  // field only from an explicit, opt-in disclosure, never inferred from
+  // behavior, and gate its use on that consent rather than on presence alone.
+  if ((userProfile.consent?.sensitiveTagsConsent && userProfile.tendencies.includes('ADHD')) || userProfile.status === 'Overwhelmed') {
     // Break cognitive load. Offer a micro-sprint instead of a summary.
     return {
       channel: userProfile.preferredChannel, // SMS
@@ -76,5 +82,5 @@ You continuously update your knowledge of:
 - **Engagement Health**: Maintain a high open/click rate on your active nudges by ensuring they are consistently valuable and non-intrusive.
 
 ## 🚀 Advanced Capabilities
-- Building variable-reward engagement loops.
-- Designing opt-out architectures that dramatically increase user participation in beneficial platform features without feeling coercive.
+- Building variable-reward engagement loops — worth disclosing this mechanism in any user-facing description of the assistant's behavior, since variable-ratio reinforcement is a well-documented engagement pattern.
+- Designing opt-out architectures where the off-ramp is genuinely easy to find and use — measured by how quickly a user who wants out can get out, not by how rarely they do.


### PR DESCRIPTION
An observation, with a small proposed change attached — happy to drop the
code change and keep only the comment if that's a better fit, or to close
this if the design is intentional as-is.

## What the code does today

`product/product-behavioral-nudge-engine.md:40` branches application behavior
on an inferred personal attribute:

```typescript
if (userProfile.tendencies.includes('ADHD') || userProfile.status === 'Overwhelmed') {
```

`userProfile.tendencies` isn't defined elsewhere in this file, so there's no
visible consent or disclosure flow attached to how that value gets set.

Separately, `product/product-behavioral-nudge-engine.md:79-80` names two
engagement mechanics as explicit design goals:

```markdown
- Building variable-reward engagement loops.
- Designing opt-out architectures that dramatically increase user participation in beneficial platform features without feeling coercive.
```

## Why this seemed worth raising

Under GDPR Art. 9, health status — including inferred mental-health-adjacent
conditions such as ADHD — is special category data, subject to a stricter
legal-basis requirement than ordinary personal data (typically explicit
consent). Separately, variable-ratio reinforcement schedules are a
well-documented pattern in behavioral-design literature for engagement
mechanics that trade user control for measured participation lift — worth
naming as such rather than only as "beneficial."

One more thing that made this feel worth a PR rather than just an issue: this
same repo already draws exactly this line elsewhere.
`support/support-legal-compliance-checker.md:89-95` classifies
`health_information` under `sensitive_data`, with `legal_basis:
"explicit_consent"` and `special_protection: true`:

```yaml
sensitive_data:
  - health_information
  - financial_data
  - biometric_data
  retention_period: "1 year"
  legal_basis: "explicit_consent"
  special_protection: true
```

That's the same repo modeling the same attribute class two different ways in
two different files — not a contradiction either file is "wrong" about on its
own, just an inconsistency between them that a PR touching one of the two
seemed like a reasonable place to flag.

## What this PR proposes

- Gate the `ADHD` check on an explicit consent field rather than presence
  alone, and add a comment naming why (Art. 9).
- Reword the two "Advanced Capabilities" bullets to name the engagement
  mechanism plainly and to define the opt-out bullet's success measure as
  "easy to find and use" rather than "without feeling coercive."

No other content in the file is touched, and the persona/tone of the rest of
the file is unchanged.
