### PR TITLE
fix(scripts): kimi skipped in --parallel, stale progress idx, --path multi-tool guard, rm -rf slug guard

### DIFF
--- a/scripts/convert.sh
+++ b/scripts/convert.sh
@@ -614,6 +614,9 @@ HEREDOC
 # but never pruned stale output). Preserves the committed README.md — the only
 # tracked file under integrations/<tool>/ for conversion targets.
 clean_tool_output() {
+  # Defensive: tool names are plain slugs; refuse anything else so a future
+  # caller can never steer this rm -rf outside $OUT_DIR via "../" or "/".
+  [[ "$1" =~ ^[a-z0-9-]+$ ]] || { echo "ERROR: clean_tool_output: refusing non-slug tool name '$1'" >&2; return 1; }
   local dir="$OUT_DIR/$1"
   [[ -d "$dir" ]] || return 0
   find "$dir" -mindepth 1 -maxdepth 1 ! -name 'README.md' -exec rm -rf {} +
@@ -717,7 +720,7 @@ main() {
 
   if $use_parallel && [[ "$tool" == "all" ]]; then
     # Tools that write to separate dirs can run in parallel; buffer output so each tool's output stays together
-    local parallel_tools=(antigravity gemini-cli opencode cursor openclaw qwen zcode codex osaurus hermes vibe)
+    local parallel_tools=(antigravity gemini-cli opencode cursor openclaw qwen zcode kimi codex osaurus hermes vibe)
     local parallel_out_dir
     parallel_out_dir="$(mktemp -d)"
     info "Converting: ${#parallel_tools[@]}/${n_tools} tools in parallel (output buffered per tool)..."
@@ -729,7 +732,7 @@ main() {
       [[ -f "$parallel_out_dir/$t" ]] && cat "$parallel_out_dir/$t"
     done
     rm -rf "$parallel_out_dir"
-    local idx=8
+    local idx=$(( ${#parallel_tools[@]} + 1 ))
     for t in aider windsurf; do
       progress_bar "$idx" "$n_tools"
       printf "\n"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1258,6 +1258,12 @@ main() {
       $duplicate || _cleaned+=("$_t")
     done
     _tool_list=("${_cleaned[@]}")
+    # --path is a single-destination override; with several tools every one of
+    # them would land in the same directory and clobber each other.
+    if [[ -n "$OVERRIDE_PATH" && ${#_tool_list[@]} -gt 1 ]]; then
+      err "--path sets ONE destination; use it with exactly one --tool (got ${#_tool_list[@]}: ${_tool_list[*]})."
+      exit 1
+    fi
   fi
 
   # Decide whether to show interactive UI


### PR DESCRIPTION
Fixes four install/convert bugs reported by @sunilkumarvalmiki, each sandbox-verified before/after.

| Issue | Bug | Fix | Verified |
|---|---|---|---|
| #817 | `--tool all --parallel` silently skipped **kimi** (parallel batch 11 + sequential 2 = 13 of 14) | add kimi to the parallel batch (it writes its own `integrations/kimi/<slug>/` — parallel-safe) | kimi **0 → 273** files |
| #818 | progress counter hardcoded `idx=8`, stale | derive from list length | `aider (8/14)` → **`13/14`, `14/14`** |
| #819 | `--path` + multiple tools → all clobber one dir | refuse `--path` with >1 tool. **Not** restricting the path itself — it's the supported override (e.g. sandboxing) | 2 tools+`--path` → error; 1 tool+`--path` still works |
| #820 | `rm -rf` on `$OUT_DIR/$1`, defensive | plain-slug guard on `$1` (a prefix check is defeated by `../`) | `../etc`/`/etc` refused, `kimi` allowed |

#821 (windsurf/aider "TOML-unsafe") is intentionally not in this PR — those outputs are plain text/markdown, not TOML, so a newline can't invalidate them; the real TOML converters already escape. Responding on the issue separately.

Fixes #817
Fixes #818
Fixes #819
Fixes #820

🤖 Generated with [Claude Code](https://claude.com/claude-code)