### PR TITLE
docs(shell): define the bash/powershell fence convention + lint it (#229)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,5 +13,6 @@
 - [ ] Follows the agent template structure from CONTRIBUTING.md
 - [ ] Includes YAML frontmatter with `name`, `description`, `color`
 - [ ] Has concrete code/template examples (for new agents)
+- [ ] Any shell blocks are tagged `bash` or `powershell` (CONTRIBUTING.md → Shell Commands & Platform Support)
 - [ ] Tested in real scenarios
 - [ ] Proofread and formatted correctly

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,6 +220,42 @@ The test: *is this agent for the user, or for the vendor?* An agent that
 solves the user's problem using a service belongs here. A service's
 quickstart guide wearing an agent costume does not.
 
+### Shell Commands & Platform Support
+
+Most agent files contain no shell at all — they're prompts, not installers. When
+you do include commands, follow this convention so Windows readers (and tools
+that re-render agents per host) can tell which shell a block is for:
+
+1. **Tag every shell block with its shell.** The canonical tags are `bash`
+   (POSIX shell — macOS, Linux, WSL, Git Bash) and `powershell` (Windows).
+   Ambiguous or non-canonical tags (`sh`, `shell`, `zsh`, `console`, `terminal`,
+   `shell-session`, `cmd`, `bat`, `batch`, `dos`, `ps`, `ps1`, `pwsh`) are
+   flagged by `scripts/lint-agents.sh`.
+2. **`bash` is the default assumption.** Tag a POSIX block `bash` even when it
+   would also run under `sh` or `zsh` — the tag is the contract, not a guess. If
+   a snippet truly depends on zsh-only syntax, rewrite it in POSIX shell rather
+   than shipping a `zsh` fence.
+3. **Don't mirror every command into PowerShell.** Doubling every block doubles
+   the agent's token cost for no benefit. Most shell in these agents targets the
+   *deployment* environment — Linux servers, containers, CI — where bash is
+   correct no matter what the reader's laptop runs. Add a `powershell` block
+   only when the command runs on the reader's own Windows machine and has no
+   bash equivalent. [Incident Responder](security/security-incident-responder.md)
+   is the model: it ships a PowerShell triage script because Windows forensics
+   *is* the subject.
+4. **Prefer portable prose when the step matters more than the syntax:** "copy
+   the agent into your Claude Code agents directory" beats
+   `cp engineering/*.md ~/.claude/agents/`.
+
+The repo's own shell scripts (`scripts/*.sh`) are Bash 3.2-compatible and run on
+macOS, Linux, WSL, and Git Bash. There is no PowerShell port of `convert.sh` or
+`install.sh` — Windows users run them from Git Bash or WSL, or use the
+[desktop app](https://agencyagents.app). The one Windows-native helper is
+`scripts/i18n/localize-agents-zh.ps1`. Keep new shell scripts Bash 3.2-compatible:
+no `jq`, no GNU-only flags, no Bash 4+ features. `python3` is already required by
+`check-agent-originality.sh`, `check-runbooks.sh`, and the Hermes build, so using
+it for JSON work is fine — reaching for `jq` is not.
+
 ### Tool-Specific Compatibility
 
 **Qwen Code Compatibility**: Agent bodies support `${variable}` templating for dynamic context (e.g., `${project_name}`, `${task_description}`). Qwen SubAgents use minimal frontmatter: only `name` and `description` are required; `color`, `emoji`, and `version` fields are omitted as Qwen doesn't use them.
@@ -338,6 +374,7 @@ We love ambitious ideas — a [Discussion](https://github.com/msitarzewski/agenc
 - [ ] Has concrete code/template examples
 - [ ] Defines success metrics
 - [ ] Includes step-by-step workflow
+- [ ] Any shell blocks are tagged `bash` or `powershell` (see Shell Commands & Platform Support)
 - [ ] Proofread and formatted correctly
 - [ ] Tested in real scenarios
 ```
@@ -362,6 +399,8 @@ We love ambitious ideas — a [Discussion](https://github.com/msitarzewski/agenc
 - Use **bold** for emphasis, `code` for technical terms
 
 ### Code Examples
+
+Shell blocks have an extra rule — see [Shell Commands & Platform Support](#shell-commands--platform-support).
 
 ```markdown
 ## Example Code Block

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ brew install --cask msitarzewski/agency-agents/agency-agents
 
 Prefer the command line? The script-based options below install the same agents.
 
+> **On Windows:** the install and convert scripts under `scripts/` are Bash (POSIX shell) — run them from **Git Bash** or **WSL**, or use the app above, which is native on Windows. (One exception: `scripts/i18n/localize-agents-zh.ps1` is PowerShell and runs natively — see `scripts/i18n/README.md`.) The same convention holds inside agent files: a `bash` code fence is POSIX shell, a `powershell` fence is Windows.
+
 ### Option 2: Use with Claude Code
 
 ```bash

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -54,9 +54,12 @@
 #      OSAURUS_SKILLS_DIR, HERMES_HOME, HERMES_PLUGIN_DIR, VIBE_HOME
 #      override default install paths (checked before hardcoded defaults).
 #
-# --- USAGE-END ---  (sentinel for usage(); do not remove)
 # Platform support:
-#   Linux, macOS (requires bash 3.2+), Windows Git Bash / WSL
+#   Linux, macOS (requires bash 3.2+), Windows Git Bash / WSL.
+#   There is no PowerShell port — on Windows run this from Git Bash or WSL,
+#   or use the desktop app: https://agencyagents.app
+#
+# --- USAGE-END ---  (sentinel for usage(); do not remove)
 
 set -euo pipefail
 

--- a/scripts/lint-agents.sh
+++ b/scripts/lint-agents.sh
@@ -4,6 +4,7 @@
 #   1. YAML frontmatter must exist with name, description, color (ERROR)
 #   2. Recommended sections checked but only warned (WARN)
 #   3. File must have meaningful content
+#   4. Shell code fences must name a canonical shell — bash or powershell (WARN)
 #
 # Usage: ./scripts/lint-agents.sh [file ...]
 #   If no files given, scans all agent directories.
@@ -119,6 +120,19 @@ lint_file() {
     echo "WARN  $file: body seems very short (< 50 words)"
     warnings=$((warnings + 1))
   fi
+
+  # 5. Shell code fences must name a canonical shell. A fence tag only ever
+  #    appears on an OPENING fence (closers are a bare ```), so a plain grep is
+  #    enough here — no fence-state tracking. Canonical tags are `bash` (POSIX
+  #    shell: macOS/Linux/WSL/Git Bash) and `powershell` (Windows); ambiguous
+  #    aliases hide which shell a block is for. See CONTRIBUTING.md.
+  local bad_fence
+  while IFS= read -r bad_fence; do
+    [[ -n "$bad_fence" ]] || continue
+    echo "WARN  $file: ambiguous shell fence '\`\`\`${bad_fence}' — use \`\`\`bash (POSIX shell) or \`\`\`powershell (Windows); see CONTRIBUTING.md"
+    warnings=$((warnings + 1))
+  done < <(grep -oiE '^```(sh|shell|zsh|console|terminal|shell-session|cmd|bat|batch|dos|ps|ps1|pwsh)[[:space:]]*$' <<<"$body" \
+             | sed -e 's/^```//' -e 's/[[:space:]]*$//' | tr '[:upper:]' '[:lower:]' | sort -u)
 
   local soul_headers=0
   local agents_headers=0


### PR DESCRIPTION
Closes #229.

## Why

#229 asks for PowerShell equivalents of the shell commands in agent files. Two things are true at once:

- **The literal claim doesn't hold.** Shell is rare in these files, and `security/security-incident-responder.md` already ships a `powershell` block. Across all 270 agent files there are 51 ```bash fences, 1 ```powershell fence, and zero ambiguous ones.
- **The gap it points at is real.** Nothing in the repo says which shell a fenced block is for, or when a Windows variant is worth its tokens. `CONTRIBUTING.md` asks for "proper syntax highlighting" but never names a shell.

So instead of duplicating 51 bash blocks into PowerShell — which doubles every agent's token cost for no benefit, since most of that shell targets Linux servers/containers/CI rather than the reader's laptop — this documents the convention and makes it checkable.

## What

- **`CONTRIBUTING.md`** — new **Shell Commands & Platform Support** section: `bash` = POSIX shell (macOS/Linux/WSL/Git Bash), `powershell` = Windows, don't mirror every block, prefer portable prose when the step matters more than the syntax. Cross-referenced from **Code Examples**.
- **`scripts/lint-agents.sh`** — WARN on ambiguous fence tags (`sh`, `shell`, `zsh`, `console`, `terminal`, `shell-session`, `cmd`, `bat`, `batch`, `dos`, `ps`, `ps1`, `pwsh`).
- **`README.md` + `install.sh --help`** — state that `scripts/` is Bash and Windows users need Git Bash/WSL or the app, noting the one PowerShell helper (`scripts/i18n/localize-agents-zh.ps1`).
- **Both PR checklists** — tag your shell blocks.

**No agent `.md` file is touched.**

## Verification

- Full-corpus lint output is **byte-identical** to before this PR: `Results: 0 error(s), 58 warning(s) in 270 files.` — the new rule has zero current hits, so CI cannot regress on existing agents.
- Positive test on a fixture with ```` ```sh ````, ```` ```console ````, ```` ```CMD ````, ```` ```bash ````, ```` ```powershell ```` → exactly 3 warnings, silent on the two canonical tags.
- `bash -n` clean on both modified scripts under macOS `/bin/bash` 3.2.57; `check-divisions.sh`, `check-tools.sh`, `check-runbooks.sh` and `check-hermes-plugin.py` all PASS.
- The new check uses a herestring rather than a pipe into `grep`, matching the existing comment at `lint-agents.sh:104-107` about SIGPIPE under `set -o pipefail`.

## Note on the issue thread

The second comment on #229 proposes an "AISP V1.0.0" command-export contract. That's third-party content in the thread, not a maintainer decision, and it lands squarely in CONTRIBUTING's "new tooling/build systems → start a Discussion first" bucket, so this PR deliberately does not implement it.