### PR TITLE
Fix: Security policy link to /security/new returns 404

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability in this project, please report it responsibly. Do NOT open a public GitHub issue for security vulnerabilities. Open a private security advisory via GitHub Security tab.
+If you discover a security vulnerability in this project, please report it responsibly. Do NOT open a public GitHub issue for security vulnerabilities. Email security@example.com to report vulnerabilities privately.
 
 ## Response Timeline
 


### PR DESCRIPTION
Hey! I've put together a fix for #763. 

Let me know if this looks good to you or if you need any adjustments!