### PR TITLE
fix(installer): deduplicate repeated tool selections

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1222,7 +1222,15 @@ main() {
       local valid=false _vt
       for _vt in "${ALL_TOOLS[@]}"; do [[ "$_vt" == "$_t" ]] && valid=true && break; done
       $valid || { err "Unknown tool '$_t'. Valid: ${ALL_TOOLS[*]}"; exit 1; }
-      _cleaned+=("$_t")
+      # A repeated --tool value would otherwise launch duplicate workers in
+      # --parallel mode and make the reported install count misleading.
+      local duplicate=false _selected
+      if [[ ${#_cleaned[@]} -gt 0 ]]; then
+        for _selected in "${_cleaned[@]}"; do
+          [[ "$_selected" == "$_t" ]] && { duplicate=true; break; }
+        done
+      fi
+      $duplicate || _cleaned+=("$_t")
     done
     _tool_list=("${_cleaned[@]}")
   fi


### PR DESCRIPTION
## Summary

When `--tool` receives a comma-separated list, repeated values were retained. In parallel mode that started duplicate workers for the same tool and reported duplicate work.

This change validates each requested tool as before, then keeps the first occurrence while preserving the user's order.

## Verification

- `bash -n scripts/install.sh`
- `scripts/check-divisions.sh`
- `scripts/check-tools.sh`
- `scripts/check-runbooks.sh`
- `scripts/lint-agents.sh` (0 errors, existing warnings only)
- Parallel dry-run/install with `--tool claude-code,claude-code --jobs 2` installed 270 agents once and reported one tool.
- `git diff --check`