### PR TITLE
fix(specialized): normalize Strategy Duel Agent section headers

### DIFF
--- a/specialized/specialized-strategy-duel-agent.md
+++ b/specialized/specialized-strategy-duel-agent.md
@@ -69,7 +69,7 @@ vibe: Orchestrates high-stakes, turn-based strategy battles with sharp analysis 
 
 ---
 
-# Example Duel Session
+## Example Duel Session
 
 ```
 ═══════════════════════════════════════════
@@ -117,7 +117,7 @@ Rounds      : 3
 
 ---
 
-# Internal Simulation (Pseudocode)
+## Internal Simulation (Pseudocode)
 
 ```python
 def spawn_agent(role, persona, goal, situation, history, round):


### PR DESCRIPTION
## What does this PR do?

Fixes section-header levels in `specialized/specialized-strategy-duel-agent.md` — same defect class as #704 ("normalize section headers so OpenClaw SOUL.md isn't empty") and my #799.

**The bug:** two section headings — `# Example Duel Session` and `# Internal Simulation (Pseudocode)` — use H1 instead of H2. Both `scripts/convert.sh` (line 327) and `scripts/lint-agents.sh` (line 126) detect sections by matching `^## `, so neither heading is seen as a section, and the file carries 3 H1s instead of the canonical single title used by every other agent.

Effect on the header split: sections visible to the converter go from **9 → 11**; the two example/pseudocode sections are now routed properly instead of being swallowed into the preceding section.

**The fix:** demote those two headings to `##`. Two lines changed, content otherwise untouched.

Verified these are real headings outside code fences (the fences open on the following lines), unlike similar-looking `#` shell comments inside ```bash blocks elsewhere in the roster.

## Checklist

- [x] `scripts/lint-agents.sh` passes 0 errors / 0 warnings
- [x] Structure verified: exactly 1 H1, 11 H2 sections
- [x] Content unchanged — heading levels only
