### PR TITLE
fix(convert): quote generated YAML frontmatter

### DIFF
--- a/.github/workflows/check-tools.yml
+++ b/.github/workflows/check-tools.yml
@@ -21,3 +21,6 @@ jobs:
 
       - name: Validate generated Hermes plugin
         run: python3 scripts/check-hermes-plugin.py
+
+      - name: Validate converted YAML frontmatter
+        run: bash scripts/test-convert-frontmatter.sh

--- a/scripts/convert.sh
+++ b/scripts/convert.sh
@@ -106,6 +106,13 @@ toml_escape_string() {
   '
 }
 
+# Quote a single-line value for a YAML frontmatter scalar. Single-quoted YAML
+# strings keep colons, hashes, backslashes, and Unicode literal, while doubling
+# an apostrophe is the only escaping rule required here.
+yaml_quote() {
+  printf "'%s'" "$(printf '%s' "$1" | sed "s/'/''/g")"
+}
+
 # --- Per-tool converters ---
 
 convert_antigravity() {
@@ -127,8 +134,8 @@ convert_antigravity() {
   # valid Agent-Skills skill for any host (and deterministic — no date stamp).
   cat > "$outfile" <<HEREDOC
 ---
-name: ${slug}
-description: ${description}
+name: $(yaml_quote "$slug")
+description: $(yaml_quote "$description")
 ---
 ${body}
 HEREDOC
@@ -154,8 +161,8 @@ convert_osaurus() {
   # Kept to the standard fields so it stays compatible with any Agent-Skills host.
   cat > "$outfile" <<HEREDOC
 ---
-name: ${slug}
-description: ${description}
+name: $(yaml_quote "$slug")
+description: $(yaml_quote "$description")
 ---
 ${body}
 HEREDOC
@@ -199,8 +206,8 @@ convert_gemini_cli() {
 
   cat > "$outfile" <<HEREDOC
 ---
-name: ${slug}
-description: ${description}
+name: $(yaml_quote "$slug")
+description: $(yaml_quote "$description")
 ---
 ${body}
 HEREDOC
@@ -267,8 +274,8 @@ convert_opencode() {
   # Named colors are resolved to hex via resolve_opencode_color().
   cat > "$outfile" <<HEREDOC
 ---
-name: ${name}
-description: ${description}
+name: $(yaml_quote "$name")
+description: $(yaml_quote "$description")
 mode: subagent
 color: '${color}'
 ---
@@ -291,7 +298,7 @@ convert_cursor() {
   # Cursor .mdc format: description + globs + alwaysApply frontmatter
   cat > "$outfile" <<HEREDOC
 ---
-description: ${description}
+description: $(yaml_quote "$description")
 globs: ""
 alwaysApply: false
 ---
@@ -409,17 +416,17 @@ convert_qwen() {
   if [[ -n "$tools" ]]; then
     cat > "$outfile" <<HEREDOC
 ---
-name: ${slug}
-description: ${description}
-tools: ${tools}
+name: $(yaml_quote "$slug")
+description: $(yaml_quote "$description")
+tools: $(yaml_quote "$tools")
 ---
 ${body}
 HEREDOC
   else
     cat > "$outfile" <<HEREDOC
 ---
-name: ${slug}
-description: ${description}
+name: $(yaml_quote "$slug")
+description: $(yaml_quote "$description")
 ---
 ${body}
 HEREDOC
@@ -446,17 +453,17 @@ convert_zcode() {
   if [[ -n "$tools" ]]; then
     cat > "$outfile" <<HEREDOC
 ---
-name: ${slug}
-description: ${description}
-tools: ${tools}
+name: $(yaml_quote "$slug")
+description: $(yaml_quote "$description")
+tools: $(yaml_quote "$tools")
 ---
 ${body}
 HEREDOC
   else
     cat > "$outfile" <<HEREDOC
 ---
-name: ${slug}
-description: ${description}
+name: $(yaml_quote "$slug")
+description: $(yaml_quote "$description")
 ---
 ${body}
 HEREDOC

--- a/scripts/test-convert-frontmatter.sh
+++ b/scripts/test-convert-frontmatter.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Regression coverage for YAML frontmatter emitted by convert.sh.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+OUTPUT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/agency-convert-frontmatter.XXXXXX")"
+trap 'rm -rf "$OUTPUT_DIR"' EXIT
+
+for tool in gemini-cli opencode qwen; do
+  "$SCRIPT_DIR/convert.sh" --tool "$tool" --out "$OUTPUT_DIR" >/dev/null
+done
+
+assert_quoted() {
+  local file="$1" field="$2" line prefix
+  line="$(awk -v key="$field" '$0 ~ "^" key ":" { print; exit }' "$file")"
+  prefix="$field: '"
+  [[ "$line" == "$prefix"*"'" ]] || {
+    printf 'Expected %s in %s to be a single-quoted YAML scalar, got: %s\n' \
+      "$field" "$file" "$line" >&2
+    return 1
+  }
+}
+
+assert_quoted \
+  "$OUTPUT_DIR/gemini-cli/agents/developer-tooling-engineer.md" \
+  description
+assert_quoted \
+  "$OUTPUT_DIR/opencode/agents/developer-tooling-engineer.md" \
+  name
+assert_quoted \
+  "$OUTPUT_DIR/opencode/agents/developer-tooling-engineer.md" \
+  description
+assert_quoted \
+  "$OUTPUT_DIR/qwen/agents/programmatic-display-buyer.md" \
+  tools
+
+echo "PASS: converted YAML frontmatter keeps scalar values safely quoted"


### PR DESCRIPTION
## Summary

Descriptions are emitted as plain YAML scalars by the Gemini CLI, OpenCode, Cursor, Antigravity, Qwen, and ZCode converters. A description containing `: `, such as the existing Developer Tooling Engineer description, makes the generated frontmatter invalid.

This change uses a small single-quote helper for generated scalar fields and doubles apostrophes safely. It covers names, descriptions, and optional tool lists without changing the source agent files.

## Verification

- `bash -n scripts/convert.sh scripts/test-convert-frontmatter.sh`
- `scripts/test-convert-frontmatter.sh`
- macOS Ruby YAML parsing of generated Gemini CLI and OpenCode frontmatter
- repository division, tool, runbook, agent-lint, diff, secret, burst, title, and preflight checks