### PR TITLE
feat(strategy): add nexus-spatial-discovery runbook to NEXUS roster

### DIFF
--- a/strategy/runbooks.json
+++ b/strategy/runbooks.json
@@ -170,6 +170,36 @@
           ]
         }
       ]
+    },
+    {
+      "slug": "nexus-spatial-discovery",
+      "title": "Nexus Spatial Discovery",
+      "mode": "NEXUS-Sprint",
+      "duration": "1-2 weeks",
+      "summary": "Full-agency product discovery exercise — 8 specialists run in parallel to evaluate a software opportunity and produce a unified plan.",
+      "doc": "examples/nexus-spatial-discovery.md",
+      "roster": [
+        {
+          "group": "Discovery Core",
+          "activation": "always",
+          "agents": [
+            "product-trend-researcher",
+            "design-ux-researcher",
+            "engineering-backend-architect",
+            "design-brand-guardian"
+          ]
+        },
+        {
+          "group": "Go-to-Market & Delivery",
+          "activation": "always",
+          "agents": [
+            "marketing-growth-hacker",
+            "support-support-responder",
+            "project-management-project-shepherd",
+            "xr-interface-architect"
+          ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Add the nexus-spatial-discovery runbook to the NEXUS roster, closing the gap between the existing examples/nexus-spatial-discovery.md and strategy/runbooks.json.

## What this PR does
Adds a new runbook entry for nexus-spatial-discovery to strategy/runbooks.json, bringing the roster from 4 to 5 runbooks and agent slug references from 64 to 72.

## Files
- strategy/runbooks.json (30 lines added, 1 entry appended)

## Runbook details
- slug: nexus-spatial-discovery
- title: Nexus Spatial Discovery
- mode: NEXUS-Sprint (8 agents, 1-2 weeks)
- doc: examples/nexus-spatial-discovery.md (already exists)
- roster: Discovery Core group (product-trend-researcher, design-ux-researcher, engineering-backend-architect, design-brand-guardian) + Go-to-Market & Delivery group (marketing-growth-hacker, support-support-responder, project-management-project-shepherd, xr-interface-architect)

## Checklist
- [x] Template: one file change only.
- [x] Frontmatter: N/A (JSON runbook).
- [x] Examples: agents listed match the existing nexus-spatial-discovery.md.
- [x] Tested locally: scripts/check-divisions.sh PASSED (18 divisions); scripts/check-tools.sh PASSED (16 tools); scripts/check-runbooks.sh PASSED (5 runbooks, 72 agent slug references).
- [x] Proofread: all agent slug references resolve to real agent files.

## Evidence
- scripts/check-divisions.sh: PASSED (18 divisions consistent)
- scripts/check-tools.sh: PASSED (16 tools consistent)
- scripts/check-runbooks.sh: PASSED (5 runbooks, 72 agent slug references)
- JSON validation: OK 5 runbooks
- CRLF check: no CRLF detected
