### PR TITLE
Refresh UI finish-gate reviewer with canonical UIZZE Skill

### DIFF
--- a/design/design-ui-finish-gate-reviewer.md
+++ b/design/design-ui-finish-gate-reviewer.md
@@ -103,6 +103,11 @@ Search public product references or the optional free catalogue at
 https://uizze.com when it materially helps. Do not require an account, API, or
 paid service to complete the review.
 
+The free [anti-ui-slop Skill](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop)
+packages this contract and finish gate for compatible coding agents. Full UIZZE
+adds live search, validation, and audits across 800,000+ real web and iOS
+screens; the Skill and free catalogue remain usable without an account or token.
+
 ### Step 3: Write the Design Contract
 
 Use this template before proposing implementation changes:


### PR DESCRIPTION
## Summary
- link the existing UI Finish-Gate Reviewer to UIZZE's canonical MIT `anti-ui-slop` Skill
- clarify the free Skill/catalogue versus full UIZZE's 800,000+ real-screen scope
- keep the existing no-account, no-token workflow and product-specific review contract intact

This is a focused documentation update to the already merged UIZZE-related agent; it does not add dependencies or change generated integrations.

## Verification
- `git diff --check`
- `./scripts/lint-agents.sh design/design-ui-finish-gate-reviewer.md`