### PR TITLE
docs: add Traditional Chinese localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1058,6 +1058,7 @@ Community-maintained translations and regional adaptations. These are independen
 |----------|-----------|------|-------|
 | 🇨🇳 简体中文 (zh-CN) | [@jnMetaCode](https://github.com/jnMetaCode) | [agency-agents-zh](https://github.com/jnMetaCode/agency-agents-zh) | 141 translated agents + 46 China-market originals |
 | 🇨🇳 简体中文 (zh-CN) | [@dsclca12](https://github.com/dsclca12) | [agent-teams](https://github.com/dsclca12/agent-teams) | Independent translation with Bilibili, WeChat, Xiaohongshu localization |
+| 🇹🇼 繁體中文 (zh-Hant) | [@kaihuang1425](https://github.com/kaihuang1425) | [agency-agents-zh-hant](https://github.com/kaihuang1425/agency-agents-zh-hant) | 20 agents: 14 upstream adaptations + 6 original agents for Taiwan/Traditional Chinese use cases |
 | 🇧🇷 Português brasileiro (pt-BR) | [@jnMetaCode](https://github.com/jnMetaCode) | [agency-agents-pt-BR](https://github.com/jnMetaCode/agency-agents-pt-BR) | 184 upstream agents translated; Brazil-market PRs welcome |
 | 🇷🇺 Русский (ru) | [@jnMetaCode](https://github.com/jnMetaCode) | [agency-agents-ru](https://github.com/jnMetaCode/agency-agents-ru) | 184 upstream agents translated; Russia-market PRs welcome |
 | 🇮🇩 Bahasa Indonesia (id) | [@jnMetaCode](https://github.com/jnMetaCode) | [agency-agents-id](https://github.com/jnMetaCode/agency-agents-id) | 184 upstream agents translated; Indonesia-market PRs welcome |


### PR DESCRIPTION
## Summary

- Add the Traditional Chinese (zh-Hant) community localization to the Community Translations & Localizations table.
- Link the `agency-agents-zh-hant` repository maintained by @kaihuang1425.
- Document the 20 available agents: 14 upstream adaptations and 6 original agents.

Closes #781