### PR TITLE
fix(agents): remove non-standard tools key from agent frontmatters (#796)

### DIFF
--- a/marketing/marketing-content-creator.md
+++ b/marketing/marketing-content-creator.md
@@ -1,7 +1,6 @@
 ---
 name: Content Creator
 description: Expert content strategist and creator for multi-platform campaigns. Develops editorial calendars, creates compelling copy, manages brand storytelling, and optimizes content for engagement across all digital channels.
-tools: WebFetch, WebSearch, Read, Write, Edit
 color: teal
 emoji: ✍️
 vibe: Crafts compelling stories across every platform your audience lives on.

--- a/marketing/marketing-growth-hacker.md
+++ b/marketing/marketing-growth-hacker.md
@@ -1,7 +1,6 @@
 ---
 name: Growth Hacker
 description: Expert growth strategist specializing in rapid user acquisition through data-driven experimentation. Develops viral loops, optimizes conversion funnels, and finds scalable growth channels for exponential business growth.
-tools: WebFetch, WebSearch, Read, Write, Edit
 color: green
 emoji: 🚀
 vibe: Finds the growth channel nobody's exploited yet — then scales it.

--- a/marketing/marketing-seo-specialist.md
+++ b/marketing/marketing-seo-specialist.md
@@ -1,7 +1,6 @@
 ---
 name: SEO Specialist
 description: Expert search engine optimization strategist specializing in technical SEO, content optimization, link authority building, and organic search growth. Drives sustainable traffic through data-driven search strategies.
-tools: WebFetch, WebSearch, Read, Write, Edit
 color: "#4285F4"
 emoji: 🔍
 vibe: Drives sustainable organic traffic through technical SEO and content strategy.

--- a/marketing/marketing-social-media-strategist.md
+++ b/marketing/marketing-social-media-strategist.md
@@ -1,7 +1,6 @@
 ---
 name: Social Media Strategist
 description: Expert social media strategist for LinkedIn, Twitter, and professional platforms. Creates cross-platform campaigns, builds communities, manages real-time engagement, and develops thought leadership strategies.
-tools: WebFetch, WebSearch, Read, Write, Edit
 color: blue
 emoji: 📣
 vibe: Orchestrates cross-platform campaigns that build community and drive engagement.

--- a/paid-media/paid-media-auditor.md
+++ b/paid-media/paid-media-auditor.md
@@ -2,7 +2,6 @@
 name: Paid Media Auditor
 description: Comprehensive paid media auditor who systematically evaluates Google Ads, Microsoft Ads, and Meta accounts across 200+ checkpoints spanning account structure, tracking, bidding, creative, audiences, and competitive positioning. Produces actionable audit reports with prioritized recommendations and projected impact.
 color: orange
-tools: WebFetch, WebSearch, Read, Write, Edit, Bash
 author: John Williams (@itallstartedwithaidea)
 emoji: 📋
 vibe: Finds the waste in your ad spend before your CFO does.

--- a/paid-media/paid-media-creative-strategist.md
+++ b/paid-media/paid-media-creative-strategist.md
@@ -2,7 +2,6 @@
 name: Ad Creative Strategist
 description: Paid media creative specialist focused on ad copywriting, RSA optimization, asset group design, and creative testing frameworks across Google, Meta, Microsoft, and programmatic platforms. Bridges the gap between performance data and persuasive messaging.
 color: orange
-tools: WebFetch, WebSearch, Read, Write, Edit, Bash
 author: John Williams (@itallstartedwithaidea)
 emoji: ✍️
 vibe: Turns ad creative from guesswork into a repeatable science.

--- a/paid-media/paid-media-paid-social-strategist.md
+++ b/paid-media/paid-media-paid-social-strategist.md
@@ -2,7 +2,6 @@
 name: Paid Social Strategist
 description: Cross-platform paid social advertising specialist covering Meta (Facebook/Instagram), LinkedIn, TikTok, Pinterest, X, and Snapchat. Designs full-funnel social ad programs from prospecting through retargeting with platform-specific creative and audience strategies.
 color: orange
-tools: WebFetch, WebSearch, Read, Write, Edit, Bash
 author: John Williams (@itallstartedwithaidea)
 emoji: 📱
 vibe: Makes every dollar on Meta, LinkedIn, and TikTok ads work harder.

--- a/paid-media/paid-media-ppc-strategist.md
+++ b/paid-media/paid-media-ppc-strategist.md
@@ -2,7 +2,6 @@
 name: PPC Campaign Strategist
 description: Senior paid media strategist specializing in large-scale search, shopping, and performance max campaign architecture across Google, Microsoft, and Amazon ad platforms. Designs account structures, budget allocation frameworks, and bidding strategies that scale from $10K to $10M+ monthly spend.
 color: orange
-tools: WebFetch, WebSearch, Read, Write, Edit, Bash
 author: John Williams (@itallstartedwithaidea)
 emoji: 💰
 vibe: Architects PPC campaigns that scale from $10K to $10M+ monthly.

--- a/paid-media/paid-media-programmatic-buyer.md
+++ b/paid-media/paid-media-programmatic-buyer.md
@@ -2,7 +2,6 @@
 name: Programmatic & Display Buyer
 description: Display advertising and programmatic media buying specialist covering managed placements, Google Display Network, DV360, trade desk platforms, partner media (newsletters, sponsored content), and ABM display strategies via platforms like Demandbase and 6Sense.
 color: orange
-tools: WebFetch, WebSearch, Read, Write, Edit, Bash
 author: John Williams (@itallstartedwithaidea)
 emoji: 📺
 vibe: Buys display and video inventory at scale with surgical precision.

--- a/paid-media/paid-media-search-query-analyst.md
+++ b/paid-media/paid-media-search-query-analyst.md
@@ -2,7 +2,6 @@
 name: Search Query Analyst
 description: Specialist in search term analysis, negative keyword architecture, and query-to-intent mapping. Turns raw search query data into actionable optimizations that eliminate waste and amplify high-intent traffic across paid search accounts.
 color: orange
-tools: WebFetch, WebSearch, Read, Write, Edit, Bash
 author: John Williams (@itallstartedwithaidea)
 emoji: 🔍
 vibe: Mines search queries to find the gold your competitors are missing.

--- a/paid-media/paid-media-tracking-specialist.md
+++ b/paid-media/paid-media-tracking-specialist.md
@@ -2,7 +2,6 @@
 name: Tracking & Measurement Specialist
 description: Expert in conversion tracking architecture, tag management, and attribution modeling across Google Tag Manager, GA4, Google Ads, Meta CAPI, LinkedIn Insight Tag, and server-side implementations. Ensures every conversion is counted correctly and every dollar of ad spend is measurable.
 color: orange
-tools: WebFetch, WebSearch, Read, Write, Edit, Bash
 author: John Williams (@itallstartedwithaidea)
 emoji: 📡
 vibe: If it's not tracked correctly, it didn't happen.

--- a/product/product-feedback-synthesizer.md
+++ b/product/product-feedback-synthesizer.md
@@ -2,7 +2,6 @@
 name: Feedback Synthesizer
 description: Expert in collecting, analyzing, and synthesizing user feedback from multiple channels to extract actionable product insights. Transforms qualitative feedback into quantitative priorities and strategic recommendations.
 color: blue
-tools: WebFetch, WebSearch, Read, Write, Edit
 emoji: 🔍
 vibe: Distills a thousand user voices into the five things you need to build next.
 ---

--- a/product/product-manager.md
+++ b/product/product-manager.md
@@ -4,7 +4,6 @@ description: Holistic product leader who owns the full product lifecycle — fro
 color: blue
 emoji: 🧭
 vibe: Ships the right thing, not just the next thing — outcome-obsessed, user-grounded, and diplomatically ruthless about focus.
-tools: WebFetch, WebSearch, Read, Write, Edit
 ---
 
 # 🧭 Product Manager Agent

--- a/product/product-sprint-prioritizer.md
+++ b/product/product-sprint-prioritizer.md
@@ -2,7 +2,6 @@
 name: Sprint Prioritizer
 description: Expert product manager specializing in agile sprint planning, feature prioritization, and resource allocation. Focused on maximizing team velocity and business value delivery through data-driven prioritization frameworks.
 color: green
-tools: WebFetch, WebSearch, Read, Write, Edit
 emoji: 🎯
 vibe: Maximizes sprint value through data-driven prioritization and ruthless focus.
 ---

--- a/product/product-trend-researcher.md
+++ b/product/product-trend-researcher.md
@@ -2,7 +2,6 @@
 name: Trend Researcher
 description: Expert market intelligence analyst specializing in identifying emerging trends, competitive analysis, and opportunity assessment. Focused on providing actionable insights that drive product strategy and innovation decisions.
 color: purple
-tools: WebFetch, WebSearch, Read, Write, Edit
 emoji: 🔭
 vibe: Spots emerging trends before they hit the mainstream.
 ---

--- a/project-management/project-management-meeting-notes-specialist.md
+++ b/project-management/project-management-meeting-notes-specialist.md
@@ -1,7 +1,6 @@
 ---
 name: Meeting Notes Specialist
 description: Extract structured decisions, action items, and open questions from meeting transcripts or rough notes into a clean 4-section summary.
-tools: Read, Write, Edit
 color: blue
 emoji: 📋
 vibe: Precise extractor — finds the signal in the noise, never invents what isn't there.

--- a/specialized/specialized-pricing-analyst.md
+++ b/specialized/specialized-pricing-analyst.md
@@ -4,7 +4,6 @@ description: Specialized pricing analyst who develops optimal pricing models thr
 color: gold
 emoji: 💰
 vibe: Finds the price point where value captured meets value delivered — then proves it with data.
-tools: WebFetch, WebSearch, Read, Write, Edit
 ---
 
 # Pricing Analyst Agent


### PR DESCRIPTION
## Summary

Fixes #796.

In 17 agent definition files across `marketing/`, `paid-media/`, `product/`, `project-management/`, and `specialized/`, a non-standard string `tools: ...` key was present in the YAML frontmatter. This caused schema validation failures when imported into tool runners like OpenCode (which expects an object or undefined).

## Changes

- Removed legacy string `tools:` frontmatter keys from the 17 affected agent definition files.