### PR TITLE
fix(ci): least-privilege permissions + tools.json schema validation

### DIFF
--- a/.github/workflows/check-divisions.yml
+++ b/.github/workflows/check-divisions.yml
@@ -11,6 +11,8 @@ jobs:
   check-divisions:
     name: divisions.json is the single source of truth
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/check-runbooks.yml
+++ b/.github/workflows/check-runbooks.yml
@@ -12,6 +12,8 @@ jobs:
   check-runbooks:
     name: runbook rosters reference real agent slugs
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/check-tools.yml
+++ b/.github/workflows/check-tools.yml
@@ -11,6 +11,8 @@ jobs:
   check-tools:
     name: tools.json is the single source of truth
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -18,6 +20,9 @@ jobs:
         run: |
           chmod +x scripts/check-tools.sh
           ./scripts/check-tools.sh
+
+      - name: Validate tools.json schema
+        run: python3 scripts/check-tools-schema.py
 
       - name: Validate generated Hermes plugin
         run: python3 scripts/check-hermes-plugin.py

--- a/.github/workflows/lint-agents.yml
+++ b/.github/workflows/lint-agents.yml
@@ -25,6 +25,8 @@ jobs:
   lint:
     name: Validate agent frontmatter and structure
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:

--- a/schema/tools.schema.json
+++ b/schema/tools.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://agency-agents.dev/schema/tools.schema.json",
+  "title": "Agency Agents Tool Catalog",
+  "description": "Schema for tools.json — the single source of truth for the supported tool set. Each entry carries the install contract plus app presentation.",
+  "type": "object",
+  "required": ["tools"],
+  "properties": {
+    "_note": { "type": "string" },
+    "tools": {
+      "type": "object",
+      "description": "Keyed by CLI tool name (kebab).",
+      "minProperties": 1,
+      "additionalProperties": { "$ref": "#/definitions/toolEntry" }
+    }
+  },
+  "definitions": {
+    "toolEntry": {
+      "type": "object",
+      "required": ["id", "label", "kebab", "format", "installKind", "dest"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "label": { "type": "string", "minLength": 1 },
+        "short": { "type": "string" },
+        "kebab": { "type": "string", "pattern": "^[a-z0-9-]+$" },
+        "accent": { "type": "string", "pattern": "^#[0-9A-Fa-f]{6}$" },
+        "icon": { "type": ["string", "null"] },
+        "order": { "type": "integer" },
+        "scope": {
+          "type": "object",
+          "required": ["user", "project"],
+          "properties": {
+            "user": { "type": "boolean" },
+            "project": { "type": "boolean" }
+          }
+        },
+        "detect": {
+          "type": "object",
+          "properties": {
+            "dirs": { "type": "array", "items": { "type": "string" } },
+            "agentsDir": { "type": ["string", "null"] }
+          }
+        },
+        "version": {
+          "type": "object",
+          "properties": {
+            "bin": { "type": "string" },
+            "args": { "type": "array", "items": { "type": "string" } }
+          }
+        },
+        "format": { "type": "string", "minLength": 1 },
+        "installKind": {
+          "type": "string",
+          "enum": ["per-agent", "roster", "plugin"]
+        },
+        "slugFrom": { "type": ["string", "null"] },
+        "slugPrefix": { "type": "string" },
+        "dest": {
+          "type": "object",
+          "required": ["user", "project"],
+          "properties": {
+            "user": { "type": "array", "items": { "type": "string" } },
+            "project": { "type": "array", "items": { "type": "string" } }
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/build-hermes-plugin.py
+++ b/scripts/build-hermes-plugin.py
@@ -122,10 +122,29 @@ _AGENTS: list[dict[str, Any]] | None = None
 _WORD_RE = re.compile(r"[a-z0-9][a-z0-9+.#_-]*", re.I)
 
 
+def _validate_agents(agents: list[dict[str, Any]]) -> None:
+    if not isinstance(agents, list):
+        raise RuntimeError(f"agents.json is not a list (got {type(agents).__name__})")
+    required = ("slug", "name", "description", "division")
+    for i, agent in enumerate(agents):
+        if not isinstance(agent, dict):
+            raise RuntimeError(f"agents.json[{i}] is not an object")
+        for field in required:
+            if field not in agent:
+                raise RuntimeError(f"agents.json[{i}] missing required field '{field}'")
+        slug = agent["slug"]
+        if not isinstance(slug, str) or not slug:
+            raise RuntimeError(f"agents.json[{i}] has invalid slug {slug!r}")
+        if not isinstance(agent["name"], str) or not agent["name"]:
+            raise RuntimeError(f"agents.json[{i}] ({slug}) has invalid name")
+
+
 def _load_agents() -> list[dict[str, Any]]:
     global _AGENTS
     if _AGENTS is None:
-        _AGENTS = json.loads(_DATA_PATH.read_text(encoding="utf-8"))
+        data = json.loads(_DATA_PATH.read_text(encoding="utf-8"))
+        _validate_agents(data)
+        _AGENTS = data
     return _AGENTS
 
 

--- a/scripts/check-tools-schema.py
+++ b/scripts/check-tools-schema.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Validate tools.json against schema/tools.schema.json.
+
+Pure-stdlib JSON Schema validator for the subset the tool catalog uses
+(type, required, properties, additionalProperties, enum, pattern, minLength,
+minProperties, items, one-level $ref). No external deps — matches the repo's
+"no deps beyond coreutils" stance, and runs identically on CI and local.
+
+Usage: python3 scripts/check-tools-schema.py
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CATALOG = REPO_ROOT / "tools.json"
+SCHEMA = REPO_ROOT / "schema" / "tools.schema.json"
+
+
+class SchemaError(Exception):
+    pass
+
+
+def _resolve(node: Any, root: dict[str, Any]) -> dict[str, Any]:
+    """Resolve a one-level $ref (only refs into #/definitions are used)."""
+    if isinstance(node, dict) and "$ref" in node:
+        ref = node["$ref"]
+        if not ref.startswith("#/definitions/"):
+            raise SchemaError(f"unsupported $ref: {ref}")
+        name = ref[len("#/definitions/"):]
+        target = root.get("definitions", {}).get(name)
+        if target is None:
+            raise SchemaError(f"unknown $ref target: {name}")
+        return target
+    return node
+
+
+def _validate_type(value: Any, expected: str | list[str]) -> bool:
+    types = [expected] if isinstance(expected, str) else expected
+    for t in types:
+        if t == "string" and isinstance(value, str):
+            return True
+        if t == "integer" and isinstance(value, int) and not isinstance(value, bool):
+            return True
+        if t == "number" and isinstance(value, (int, float)) and not isinstance(value, bool):
+            return True
+        if t == "boolean" and isinstance(value, bool):
+            return True
+        if t == "object" and isinstance(value, dict):
+            return True
+        if t == "array" and isinstance(value, list):
+            return True
+        if t == "null" and value is None:
+            return True
+    return False
+
+
+def validate(value: Any, node: Any, root: dict[str, Any], path: str, errors: list[str]) -> None:
+    node = _resolve(node, root)
+
+    if "type" in node and not _validate_type(value, node["type"]):
+        errors.append(f"{path}: expected type {node['type']}, got {type(value).__name__}")
+        return
+
+    if isinstance(value, dict):
+        for field in node.get("required", []):
+            if field not in value:
+                errors.append(f"{path}: missing required field '{field}'")
+        if "minProperties" in node and len(value) < node["minProperties"]:
+            errors.append(f"{path}: expected >= {node['minProperties']} properties")
+        props = node.get("properties", {})
+        addl = node.get("additionalProperties", True)
+        for key, sub in value.items():
+            subpath = f"{path}.{key}" if path else key
+            if key in props:
+                validate(sub, props[key], root, subpath, errors)
+            elif addl is True:
+                continue
+            elif isinstance(addl, dict):
+                validate(sub, addl, root, subpath, errors)
+            else:
+                errors.append(f"{subpath}: unexpected property '{key}'")
+
+    if isinstance(value, list) and "items" in node:
+        for i, item in enumerate(value):
+            validate(item, node["items"], root, f"{path}[{i}]", errors)
+
+    if "enum" in node and value not in node["enum"]:
+        errors.append(f"{path}: value {value!r} not in enum {node['enum']}")
+
+    if "pattern" in node and isinstance(value, str):
+        if not re.search(node["pattern"], value):
+            errors.append(f"{path}: {value!r} does not match pattern {node['pattern']}")
+
+    if "minLength" in node and isinstance(value, str) and len(value) < node["minLength"]:
+        errors.append(f"{path}: length {len(value)} < minLength {node['minLength']}")
+
+
+def main() -> int:
+    try:
+        schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+        catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        print(f"ERROR: {e}")
+        return 1
+
+    errors: list[str] = []
+    validate(catalog, schema, schema, "", errors)
+
+    if errors:
+        print(f"FAILED: {len(errors)} schema violation(s).")
+        for e in errors:
+            print(f"  - {e}")
+        return 1
+
+    n = len(catalog.get("tools", {}))
+    print(f"PASSED: tools.json ({n} tools) conforms to schema/tools.schema.json.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Addresses code review findings from PR #720.

### P0 — GitHub Actions least-privilege
All 4 workflows were missing a `permissions:` block (GitHub defaults to broad permissions). Added `permissions: contents: read` to:
- `check-tools.yml`
- `check-divisions.yml`
- `check-runbooks.yml`
- `lint-agents.yml`

### P1 — tools.json JSON Schema
- Added `schema/tools.schema.json` (draft-07) covering the full tool entry contract.
- Added `scripts/check-tools-schema.py` — pure-stdlib validator (no jsonschema dep), wired into `check-tools.yml` CI.

### P1 — Runtime schema validation
- `build-hermes-plugin.py` now emits `_validate_agents()` in the generated plugin, validating `agents.json` on every load (required fields + slug/name types), not just at build time.

## Verification
- `python3 scripts/check-tools-schema.py` → PASS (16 tools)
- `python3 scripts/check-hermes-plugin.py` → PASS
- `bash scripts/check-tools.sh` → PASS
- Negative-case runtime validation test → correctly rejects corrupted agents.json