### PR TITLE
fix(lib): get_field strips quoted-scalar delimiters so quoted sources don't double-wrap

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -21,7 +21,16 @@ get_field() {
   local field="$1" file="$2"
   awk -v f="$field" '
     /^---$/ { fm++; next }
-    fm == 1 && $0 ~ "^" f ": " { sub("^" f ": ", ""); print; exit }
+    fm == 1 && $0 ~ "^" f ": " {
+      sub("^" f ": ", "")
+      # A quoted YAML scalar carries its quotes as delimiters, not content.
+      # Strip one matching outer pair and unescape, so a quoted source value
+      # never double-wraps when a converter re-quotes it (\047 is a literal
+      # apostrophe; this program sits inside shell single quotes).
+      if ($0 ~ /^".*"$/)            { $0 = substr($0, 2, length($0) - 2); gsub(/\\"/, "\"", $0); gsub(/\\\\/, "\\", $0) }
+      else if ($0 ~ /^\047.*\047$/) { $0 = substr($0, 2, length($0) - 2); gsub(/\047\047/, "\047", $0) }
+      print; exit
+    }
   ' "$file"
 }
 


### PR DESCRIPTION
Three separate contributors reached for the same fix when a description's `: ` broke YAML frontmatter — double-quote the source (#473 → zk-steward, re-proposed in #548, again in #810). #778 fixed it one layer down (converters emit quoted scalars). **The two compose badly:** `get_field` returned a quoted source's quotes as *content*, so `yaml_quote` wrapped them again and already-quoted agents shipped as `description: '"…"'` with a literal quote leaking into the parsed value. **zk-steward and ai-data-remediation-engineer are affected on `main` today** — a regression from #778.

`get_field` now treats one matching outer pair of `"…"`/`'…'` as delimiters: strips them and unescapes (`\"`→`"`, `\\`→`\`, `''`→`'`). Quoting a source description becomes safe, so the contributors' instinct and the generator-side fix reconcile. Unquoted sources are byte-identical.

**Sandbox-verified end-to-end** (source → `convert.sh` → parsed YAML):
| fixture | before | after |
|---|---|---|
| zk-steward (`"…"`, has `Luhmann's`) | `'"Knowledge-base…` leaks `"` | `Knowledge-base…`, apostrophe intact |
| ai-data-remediation (`"…"`, has `can't`) | leaks `"` | clean |
| developer-tooling (unquoted, has `: `) | valid (per #778) | **unchanged** |
| synthetic `'It''s…'` / `"Say \\"hi\\"…"` | — | unescaped correctly |

Blast radius: `get_field` is called only from `convert.sh` (install.sh's mention is a comment). Guards green.

Refs #473 #548 #810 #778

🤖 Generated with [Claude Code](https://claude.com/claude-code)