### PR TITLE
docs: add Mistral Vibe and ZCode to Supported Tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -723,6 +723,8 @@ The Agency works natively with Claude Code, and ships conversion + install scrip
 - **[Codex](https://developers.openai.com/codex/overview)** — TOML custom agents → `~/.codex/agents/`
 - **Osaurus** -- `SKILL.md` skills -> `~/.osaurus/skills/`
 - **[Hermes](integrations/hermes/README.md)** -- lazy-router plugin -> `~/.hermes/plugins/`
+- **Mistral Vibe** -- TOML + prompt `.md` files -> `~/.vibe/agents/`
+- **ZCode** -- `.md` agent files -> `~/.zcode/agents/`
 
 ---
 


### PR DESCRIPTION
## Summary
- Both Mistral Vibe and ZCode integrations are fully implemented (`tools.json`, `scripts/install.sh`, `scripts/convert.sh`) but were missing from the README's "Supported Tools" section.
- Adds one bullet each, consistent with the existing entries' style.

## Test plan
- [x] Verified both tool IDs exist in `tools.json` with full `dest`/`format` config
- [x] Verified `install_zcode()` and matching vibe install logic exist in `scripts/install.sh`
- [x] Documentation-only change, no code touched