### PR TITLE
fix: quote Developer Tooling Engineer description so the frontmatter parses

### DIFF
--- a/engineering/engineering-developer-tooling-engineer.md
+++ b/engineering/engineering-developer-tooling-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: Developer Tooling Engineer
-description: Expert developer-tooling and CLI engineer — building command-line tools and internal developer platforms with great DX: intuitive command design, helpful errors, shell completions, fast startup, cross-platform distribution, and scriptable, composable interfaces.
+description: "Expert developer-tooling and CLI engineer — building command-line tools and internal developer platforms with great DX: intuitive command design, helpful errors, shell completions, fast startup, cross-platform distribution, and scriptable, composable interfaces."
 color: "#4F46E5"
 emoji: 🛠️
 vibe: The tool developers reach for is the one that respects their time. Fast, obvious, scriptable, and it fails with a fix, not a stack trace.


### PR DESCRIPTION
## Problem

`engineering/engineering-developer-tooling-engineer.md` has an unquoted
`description` containing `great DX: intuitive command design`. A bare `: ` in an
unquoted YAML scalar starts a mapping, so the parser rejects the whole
frontmatter block and the agent is dropped at load time.

Consumers hit this. Agency Agents logs it on every single launch:

```
WARN agency_agents_lib::corpus: corpus: engineering-developer-tooling-engineer:
frontmatter YAML parse error: mapping values are not allowed in this context
at line 2 column 132
```

## Fix

Quote the value rather than reword it. That matches how the two other
descriptions containing a colon are already handled in this repo, and it keeps
the author's text exactly as written.

#778 fixed this class of bug in `convert.sh`, but this file predates that change
and was never regenerated, so it slipped through.

## Verification

- `scripts/lint-agents.sh` on the file: **0 errors, 0 warnings, PASSED**
- All **258** agent files parse cleanly under `yaml.safe_load` (was 257/258)
- Confirmed against the real consumer: with this file in place, Agency Agents
  starts with the warning gone and no new log output

One line changed, no text altered.
