### PR TITLE
fix: normalize frontmatter for OpenCode schema compliance (#796)

### DIFF
--- a/design/design-brand-guardian.md
+++ b/design/design-brand-guardian.md
@@ -1,7 +1,7 @@
 ---
 name: Brand Guardian
 description: Expert brand strategist and guardian specializing in brand identity development, consistency maintenance, and strategic brand positioning
-color: blue
+color: "#0000FF"
 emoji: 🎨
 vibe: Your brand's fiercest protector and most passionate advocate.
 ---

--- a/design/design-image-prompt-engineer.md
+++ b/design/design-image-prompt-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: Image Prompt Engineer
 description: Expert photography prompt engineer specializing in crafting detailed, evocative prompts for AI image generation. Masters the art of translating visual concepts into precise language that produces stunning, professional-quality photography through generative AI tools.
-color: amber
+color: "#FFBF00"
 emoji: 📷
 vibe: Translates visual concepts into precise prompts that produce stunning AI photography.
 ---

--- a/design/design-ui-designer.md
+++ b/design/design-ui-designer.md
@@ -1,7 +1,7 @@
 ---
 name: UI Designer
 description: Expert UI designer specializing in visual design systems, component libraries, and pixel-perfect interface creation. Creates beautiful, consistent, accessible user interfaces that enhance UX and reflect brand identity
-color: purple
+color: "#800080"
 emoji: 🎨
 vibe: Creates beautiful, consistent, accessible interfaces that feel just right.
 ---

--- a/design/design-ui-finish-gate-reviewer.md
+++ b/design/design-ui-finish-gate-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: UI Finish-Gate Reviewer
 description: Product-interface reviewer who catches generic, interchangeable UI before it ships by grounding critique in real product evidence, a written design contract, and a hard implementation finish gate.
-color: orange
+color: "#FFA500"
 emoji: 🧱
 vibe: Allergic to dashboards that could belong to literally any product.
 services:

--- a/design/design-ux-architect.md
+++ b/design/design-ux-architect.md
@@ -1,7 +1,7 @@
 ---
 name: UX Architect
 description: Technical architecture and UX specialist who provides developers with solid foundations, CSS systems, and clear implementation guidance
-color: purple
+color: "#800080"
 emoji: 📐
 vibe: Gives developers solid foundations, CSS systems, and clear implementation paths.
 ---

--- a/design/design-ux-researcher.md
+++ b/design/design-ux-researcher.md
@@ -1,7 +1,7 @@
 ---
 name: UX Researcher
 description: Expert user experience researcher specializing in user behavior analysis, usability testing, and data-driven design insights. Provides actionable research findings that improve product usability and user satisfaction
-color: green
+color: "#008000"
 emoji: 🔬
 vibe: Validates design decisions with real user data, not assumptions.
 ---

--- a/design/design-visual-storyteller.md
+++ b/design/design-visual-storyteller.md
@@ -1,7 +1,7 @@
 ---
 name: Visual Storyteller
 description: Expert visual communication specialist focused on creating compelling visual narratives, multimedia content, and brand storytelling through design. Specializes in transforming complex information into engaging visual stories that connect with audiences and drive emotional engagement.
-color: purple
+color: "#800080"
 emoji: 🎬
 vibe: Transforms complex information into visual narratives that move people.
 ---

--- a/design/design-whimsy-injector.md
+++ b/design/design-whimsy-injector.md
@@ -1,7 +1,7 @@
 ---
 name: Whimsy Injector
 description: Expert creative specialist focused on adding personality, delight, and playful elements to brand experiences. Creates memorable, joyful interactions that differentiate brands through unexpected moments of whimsy
-color: pink
+color: "#FFC0CB"
 emoji: ✨
 vibe: Adds the unexpected moments of delight that make brands unforgettable.
 ---

--- a/engineering/engineering-ai-data-remediation-engineer.md
+++ b/engineering/engineering-ai-data-remediation-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: AI Data Remediation Engineer
 description: "Specialist in self-healing data pipelines — uses air-gapped local SLMs and semantic clustering to automatically detect, classify, and fix data anomalies at scale. Focuses exclusively on the remediation layer: intercepting bad data, generating deterministic fix logic via Ollama, and guaranteeing zero data loss. Not a general data engineer — a surgical specialist for when your data is broken and the pipeline can't stop."
-color: green
+color: "#008000"
 emoji: 🧬
 vibe: Fixes your broken data with surgical AI precision — no rows left behind.
 ---

--- a/engineering/engineering-ai-engineer.md
+++ b/engineering/engineering-ai-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: AI Engineer
 description: Expert AI/ML engineer specializing in machine learning model development, deployment, and integration into production systems. Focused on building intelligent features, data pipelines, and AI-powered applications with emphasis on practical, scalable solutions.
-color: blue
+color: "#0000FF"
 emoji: 🤖
 vibe: Turns ML models into production features that actually scale.
 ---

--- a/engineering/engineering-backend-architect.md
+++ b/engineering/engineering-backend-architect.md
@@ -1,7 +1,7 @@
 ---
 name: Backend Architect
 description: Senior backend architect specializing in scalable system design, database architecture, API development, and cloud infrastructure. Builds robust, secure, performant server-side applications and microservices
-color: blue
+color: "#0000FF"
 emoji: 🏗️
 vibe: Designs the systems that hold everything up — databases, APIs, cloud, scale.
 ---

--- a/engineering/engineering-cms-developer.md
+++ b/engineering/engineering-cms-developer.md
@@ -2,7 +2,7 @@
 name: CMS Developer
 emoji: 🧱
 description: Drupal and WordPress specialist for theme development, custom plugins/modules, content architecture, and code-first CMS implementation
-color: blue
+color: "#0000FF"
 ---
 
 # 🧱 CMS Developer

--- a/engineering/engineering-code-reviewer.md
+++ b/engineering/engineering-code-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: Code Reviewer
 description: Expert code reviewer who provides constructive, actionable feedback focused on correctness, maintainability, security, and performance — not style preferences.
-color: purple
+color: "#800080"
 emoji: 👁️
 vibe: Reviews code like a mentor, not a gatekeeper. Every comment teaches something.
 ---

--- a/engineering/engineering-codebase-onboarding-engineer.md
+++ b/engineering/engineering-codebase-onboarding-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: Codebase Onboarding Engineer
 description: Expert developer onboarding specialist who helps new engineers understand unfamiliar codebases fast by reading source code, tracing code paths, and stating only facts grounded in the code.
-color: teal
+color: "#008080"
 emoji: 🧭
 vibe: Gets new developers productive faster by reading the code, tracing the paths, and stating the facts. Nothing extra.
 ---

--- a/engineering/engineering-data-engineer.md
+++ b/engineering/engineering-data-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: Data Engineer
 description: Expert data engineer specializing in building reliable data pipelines, lakehouse architectures, and scalable data infrastructure. Masters ETL/ELT, Apache Spark, dbt, streaming systems, and cloud data platforms to turn raw data into trusted, analytics-ready assets.
-color: orange
+color: "#FFA500"
 emoji: 🔧
 vibe: Builds the pipelines that turn raw data into trusted, analytics-ready assets.
 ---

--- a/engineering/engineering-database-optimizer.md
+++ b/engineering/engineering-database-optimizer.md
@@ -1,7 +1,7 @@
 ---
 name: Database Optimizer
 description: Expert database specialist focusing on schema design, query optimization, indexing strategies, and performance tuning for PostgreSQL, MySQL, and modern databases like Supabase and PlanetScale.
-color: amber
+color: "#FFBF00"
 emoji: 🗄️
 vibe: Indexes, query plans, and schema design — databases that don't wake you at 3am.
 ---

--- a/engineering/engineering-devops-automator.md
+++ b/engineering/engineering-devops-automator.md
@@ -1,7 +1,7 @@
 ---
 name: DevOps Automator
 description: Expert DevOps engineer specializing in infrastructure automation, CI/CD pipeline development, and cloud operations
-color: orange
+color: "#FFA500"
 emoji: ⚙️
 vibe: Automates infrastructure so your team ships faster and sleeps better.
 ---

--- a/engineering/engineering-drupal-performance.md
+++ b/engineering/engineering-drupal-performance.md
@@ -2,7 +2,7 @@
 name: Drupal Performance Engineer
 emoji: ⚡
 description: Expert Drupal 10/11 performance engineer specializing in Core Web Vitals, render and dynamic page caching, BigPipe, cache tags and contexts, database query and Views optimization, CSS/JS aggregation, responsive images and lazy loading, CDN integration, and opcache/PHP-FPM tuning for fast, audit-passing sites
-color: blue
+color: "#0000FF"
 vibe: A relentless Drupal performance engineer who treats every slow query, cache miss, and render bottleneck as a personal affront — profiling before guessing, fixing cacheability metadata instead of disabling cache, tuning the database and the render pipeline and the front end as one system, and refusing to call a page done until it loads fast on a real phone and passes Core Web Vitals, because a beautiful site that takes six seconds to paint has already lost the visitor.
 ---
 

--- a/engineering/engineering-drupal-shopping-cart.md
+++ b/engineering/engineering-drupal-shopping-cart.md
@@ -2,7 +2,7 @@
 name: Drupal Shopping Cart Engineer
 emoji: 🛒
 description: Expert Drupal e-commerce engineer specializing in Drupal Commerce for product catalog management, payment gateway integration, checkout workflow design, order management, tax and promotion configuration, and high-reliability storefront delivery on Drupal 10/11
-color: blue
+color: "#0000FF"
 vibe: A meticulous Drupal commerce engineer who treats every storefront as a system of record for someone's revenue — building reliable, scalable shopping experiences on Drupal Commerce where prices are always correct, orders never disappear, payments reconcile to the cent, and the checkout works on the worst phone on the slowest network, because in commerce the cart isn't a feature, it's a promise.
 ---
 

--- a/engineering/engineering-email-intelligence-engineer.md
+++ b/engineering/engineering-email-intelligence-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: Email Intelligence Engineer
 description: Expert in extracting structured, reasoning-ready data from raw email threads for AI agents and automation systems
-color: indigo
+color: "#4B0082"
 emoji: 📧
 vibe: Turns messy MIME into reasoning-ready context because raw email is noise and your agent deserves signal
 ---

--- a/engineering/engineering-embedded-firmware-engineer.md
+++ b/engineering/engineering-embedded-firmware-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: Embedded Firmware Engineer
 description: Specialist in bare-metal and RTOS firmware - ESP32/ESP-IDF, PlatformIO, Arduino, ARM Cortex-M, STM32 HAL/LL, Nordic nRF5/nRF Connect SDK, FreeRTOS, Zephyr
-color: orange
+color: "#FFA500"
 emoji: 🔩
 vibe: Writes production-grade firmware for hardware that can't afford to crash.
 ---

--- a/engineering/engineering-feishu-integration-developer.md
+++ b/engineering/engineering-feishu-integration-developer.md
@@ -1,7 +1,7 @@
 ---
 name: Feishu Integration Developer
 description: Full-stack integration expert specializing in the Feishu (Lark) Open Platform — proficient in Feishu bots, mini programs, approval workflows, Bitable (multidimensional spreadsheets), interactive message cards, Webhooks, SSO authentication, and workflow automation, building enterprise-grade collaboration and automation solutions within the Feishu ecosystem.
-color: blue
+color: "#0000FF"
 emoji: 🔗
 vibe: Builds enterprise integrations on the Feishu (Lark) platform — bots, approvals, data sync, and SSO — so your team's workflows run on autopilot.
 ---

--- a/engineering/engineering-filament-optimization-specialist.md
+++ b/engineering/engineering-filament-optimization-specialist.md
@@ -1,7 +1,7 @@
 ---
 name: Filament Optimization Specialist
 description: Expert in restructuring and optimizing Filament PHP admin interfaces for maximum usability and efficiency. Focuses on impactful structural changes — not just cosmetic tweaks.
-color: indigo
+color: "#4B0082"
 emoji: 🔧
 vibe: Pragmatic perfectionist — streamlines complex admin environments.
 ---

--- a/engineering/engineering-frontend-developer.md
+++ b/engineering/engineering-frontend-developer.md
@@ -1,7 +1,7 @@
 ---
 name: Frontend Developer
 description: Expert frontend developer specializing in modern web technologies, React/Vue/Angular frameworks, UI implementation, and performance optimization
-color: cyan
+color: "#00FFFF"
 emoji: 🖥️
 vibe: Builds responsive, accessible web apps with pixel-perfect precision.
 ---

--- a/engineering/engineering-gaussdb-expert.md
+++ b/engineering/engineering-gaussdb-expert.md
@@ -1,7 +1,7 @@
 ---
 name: GaussDB Expert Engineer
 description: Expert database specialist focusing on GaussDB OLTP — Huawei's self-developed enterprise-grade relational database (NOT GaussDB(DWS) OLAP, NOT GaussDB(for openGauss) cloud service, NOT GaussDB(for MySQL)). Covers schema design, distributed table design, query optimization, indexing, Ustore engine, and performance tuning for both distributed and centralized deployments.
-color: amber
+color: "#FFBF00"
 emoji: 🗄️
 vibe: Distribution keys, CN/DN query plans, Ustore engine — GaussDB databases that don't wake you at 3am.
 ---

--- a/engineering/engineering-git-workflow-master.md
+++ b/engineering/engineering-git-workflow-master.md
@@ -1,7 +1,7 @@
 ---
 name: Git Workflow Master
 description: Expert in Git workflows, branching strategies, and version control best practices including conventional commits, rebasing, worktrees, and CI-friendly branch management.
-color: orange
+color: "#FFA500"
 emoji: 🌿
 vibe: Clean history, atomic commits, and branches that tell a story.
 ---

--- a/engineering/engineering-it-service-manager.md
+++ b/engineering/engineering-it-service-manager.md
@@ -2,7 +2,7 @@
 name: IT Service Manager
 emoji: 🖧
 description: Expert IT service management specialist using ITIL 4 framework for service catalog design, incident and problem management, change control, SLA governance, CMDB maintenance, and continual service improvement — ensuring IT delivers reliable, measurable business value across any organization size
-color: blue
+color: "#0000FF"
 vibe: IT exists to serve the business — not the other way around. Every ticket, every SLA, every change window is a promise made to the people who depend on technology to do their jobs. Keep the promises. Measure everything. Improve continuously.
 ---
 

--- a/engineering/engineering-knowledge-graph-engineer.md
+++ b/engineering/engineering-knowledge-graph-engineer.md
@@ -2,7 +2,7 @@
 name: Knowledge Graph Engineer
 emoji: 🧠
 description: Structures information and capabilities into interconnected nodes (entities) and edges (relationships) — enabling dynamic context navigation, modular competency chaining, lower token costs, and hallucination reduction.
-color: violet
+color: "#8F00FF"
 vibe: Flat files are dead. Every piece of information is a node; every relationship is an edge. Navigate the graph, not the noise.
 ---
 

--- a/engineering/engineering-minimal-change-engineer.md
+++ b/engineering/engineering-minimal-change-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: Minimal Change Engineer
 description: Engineering specialist focused on minimum-viable diffs — fixes only what was asked, refuses scope creep, prefers three similar lines over a premature abstraction. The discipline that prevents bug-fix PRs from becoming refactor avalanches.
-color: slate
+color: "#708090"
 emoji: 🪡
 vibe: The smallest diff that solves the problem — every extra line is a liability.
 ---

--- a/engineering/engineering-mobile-app-builder.md
+++ b/engineering/engineering-mobile-app-builder.md
@@ -1,7 +1,7 @@
 ---
 name: Mobile App Builder
 description: Specialized mobile application developer with expertise in native iOS/Android development and cross-platform frameworks
-color: purple
+color: "#800080"
 emoji: 📲
 vibe: Ships native-quality apps on iOS and Android, fast.
 ---

--- a/engineering/engineering-multi-agent-systems-architect.md
+++ b/engineering/engineering-multi-agent-systems-architect.md
@@ -2,7 +2,7 @@
 name: Multi-Agent Systems Architect
 emoji: 🕸️
 description: Systems architect specializing in the design, coordination, and governance of multi-agent AI pipelines — covering topology selection, context management, inter-agent trust, failure recovery, human-in-the-loop gating, and observability for production-grade agent systems.
-color: cyan
+color: "#00FFFF"
 vibe: Treats a team of AI agents like a distributed system — if it only survives the demo and not production load, ambiguous inputs, and cascading failures, it isn't architecture yet.
 ---
 

--- a/engineering/engineering-orgscript-engineer.md
+++ b/engineering/engineering-orgscript-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: OrgScript Engineer
 description: Expert in designing, parsing, and implementing OrgScript grammar, AST validation, and business logic definitions.
-color: green
+color: "#008000"
 emoji: 📜
 vibe: Process-oriented, strict on semantics, focused on turning human processes into AI-friendly logic.
 ---

--- a/engineering/engineering-prompt-engineer.md
+++ b/engineering/engineering-prompt-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: Prompt Engineer
 description: Specialist in crafting, testing, and systematically optimizing prompts for LLMs — turning vague instructions into reliable, production-grade AI behaviors.
-color: violet
+color: "#8F00FF"
 emoji: 🧬
 vibe: I don't write prompts, I write contracts between humans and models.
 ---

--- a/engineering/engineering-rapid-prototyper.md
+++ b/engineering/engineering-rapid-prototyper.md
@@ -1,7 +1,7 @@
 ---
 name: Rapid Prototyper
 description: Specialized in ultra-fast proof-of-concept development and MVP creation using efficient tools and frameworks
-color: green
+color: "#008000"
 emoji: ⚡
 vibe: Turns an idea into a working prototype before the meeting's over.
 ---

--- a/engineering/engineering-section-508-specialist.md
+++ b/engineering/engineering-section-508-specialist.md
@@ -2,7 +2,7 @@
 name: Section 508 Accessibility Specialist
 emoji: ♿
 description: Expert U.S. federal Section 508 accessibility engineer (the 508 legal baseline is WCAG 2.0 Level AA; WCAG 2.1/2.2 AA are recommended best practice, and ADA Title II requires WCAG 2.1 AA for state/local government) specializing in accessible web development, ARIA implementation, screen reader testing (JAWS/NVDA/VoiceOver), keyboard navigation, color contrast, accessible forms and PDFs, VPAT/ACR authoring, automated and manual auditing (axe/WAVE/Lighthouse), and remediation for government and enterprise sites
-color: blue
+color: "#0000FF"
 vibe: A meticulous accessibility engineer who makes sure every user — regardless of ability — can perceive, navigate, understand, and operate a site, holding the line on the Section 508 legal baseline of WCAG 2.0 Level AA while targeting WCAG 2.1/2.2 AA as best practice (and WCAG 2.1 AA where ADA Title II applies to state and local government), testing with real assistive technology instead of trusting a green automated score, because the 30% of barriers a scanner can't catch are exactly the ones that lock a screen reader user out of a government service they have a legal right to use.
 ---
 

--- a/engineering/engineering-senior-developer.md
+++ b/engineering/engineering-senior-developer.md
@@ -1,7 +1,7 @@
 ---
 name: Senior Developer
 description: Premium implementation specialist - Masters Laravel/Livewire/FluxUI, advanced CSS, Three.js integration
-color: green
+color: "#008000"
 emoji: 💎
 vibe: Premium full-stack craftsperson — Laravel, Livewire, Three.js, advanced CSS.
 ---

--- a/engineering/engineering-software-architect.md
+++ b/engineering/engineering-software-architect.md
@@ -1,7 +1,7 @@
 ---
 name: Software Architect
 description: Expert software architect specializing in system design, domain-driven design, architectural patterns, and technical decision-making for scalable, maintainable systems.
-color: indigo
+color: "#4B0082"
 emoji: 🏛️
 vibe: Designs systems that survive the team that built them. Every decision has a trade-off — name it.
 ---

--- a/engineering/engineering-solidity-smart-contract-engineer.md
+++ b/engineering/engineering-solidity-smart-contract-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: Solidity Smart Contract Engineer
 description: Expert Solidity developer specializing in EVM smart contract architecture, gas optimization, upgradeable proxy patterns, DeFi protocol development, and security-first contract design across Ethereum and L2 chains.
-color: orange
+color: "#FFA500"
 emoji: ⛓️
 vibe: Battle-hardened Solidity developer who lives and breathes the EVM.
 ---

--- a/engineering/engineering-technical-writer.md
+++ b/engineering/engineering-technical-writer.md
@@ -1,7 +1,7 @@
 ---
 name: Technical Writer
 description: Expert technical writer specializing in developer documentation, API references, README files, and tutorials. Transforms complex engineering concepts into clear, accurate, and engaging docs that developers actually read and use.
-color: teal
+color: "#008080"
 emoji: 📚
 vibe: Writes the docs that developers actually read and use.
 ---

--- a/engineering/engineering-uswds-developer.md
+++ b/engineering/engineering-uswds-developer.md
@@ -2,7 +2,7 @@
 name: USWDS Developer
 emoji: 🏛️
 description: Expert U.S. Web Design System frontend developer specializing in USWDS components and design tokens, accessible-by-default patterns, responsive government UI, Sass settings/theming, the federal design language, integration into CMS platforms (Drupal/WordPress), and compliance with 21st Century IDEA and the Federal Website Standards
-color: blue
+color: "#0000FF"
 vibe: A government-focused frontend developer who builds trustworthy, accessible, consistent federal interfaces with the U.S. Web Design System — theming through design tokens and Sass settings instead of overriding the framework, reaching for the maintained USWDS component before hand-rolling a custom one, and treating accessibility and 21st Century IDEA conformance as the baseline rather than a later phase, because a federal site that looks official but locks users out has failed the public it exists to serve.
 ---
 

--- a/engineering/engineering-voice-ai-integration-engineer.md
+++ b/engineering/engineering-voice-ai-integration-engineer.md
@@ -2,7 +2,7 @@
 name: Voice AI Integration Engineer
 emoji: 🎙️
 description: Expert in building end-to-end speech transcription pipelines using Whisper-style models and cloud ASR services — from raw audio ingestion through preprocessing, transcript cleanup, subtitle generation, speaker diarization, and structured downstream integration into apps, APIs, and CMS platforms.
-color: violet
+color: "#8F00FF"
 vibe: Turns raw audio into structured, production-ready text that machines and humans can actually use.
 ---
 

--- a/engineering/engineering-wechat-mini-program-developer.md
+++ b/engineering/engineering-wechat-mini-program-developer.md
@@ -1,7 +1,7 @@
 ---
 name: WeChat Mini Program Developer
 description: Expert WeChat Mini Program developer specializing in 小程序 development with WXML/WXSS/WXS, WeChat API integration, payment systems, subscription messaging, and the full WeChat ecosystem.
-color: green
+color: "#008000"
 emoji: 💬
 vibe: Builds performant Mini Programs that thrive in the WeChat ecosystem.
 ---

--- a/engineering/engineering-wordpress-performance.md
+++ b/engineering/engineering-wordpress-performance.md
@@ -2,7 +2,7 @@
 name: WordPress Performance Engineer
 emoji: ⚡
 description: Expert WordPress performance engineer specializing in Core Web Vitals, object caching (Redis/Memcached), page caching, database and WP_Query optimization, the Transients API, asset minification/deferral/critical CSS, image optimization and lazy loading, CDN integration, plugin performance auditing, and PHP-FPM/opcache tuning for fast, audit-passing sites
-color: purple
+color: "#800080"
 vibe: A pragmatic WordPress performance engineer who turns sluggish sites into fast, Core-Web-Vitals-passing storefronts through smart caching and query discipline — profiling with Query Monitor before touching anything, killing the autoloaded-options bloat and the plugin that fires forty queries per request, layering object cache and page cache and CDN so they reinforce instead of fight, and refusing to call a page done until it loads fast on a real phone, because a plugin-heavy site that looks fine on the developer's fiber connection is still losing the customer on 4G.
 ---
 

--- a/engineering/engineering-wordpress-shopping-cart.md
+++ b/engineering/engineering-wordpress-shopping-cart.md
@@ -2,7 +2,7 @@
 name: WordPress Shopping Cart Engineer
 emoji: 🛍️
 description: Expert WordPress e-commerce engineer specializing in WooCommerce for product catalog management, payment gateway integration, checkout customization, order management, tax and coupon configuration, and conversion-optimized storefront delivery on WordPress
-color: purple
+color: "#800080"
 vibe: A pragmatic WordPress commerce engineer who turns WooCommerce into powerful, conversion-optimized storefronts — shipping fast without shipping fragile, customizing through hooks instead of hacking core, keeping the checkout fast and frictionless on real phones, and treating every order, payment, and tax line as money that has to reconcile, because a storefront that converts but miscounts is worse than one that never launched.
 ---
 

--- a/finance/finance-bookkeeper-controller.md
+++ b/finance/finance-bookkeeper-controller.md
@@ -1,7 +1,7 @@
 ---
 name: Bookkeeper & Controller
 description: Expert bookkeeper and controller specializing in day-to-day accounting operations, financial reconciliations, month-end close processes, and internal controls. Ensures the accuracy, completeness, and timeliness of financial records while maintaining GAAP compliance and audit readiness at all times.
-color: green
+color: "#008000"
 emoji: 📒
 vibe: Every penny accounted for, every close on time — the backbone of financial trust.
 ---

--- a/finance/finance-financial-analyst.md
+++ b/finance/finance-financial-analyst.md
@@ -1,7 +1,7 @@
 ---
 name: Financial Analyst
 description: Expert financial analyst specializing in financial modeling, forecasting, scenario analysis, and data-driven decision support. Transforms raw financial data into actionable business intelligence that drives strategic planning, investment decisions, and operational optimization.
-color: green
+color: "#008000"
 emoji: 📊
 vibe: Turns spreadsheets into strategy — every number tells a story, every model drives a decision.
 ---

--- a/finance/finance-fpa-analyst.md
+++ b/finance/finance-fpa-analyst.md
@@ -1,7 +1,7 @@
 ---
 name: FP&A Analyst
 description: Expert Financial Planning & Analysis (FP&A) analyst specializing in budgeting, variance analysis, financial planning, rolling forecasts, and strategic decision support. Bridges the gap between the numbers and the business narrative to drive operational performance and strategic resource allocation.
-color: green
+color: "#008000"
 emoji: 📈
 vibe: The budget whisperer — turns plans into numbers and numbers into action.
 ---

--- a/finance/finance-investment-researcher.md
+++ b/finance/finance-investment-researcher.md
@@ -1,7 +1,7 @@
 ---
 name: Investment Researcher
 description: Expert investment researcher specializing in market research, due diligence, portfolio analysis, and asset valuation. Conducts rigorous fundamental and quantitative analysis to identify investment opportunities, assess risks, and support data-driven portfolio decisions across public equities, private markets, and alternative assets.
-color: green
+color: "#008000"
 emoji: 🔍
 vibe: Digs deeper than the consensus — finds alpha in the footnotes and risks in the narratives.
 ---

--- a/finance/finance-tax-strategist.md
+++ b/finance/finance-tax-strategist.md
@@ -1,7 +1,7 @@
 ---
 name: Tax Strategist
 description: Expert tax strategist specializing in tax optimization, multi-jurisdictional compliance, transfer pricing, and strategic tax planning. Navigates complex tax codes to minimize liability while ensuring full regulatory compliance across local, state, federal, and international tax regimes.
-color: green
+color: "#008000"
 emoji: 🏛️
 vibe: Finds every legal dollar of savings in the tax code — compliance is the floor, optimization is the mission.
 ---

--- a/game-development/blender/blender-addon-engineer.md
+++ b/game-development/blender/blender-addon-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: Blender Add-on Engineer
 description: Blender tooling specialist - Builds Python add-ons, asset validators, exporters, and pipeline automations that turn repetitive DCC work into reliable one-click workflows
-color: blue
+color: "#0000FF"
 emoji: 🧩
 vibe: Turns repetitive Blender pipeline work into reliable one-click tools that artists actually use.
 ---

--- a/game-development/economy-designer.md
+++ b/game-development/economy-designer.md
@@ -1,7 +1,7 @@
 ---
 name: Economy Designer
 description: Virtual economy architect - Masters currency systems, sources and sinks, monetization modeling, inflation control, and data-driven economic balancing for live games
-color: green
+color: "#008000"
 emoji: 💰
 vibe: Sees every game as a flow of currencies, and every player decision as a transaction.
 ---

--- a/game-development/game-audio-engineer.md
+++ b/game-development/game-audio-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: Game Audio Engineer
 description: Interactive audio specialist - Masters FMOD/Wwise integration, adaptive music systems, spatial audio, and audio performance budgeting across all game engines
-color: indigo
+color: "#4B0082"
 emoji: 🎵
 vibe: Makes every gunshot, footstep, and musical cue feel alive in the game world.
 ---

--- a/game-development/game-designer.md
+++ b/game-development/game-designer.md
@@ -1,7 +1,7 @@
 ---
 name: Game Designer
 description: Systems and mechanics architect - Masters GDD authorship, player psychology, economy balancing, and gameplay loop design across all engines and genres
-color: yellow
+color: "#FFFF00"
 emoji: 🎮
 vibe: Thinks in loops, levers, and player motivations to architect compelling gameplay.
 ---

--- a/game-development/godot/godot-gameplay-scripter.md
+++ b/game-development/godot/godot-gameplay-scripter.md
@@ -1,7 +1,7 @@
 ---
 name: Godot Gameplay Scripter
 description: Composition and signal integrity specialist - Masters GDScript 2.0, C# integration, node-based architecture, and type-safe signal design for Godot 4 projects
-color: purple
+color: "#800080"
 emoji: 🎯
 vibe: Builds Godot 4 gameplay systems with the discipline of a software architect.
 ---

--- a/game-development/godot/godot-multiplayer-engineer.md
+++ b/game-development/godot/godot-multiplayer-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: Godot Multiplayer Engineer
 description: Godot 4 networking specialist - Masters the MultiplayerAPI, scene replication, ENet/WebRTC transport, RPCs, and authority models for real-time multiplayer games
-color: violet
+color: "#8F00FF"
 emoji: 🌐
 vibe: Masters Godot's MultiplayerAPI to make real-time netcode feel seamless.
 ---

--- a/game-development/godot/godot-shader-developer.md
+++ b/game-development/godot/godot-shader-developer.md
@@ -1,7 +1,7 @@
 ---
 name: Godot Shader Developer
 description: Godot 4 visual effects specialist - Masters the Godot Shading Language (GLSL-like), VisualShader editor, CanvasItem and Spatial shaders, post-processing, and performance optimization for 2D/3D effects
-color: purple
+color: "#800080"
 emoji: 💎
 vibe: Bends light and pixels through Godot's shading language to create stunning effects.
 ---

--- a/game-development/level-designer.md
+++ b/game-development/level-designer.md
@@ -1,7 +1,7 @@
 ---
 name: Level Designer
 description: Spatial storytelling and flow specialist - Masters layout theory, pacing architecture, encounter design, and environmental narrative across all game engines
-color: teal
+color: "#008080"
 emoji: 🗺️
 vibe: Treats every level as an authored experience where space tells the story.
 ---

--- a/game-development/narrative-designer.md
+++ b/game-development/narrative-designer.md
@@ -1,7 +1,7 @@
 ---
 name: Narrative Designer
 description: Story systems and dialogue architect - Masters GDD-aligned narrative design, branching dialogue, lore architecture, and environmental storytelling across all game engines
-color: red
+color: "#FF0000"
 emoji: 📖
 vibe: Architects story systems where narrative and gameplay are inseparable.
 ---

--- a/game-development/roblox-studio/roblox-avatar-creator.md
+++ b/game-development/roblox-studio/roblox-avatar-creator.md
@@ -1,7 +1,7 @@
 ---
 name: Roblox Avatar Creator
 description: Roblox UGC and avatar pipeline specialist - Masters Roblox's avatar system, UGC item creation, accessory rigging, texture standards, and the Creator Marketplace submission pipeline
-color: fuchsia
+color: "#FF00FF"
 emoji: 👤
 vibe: Masters the UGC pipeline from rigging to Creator Marketplace submission.
 ---

--- a/game-development/roblox-studio/roblox-experience-designer.md
+++ b/game-development/roblox-studio/roblox-experience-designer.md
@@ -1,7 +1,7 @@
 ---
 name: Roblox Experience Designer
 description: Roblox platform UX and monetization specialist - Masters engagement loop design, DataStore-driven progression, Roblox monetization systems (Passes, Developer Products, UGC), and player retention for Roblox experiences
-color: lime
+color: "#00FF00"
 emoji: 🎪
 vibe: Designs engagement loops and monetization systems that keep players coming back.
 ---

--- a/game-development/roblox-studio/roblox-systems-scripter.md
+++ b/game-development/roblox-studio/roblox-systems-scripter.md
@@ -1,7 +1,7 @@
 ---
 name: Roblox Systems Scripter
 description: Roblox platform engineering specialist - Masters Luau, the client-server security model, RemoteEvents/RemoteFunctions, DataStore, and module architecture for scalable Roblox experiences
-color: rose
+color: "#FF007F"
 emoji: 🔧
 vibe: Builds scalable Roblox experiences with rock-solid Luau and client-server security.
 ---

--- a/game-development/technical-artist.md
+++ b/game-development/technical-artist.md
@@ -1,7 +1,7 @@
 ---
 name: Technical Artist
 description: Art-to-engine pipeline specialist - Masters shaders, VFX systems, LOD pipelines, performance budgeting, and cross-engine asset optimization
-color: pink
+color: "#FFC0CB"
 emoji: 🎨
 vibe: The bridge between artistic vision and engine reality.
 ---

--- a/game-development/unity/unity-architect.md
+++ b/game-development/unity/unity-architect.md
@@ -1,7 +1,7 @@
 ---
 name: Unity Architect
 description: Data-driven modularity specialist - Masters ScriptableObjects, decoupled systems, and single-responsibility component design for scalable Unity projects
-color: blue
+color: "#0000FF"
 emoji: 🏛️
 vibe: Designs data-driven, decoupled Unity systems that scale without spaghetti.
 ---

--- a/game-development/unity/unity-editor-tool-developer.md
+++ b/game-development/unity/unity-editor-tool-developer.md
@@ -1,7 +1,7 @@
 ---
 name: Unity Editor Tool Developer
 description: Unity editor automation specialist - Masters custom EditorWindows, PropertyDrawers, AssetPostprocessors, ScriptedImporters, and pipeline automation that saves teams hours per week
-color: gray
+color: "#808080"
 emoji: 🛠️
 vibe: Builds custom Unity editor tools that save teams hours every week.
 ---

--- a/game-development/unity/unity-multiplayer-engineer.md
+++ b/game-development/unity/unity-multiplayer-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: Unity Multiplayer Engineer
 description: Networked gameplay specialist - Masters Netcode for GameObjects, Unity Gaming Services (Relay/Lobby), client-server authority, lag compensation, and state synchronization
-color: blue
+color: "#0000FF"
 emoji: 🔗
 vibe: Makes networked Unity gameplay feel local through smart sync and prediction.
 ---

--- a/game-development/unity/unity-shader-graph-artist.md
+++ b/game-development/unity/unity-shader-graph-artist.md
@@ -1,7 +1,7 @@
 ---
 name: Unity Shader Graph Artist
 description: Visual effects and material specialist - Masters Unity Shader Graph, HLSL, URP/HDRP rendering pipelines, and custom pass authoring for real-time visual effects
-color: cyan
+color: "#00FFFF"
 emoji: ✨
 vibe: Crafts real-time visual magic through Shader Graph and custom render passes.
 ---

--- a/game-development/unreal-engine/unreal-multiplayer-architect.md
+++ b/game-development/unreal-engine/unreal-multiplayer-architect.md
@@ -1,7 +1,7 @@
 ---
 name: Unreal Multiplayer Architect
 description: Unreal Engine networking specialist - Masters Actor replication, GameMode/GameState architecture, server-authoritative gameplay, network prediction, and dedicated server setup for UE5
-color: red
+color: "#FF0000"
 emoji: 🌐
 vibe: Architects server-authoritative Unreal multiplayer that feels lag-free.
 ---

--- a/game-development/unreal-engine/unreal-systems-engineer.md
+++ b/game-development/unreal-engine/unreal-systems-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: Unreal Systems Engineer
 description: Performance and hybrid architecture specialist - Masters C++/Blueprint continuum, Nanite geometry, Lumen GI, and Gameplay Ability System for AAA-grade Unreal Engine projects
-color: orange
+color: "#FFA500"
 emoji: ⚙️
 vibe: Masters the C++/Blueprint continuum for AAA-grade Unreal Engine projects.
 ---

--- a/game-development/unreal-engine/unreal-technical-artist.md
+++ b/game-development/unreal-engine/unreal-technical-artist.md
@@ -1,7 +1,7 @@
 ---
 name: Unreal Technical Artist
 description: Unreal Engine visual pipeline specialist - Masters the Material Editor, Niagara VFX, Procedural Content Generation, and the art-to-engine pipeline for UE5 projects
-color: orange
+color: "#FFA500"
 emoji: 🎨
 vibe: Bridges Niagara VFX, Material Editor, and PCG into polished UE5 visuals.
 ---

--- a/game-development/unreal-engine/unreal-world-builder.md
+++ b/game-development/unreal-engine/unreal-world-builder.md
@@ -1,7 +1,7 @@
 ---
 name: Unreal World Builder
 description: Open-world and environment specialist - Masters UE5 World Partition, Landscape, procedural foliage, HLOD, and large-scale level streaming for seamless open-world experiences
-color: green
+color: "#008000"
 emoji: 🌍
 vibe: Builds seamless open worlds with World Partition, Nanite, and procedural foliage.
 ---

--- a/gis/gis-3d-scene-developer.md
+++ b/gis/gis-3d-scene-developer.md
@@ -1,7 +1,7 @@
 ---
 name: 3D & Scene Developer
 description: Web 3D visualization specialist who creates immersive 3D scenes, terrain models, point cloud visualizations, and interactive web experiences using Cesium, ArcGIS Scene Viewer, and modern 3D web frameworks.
-color: cyan
+color: "#00FFFF"
 emoji: 🏔️
 vibe: Bringing the third dimension to the web — one scene at a time.
 ---

--- a/gis/gis-analyst.md
+++ b/gis/gis-analyst.md
@@ -1,7 +1,7 @@
 ---
 name: GIS Analyst
 description: Day-to-day GIS operator who creates maps, manages layers, performs spatial queries, and maintains geospatial data integrity across desktop and web environments.
-color: teal
+color: "#008080"
 emoji: 🖥️
 vibe: The reliable hands-on operator who keeps the GIS running day to day.
 ---

--- a/gis/gis-bim-specialist.md
+++ b/gis/gis-bim-specialist.md
@@ -1,7 +1,7 @@
 ---
 name: BIM/GIS Specialist
 description: Integration specialist who bridges Building Information Modeling and Geographic Information Systems — Revit/IFC data conversion, indoor mapping, digital twin architecture, and facility management data models.
-color: gold
+color: "#FFD700"
 emoji: 🏗️
 vibe: Where buildings meet geography — the spatial side of the built world.
 ---

--- a/gis/gis-cartography-designer.md
+++ b/gis/gis-cartography-designer.md
@@ -1,7 +1,7 @@
 ---
 name: Cartography Designer
 description: Map aesthetics specialist who designs beautiful, readable, and effective maps — color theory, typography, label placement, basemap selection, and visual hierarchy for both print and web.
-color: pink
+color: "#FFC0CB"
 emoji: 🎨
 vibe: A map that communicates beautifully is a map that gets used.
 ---

--- a/gis/gis-drone-reality-mapping.md
+++ b/gis/gis-drone-reality-mapping.md
@@ -1,7 +1,7 @@
 ---
 name: Drone/Reality Mapping Specialist
 description: Photogrammetry and reality capture expert who processes drone imagery into orthomosaics, digital terrain models, point clouds, and 3D meshes — bridging field capture and GIS-ready products.
-color: amber
+color: "#FFBF00"
 emoji: 🛸
 vibe: From raw drone footage to production-ready GIS data — seamless.
 ---

--- a/gis/gis-geoai-ml-engineer.md
+++ b/gis/gis-geoai-ml-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: GeoAI/ML Engineer
 description: Geospatial machine learning specialist who builds models for feature extraction, object detection, image segmentation, and land cover classification from satellite and aerial imagery.
-color: green
+color: "#008000"
 emoji: 🤖
 vibe: Teaching machines to see the Earth — one pixel at a time.
 ---

--- a/gis/gis-geoprocessing-specialist.md
+++ b/gis/gis-geoprocessing-specialist.md
@@ -1,7 +1,7 @@
 ---
 name: Geoprocessing Specialist
 description: ArcPy and Python toolbox expert who automates spatial workflows — builds .pyt toolboxes, Model Builder processes, batch geoprocessing automation, and custom analysis scripts for ArcGIS Pro.
-color: red
+color: "#FF0000"
 emoji: ⚙️
 vibe: If you've done it manually more than twice, this agent will automate it.
 ---

--- a/gis/gis-qa-engineer.md
+++ b/gis/gis-qa-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: GIS QA Engineer
 description: Quality assurance specialist who validates geospatial data integrity — topology checks, metadata audits, CRS consistency, accuracy assessment, and compliance verification.
-color: purple
+color: "#800080"
 emoji: ✅
 vibe: Data doesn't ship until QA says it ships.
 ---

--- a/gis/gis-solution-engineer.md
+++ b/gis/gis-solution-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: Solution Engineer
 description: Hands-on GIS prototype builder who takes strategy from Technical Consultant and turns it into working demos, proof-of-concepts, and technical validations across the full Esri and open-source stack.
-color: blue
+color: "#0000FF"
 emoji: 🔧
 vibe: The builder who makes strategy real — one working demo at a time.
 ---

--- a/gis/gis-spatial-data-engineer.md
+++ b/gis/gis-spatial-data-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: Spatial Data Engineer
 description: ETL specialist who transforms messy geospatial data from any source into clean, standardized, production-ready datasets — format conversion, CRS reprojection, attribute normalization, and automated pipelines.
-color: orange
+color: "#FFA500"
 emoji: 📦
 vibe: Data comes in dirty. It leaves clean, documented, and ready to publish.
 ---

--- a/gis/gis-spatial-data-scientist.md
+++ b/gis/gis-spatial-data-scientist.md
@@ -1,7 +1,7 @@
 ---
 name: Spatial Data Scientist
 description: Advanced spatial analytics specialist who applies statistical modeling, spatial econometrics, clustering, and predictive analytics to geospatial data — finding patterns that aren't visible on a map.
-color: indigo
+color: "#4B0082"
 emoji: 📊
 vibe: Finding the patterns in space that even experienced analysts miss.
 ---

--- a/gis/gis-technical-consultant.md
+++ b/gis/gis-technical-consultant.md
@@ -1,7 +1,7 @@
 ---
 name: Technical Consultant
 description: Strategic GIS advisor who translates business problems into geospatial solutions — gap analysis, technology roadmaps, RFP responses, and digital transformation strategy across Esri and open-source ecosystems.
-color: navy
+color: "#000080"
 emoji: 🧠
 vibe: The strategist who connects business pain points with geospatial solutions that actually deliver ROI.
 ---

--- a/gis/gis-web-gis-developer.md
+++ b/gis/gis-web-gis-developer.md
@@ -1,7 +1,7 @@
 ---
 name: Web GIS Developer
 description: Full-stack web GIS engineer who builds interactive mapping applications — MapLibre GL JS, ArcGIS JS API, Leaflet, real-time dashboards, REST API integration, and geospatial web services.
-color: blue
+color: "#0000FF"
 emoji: 🌐
 vibe: Maps on the web that actually work — fast, responsive, and beautiful.
 ---

--- a/marketing/marketing-app-store-optimizer.md
+++ b/marketing/marketing-app-store-optimizer.md
@@ -1,7 +1,7 @@
 ---
 name: App Store Optimizer
 description: Expert app store marketing specialist focused on App Store Optimization (ASO), conversion rate optimization, and app discoverability
-color: blue
+color: "#0000FF"
 emoji: 📱
 vibe: Gets your app found, downloaded, and loved in the store.
 ---

--- a/marketing/marketing-baidu-seo-specialist.md
+++ b/marketing/marketing-baidu-seo-specialist.md
@@ -1,7 +1,7 @@
 ---
 name: Baidu SEO Specialist
 description: Expert Baidu search optimization specialist focused on Chinese search engine ranking, Baidu ecosystem integration, ICP compliance, Chinese keyword research, and mobile-first indexing for the China market.
-color: blue
+color: "#0000FF"
 emoji: 🇨🇳
 vibe: Masters Baidu's algorithm so your brand ranks in China's search ecosystem.
 ---

--- a/marketing/marketing-bilibili-content-strategist.md
+++ b/marketing/marketing-bilibili-content-strategist.md
@@ -1,7 +1,7 @@
 ---
 name: Bilibili Content Strategist
 description: Expert Bilibili marketing specialist focused on UP主 growth, danmaku culture mastery, B站 algorithm optimization, community building, and branded content strategy for China's leading video community platform.
-color: pink
+color: "#FFC0CB"
 emoji: 🎬
 vibe: Speaks fluent danmaku and grows your brand on B站.
 ---

--- a/marketing/marketing-china-ecommerce-operator.md
+++ b/marketing/marketing-china-ecommerce-operator.md
@@ -1,7 +1,7 @@
 ---
 name: China E-Commerce Operator
 description: Expert China e-commerce operations specialist covering Taobao, Tmall, Pinduoduo, and JD ecosystems with deep expertise in product listing optimization, live commerce, store operations, 618/Double 11 campaigns, and cross-platform strategy.
-color: red
+color: "#FF0000"
 emoji: 🛒
 vibe: Runs your Taobao, Tmall, Pinduoduo, and JD storefronts like a native operator.
 ---

--- a/marketing/marketing-content-creator.md
+++ b/marketing/marketing-content-creator.md
@@ -1,8 +1,7 @@
 ---
 name: Content Creator
 description: Expert content strategist and creator for multi-platform campaigns. Develops editorial calendars, creates compelling copy, manages brand storytelling, and optimizes content for engagement across all digital channels.
-tools: WebFetch, WebSearch, Read, Write, Edit
-color: teal
+color: "#008080"
 emoji: ✍️
 vibe: Crafts compelling stories across every platform your audience lives on.
 ---

--- a/marketing/marketing-cross-border-ecommerce.md
+++ b/marketing/marketing-cross-border-ecommerce.md
@@ -1,7 +1,7 @@
 ---
 name: Cross-Border E-Commerce Specialist
 description: Full-funnel cross-border e-commerce strategist covering Amazon, Shopee, Lazada, AliExpress, Temu, and TikTok Shop operations, international logistics and overseas warehousing, compliance and taxation, multilingual listing optimization, brand globalization, and DTC independent site development.
-color: blue
+color: "#0000FF"
 emoji: 🌏
 vibe: Takes your products from Chinese factories to global bestseller lists.
 ---

--- a/marketing/marketing-email-strategist.md
+++ b/marketing/marketing-email-strategist.md
@@ -1,7 +1,7 @@
 ---
 name: Email Marketing Strategist
 description: Expert email marketing strategist for CRM-driven campaigns, lifecycle automation, segmentation architecture, and deliverability. Designs sequences (welcome, nurture, reactivation, win-back, review, referral) grounded in 2025-2026 benchmarks, AI-driven personalization, and post-Apple MPP measurement.
-color: green
+color: "#008000"
 emoji: 📧
 vibe: Turns a messy contact list into a segmented, automated revenue engine that sends the right message at the right time.
 ---

--- a/marketing/marketing-global-podcast-strategist.md
+++ b/marketing/marketing-global-podcast-strategist.md
@@ -1,7 +1,7 @@
 ---
 name: Global Podcast Strategist
 description: Expert podcast growth specialist focused on show positioning, audience development, content strategy, and monetisation. Transforms raw ideas into authoritative audio brands that compound listeners and revenue over time on Spotify, Apple Podcasts, and YouTube.
-color: purple
+color: "#800080"
 emoji: 🎙️
 vibe: Turns conversations into communities and episodes into growth engines.
 ---

--- a/marketing/marketing-growth-hacker.md
+++ b/marketing/marketing-growth-hacker.md
@@ -1,8 +1,7 @@
 ---
 name: Growth Hacker
 description: Expert growth strategist specializing in rapid user acquisition through data-driven experimentation. Develops viral loops, optimizes conversion funnels, and finds scalable growth channels for exponential business growth.
-tools: WebFetch, WebSearch, Read, Write, Edit
-color: green
+color: "#008000"
 emoji: 🚀
 vibe: Finds the growth channel nobody's exploited yet — then scales it.
 ---

--- a/marketing/marketing-kuaishou-strategist.md
+++ b/marketing/marketing-kuaishou-strategist.md
@@ -1,7 +1,7 @@
 ---
 name: Kuaishou Strategist
 description: Expert Kuaishou marketing strategist specializing in short-video content for China's lower-tier city markets, live commerce operations, community trust building, and grassroots audience growth on 快手.
-color: orange
+color: "#FFA500"
 emoji: 🎥
 vibe: Grows grassroots audiences and drives live commerce on 快手.
 ---

--- a/marketing/marketing-podcast-strategist.md
+++ b/marketing/marketing-podcast-strategist.md
@@ -1,7 +1,7 @@
 ---
 name: Podcast Strategist
 description: Content strategy and operations expert for the Chinese podcast market, with deep expertise in Xiaoyuzhou, Ximalaya, and other major audio platforms, covering show positioning, audio production, audience growth, multi-platform distribution, and monetization to help podcast creators build sticky audio content brands.
-color: purple
+color: "#800080"
 emoji: 🎧
 vibe: Guides your podcast from concept to loyal audience in China's booming audio scene.
 ---

--- a/marketing/marketing-pr-communications-manager.md
+++ b/marketing/marketing-pr-communications-manager.md
@@ -2,7 +2,7 @@
 name: PR & Communications Manager
 emoji: 📣
 description: Strategic public relations and communications specialist for media relations, press releases, crisis communications, executive thought leadership, brand reputation management, and integrated communications planning — building and protecting reputations through earned media, storytelling, and proactive narrative control
-color: blue
+color: "#0000FF"
 vibe: Reputation is built in years and lost in minutes. Every message, every statement, every interview is either protecting or eroding the brand — there is no neutral.
 ---
 

--- a/marketing/marketing-seo-specialist.md
+++ b/marketing/marketing-seo-specialist.md
@@ -1,7 +1,6 @@
 ---
 name: SEO Specialist
 description: Expert search engine optimization strategist specializing in technical SEO, content optimization, link authority building, and organic search growth. Drives sustainable traffic through data-driven search strategies.
-tools: WebFetch, WebSearch, Read, Write, Edit
 color: "#4285F4"
 emoji: 🔍
 vibe: Drives sustainable organic traffic through technical SEO and content strategy.

--- a/marketing/marketing-social-media-strategist.md
+++ b/marketing/marketing-social-media-strategist.md
@@ -1,8 +1,7 @@
 ---
 name: Social Media Strategist
 description: Expert social media strategist for LinkedIn, Twitter, and professional platforms. Creates cross-platform campaigns, builds communities, manages real-time engagement, and develops thought leadership strategies.
-tools: WebFetch, WebSearch, Read, Write, Edit
-color: blue
+color: "#0000FF"
 emoji: 📣
 vibe: Orchestrates cross-platform campaigns that build community and drive engagement.
 ---

--- a/marketing/marketing-video-optimization-specialist.md
+++ b/marketing/marketing-video-optimization-specialist.md
@@ -1,7 +1,7 @@
 ---
 name: Video Optimization Specialist
 description: Video marketing strategist specializing in YouTube algorithm optimization, audience retention, chaptering, thumbnail concepts, and cross-platform video syndication.
-color: red
+color: "#FF0000"
 emoji: 🎬
 vibe: Energetic, data-driven, strategic, and hyper-focused on audience retention
 ---

--- a/paid-media/paid-media-auditor.md
+++ b/paid-media/paid-media-auditor.md
@@ -1,8 +1,7 @@
 ---
 name: Paid Media Auditor
 description: Comprehensive paid media auditor who systematically evaluates Google Ads, Microsoft Ads, and Meta accounts across 200+ checkpoints spanning account structure, tracking, bidding, creative, audiences, and competitive positioning. Produces actionable audit reports with prioritized recommendations and projected impact.
-color: orange
-tools: WebFetch, WebSearch, Read, Write, Edit, Bash
+color: "#FFA500"
 author: John Williams (@itallstartedwithaidea)
 emoji: 📋
 vibe: Finds the waste in your ad spend before your CFO does.

--- a/paid-media/paid-media-creative-strategist.md
+++ b/paid-media/paid-media-creative-strategist.md
@@ -1,8 +1,7 @@
 ---
 name: Ad Creative Strategist
 description: Paid media creative specialist focused on ad copywriting, RSA optimization, asset group design, and creative testing frameworks across Google, Meta, Microsoft, and programmatic platforms. Bridges the gap between performance data and persuasive messaging.
-color: orange
-tools: WebFetch, WebSearch, Read, Write, Edit, Bash
+color: "#FFA500"
 author: John Williams (@itallstartedwithaidea)
 emoji: ✍️
 vibe: Turns ad creative from guesswork into a repeatable science.

--- a/paid-media/paid-media-paid-social-strategist.md
+++ b/paid-media/paid-media-paid-social-strategist.md
@@ -1,8 +1,7 @@
 ---
 name: Paid Social Strategist
 description: Cross-platform paid social advertising specialist covering Meta (Facebook/Instagram), LinkedIn, TikTok, Pinterest, X, and Snapchat. Designs full-funnel social ad programs from prospecting through retargeting with platform-specific creative and audience strategies.
-color: orange
-tools: WebFetch, WebSearch, Read, Write, Edit, Bash
+color: "#FFA500"
 author: John Williams (@itallstartedwithaidea)
 emoji: 📱
 vibe: Makes every dollar on Meta, LinkedIn, and TikTok ads work harder.

--- a/paid-media/paid-media-ppc-strategist.md
+++ b/paid-media/paid-media-ppc-strategist.md
@@ -1,8 +1,7 @@
 ---
 name: PPC Campaign Strategist
 description: Senior paid media strategist specializing in large-scale search, shopping, and performance max campaign architecture across Google, Microsoft, and Amazon ad platforms. Designs account structures, budget allocation frameworks, and bidding strategies that scale from $10K to $10M+ monthly spend.
-color: orange
-tools: WebFetch, WebSearch, Read, Write, Edit, Bash
+color: "#FFA500"
 author: John Williams (@itallstartedwithaidea)
 emoji: 💰
 vibe: Architects PPC campaigns that scale from $10K to $10M+ monthly.

--- a/paid-media/paid-media-programmatic-buyer.md
+++ b/paid-media/paid-media-programmatic-buyer.md
@@ -1,8 +1,7 @@
 ---
 name: Programmatic & Display Buyer
 description: Display advertising and programmatic media buying specialist covering managed placements, Google Display Network, DV360, trade desk platforms, partner media (newsletters, sponsored content), and ABM display strategies via platforms like Demandbase and 6Sense.
-color: orange
-tools: WebFetch, WebSearch, Read, Write, Edit, Bash
+color: "#FFA500"
 author: John Williams (@itallstartedwithaidea)
 emoji: 📺
 vibe: Buys display and video inventory at scale with surgical precision.

--- a/paid-media/paid-media-search-query-analyst.md
+++ b/paid-media/paid-media-search-query-analyst.md
@@ -1,8 +1,7 @@
 ---
 name: Search Query Analyst
 description: Specialist in search term analysis, negative keyword architecture, and query-to-intent mapping. Turns raw search query data into actionable optimizations that eliminate waste and amplify high-intent traffic across paid search accounts.
-color: orange
-tools: WebFetch, WebSearch, Read, Write, Edit, Bash
+color: "#FFA500"
 author: John Williams (@itallstartedwithaidea)
 emoji: 🔍
 vibe: Mines search queries to find the gold your competitors are missing.

--- a/paid-media/paid-media-tracking-specialist.md
+++ b/paid-media/paid-media-tracking-specialist.md
@@ -1,8 +1,7 @@
 ---
 name: Tracking & Measurement Specialist
 description: Expert in conversion tracking architecture, tag management, and attribution modeling across Google Tag Manager, GA4, Google Ads, Meta CAPI, LinkedIn Insight Tag, and server-side implementations. Ensures every conversion is counted correctly and every dollar of ad spend is measurable.
-color: orange
-tools: WebFetch, WebSearch, Read, Write, Edit, Bash
+color: "#FFA500"
 author: John Williams (@itallstartedwithaidea)
 emoji: 📡
 vibe: If it's not tracked correctly, it didn't happen.

--- a/product/product-feedback-synthesizer.md
+++ b/product/product-feedback-synthesizer.md
@@ -1,8 +1,7 @@
 ---
 name: Feedback Synthesizer
 description: Expert in collecting, analyzing, and synthesizing user feedback from multiple channels to extract actionable product insights. Transforms qualitative feedback into quantitative priorities and strategic recommendations.
-color: blue
-tools: WebFetch, WebSearch, Read, Write, Edit
+color: "#0000FF"
 emoji: 🔍
 vibe: Distills a thousand user voices into the five things you need to build next.
 ---

--- a/product/product-manager.md
+++ b/product/product-manager.md
@@ -1,10 +1,9 @@
 ---
 name: Product Manager
 description: Holistic product leader who owns the full product lifecycle — from discovery and strategy through roadmap, stakeholder alignment, go-to-market, and outcome measurement. Bridges business goals, user needs, and technical reality to ship the right thing at the right time.
-color: blue
+color: "#0000FF"
 emoji: 🧭
 vibe: Ships the right thing, not just the next thing — outcome-obsessed, user-grounded, and diplomatically ruthless about focus.
-tools: WebFetch, WebSearch, Read, Write, Edit
 ---
 
 # 🧭 Product Manager Agent

--- a/product/product-sprint-prioritizer.md
+++ b/product/product-sprint-prioritizer.md
@@ -1,8 +1,7 @@
 ---
 name: Sprint Prioritizer
 description: Expert product manager specializing in agile sprint planning, feature prioritization, and resource allocation. Focused on maximizing team velocity and business value delivery through data-driven prioritization frameworks.
-color: green
-tools: WebFetch, WebSearch, Read, Write, Edit
+color: "#008000"
 emoji: 🎯
 vibe: Maximizes sprint value through data-driven prioritization and ruthless focus.
 ---

--- a/product/product-trend-researcher.md
+++ b/product/product-trend-researcher.md
@@ -1,8 +1,7 @@
 ---
 name: Trend Researcher
 description: Expert market intelligence analyst specializing in identifying emerging trends, competitive analysis, and opportunity assessment. Focused on providing actionable insights that drive product strategy and innovation decisions.
-color: purple
-tools: WebFetch, WebSearch, Read, Write, Edit
+color: "#800080"
 emoji: 🔭
 vibe: Spots emerging trends before they hit the mainstream.
 ---

--- a/project-management/project-management-experiment-tracker.md
+++ b/project-management/project-management-experiment-tracker.md
@@ -1,7 +1,7 @@
 ---
 name: Experiment Tracker
 description: Expert project manager specializing in experiment design, execution tracking, and data-driven decision making. Focused on managing A/B tests, feature experiments, and hypothesis validation through systematic experimentation and rigorous analysis.
-color: purple
+color: "#800080"
 emoji: 🧪
 vibe: Designs experiments, tracks results, and lets the data decide.
 ---

--- a/project-management/project-management-jira-workflow-steward.md
+++ b/project-management/project-management-jira-workflow-steward.md
@@ -1,7 +1,7 @@
 ---
 name: Jira Workflow Steward
 description: Expert delivery operations specialist who enforces Jira-linked Git workflows, traceable commits, structured pull requests, and release-safe branch strategy across software teams.
-color: orange
+color: "#FFA500"
 emoji: 📋
 vibe: Enforces traceable commits, structured PRs, and release-safe branch strategy.
 ---

--- a/project-management/project-management-meeting-notes-specialist.md
+++ b/project-management/project-management-meeting-notes-specialist.md
@@ -1,8 +1,7 @@
 ---
 name: Meeting Notes Specialist
 description: Extract structured decisions, action items, and open questions from meeting transcripts or rough notes into a clean 4-section summary.
-tools: Read, Write, Edit
-color: blue
+color: "#0000FF"
 emoji: 📋
 vibe: Precise extractor — finds the signal in the noise, never invents what isn't there.
 ---

--- a/project-management/project-management-project-shepherd.md
+++ b/project-management/project-management-project-shepherd.md
@@ -1,7 +1,7 @@
 ---
 name: Project Shepherd
 description: Expert project manager specializing in cross-functional project coordination, timeline management, and stakeholder alignment. Focused on shepherding projects from conception to completion while managing resources, risks, and communications across multiple teams and departments.
-color: blue
+color: "#0000FF"
 emoji: 🐑
 vibe: Herds cross-functional chaos into on-time, on-scope delivery.
 ---

--- a/project-management/project-management-studio-operations.md
+++ b/project-management/project-management-studio-operations.md
@@ -1,7 +1,7 @@
 ---
 name: Studio Operations
 description: Expert operations manager specializing in day-to-day studio efficiency, process optimization, and resource coordination. Focused on ensuring smooth operations, maintaining productivity standards, and supporting all teams with the tools and processes needed for success.
-color: green
+color: "#008000"
 emoji: 🏭
 vibe: Keeps the studio running smoothly — processes, tools, and people in sync.
 ---

--- a/project-management/project-management-studio-producer.md
+++ b/project-management/project-management-studio-producer.md
@@ -1,7 +1,7 @@
 ---
 name: Studio Producer
 description: Senior strategic leader specializing in high-level creative and technical project orchestration, resource allocation, and multi-project portfolio management. Focused on aligning creative vision with business objectives while managing complex cross-functional initiatives and ensuring optimal studio operations.
-color: gold
+color: "#FFD700"
 emoji: 🎬
 vibe: Aligns creative vision with business objectives across complex initiatives.
 ---

--- a/project-management/project-manager-senior.md
+++ b/project-management/project-manager-senior.md
@@ -1,7 +1,7 @@
 ---
 name: Senior Project Manager
 description: Converts specs to tasks and remembers previous projects. Focused on realistic scope, no background processes, exact spec requirements
-color: blue
+color: "#0000FF"
 emoji: 📝
 vibe: Converts specs to tasks with realistic scope — no gold-plating, no fantasy.
 ---

--- a/security/security-architect.md
+++ b/security/security-architect.md
@@ -1,7 +1,7 @@
 ---
 name: Security Architect
 description: Expert security architect specializing in threat modeling, secure-by-design architecture, trust-boundary analysis, defense-in-depth, and risk-based security reviews across web, API, cloud-native, and distributed systems. Designs the security model; hands code-level SAST/DAST and SDLC work to the AppSec Engineer.
-color: red
+color: "#FF0000"
 emoji: 🛡️
 vibe: Designs the security architecture and threat models that hold under adversarial pressure — the blueprint, not the bug-fix.
 ---

--- a/security/security-blockchain-security-auditor.md
+++ b/security/security-blockchain-security-auditor.md
@@ -1,7 +1,7 @@
 ---
 name: Blockchain Security Auditor
 description: Expert smart contract security auditor specializing in vulnerability detection, formal verification, exploit analysis, and comprehensive audit report writing for DeFi protocols and blockchain applications.
-color: red
+color: "#FF0000"
 emoji: 🛡️
 vibe: Finds the exploit in your smart contract before the attacker does.
 ---

--- a/security/security-compliance-auditor.md
+++ b/security/security-compliance-auditor.md
@@ -1,7 +1,7 @@
 ---
 name: Compliance Auditor
 description: Expert technical compliance auditor specializing in SOC 2, ISO 27001, HIPAA, and PCI-DSS audits — from readiness assessment through evidence collection to certification.
-color: orange
+color: "#FFA500"
 emoji: 📋
 vibe: Walks you from readiness assessment through evidence collection to SOC 2 certification.
 ---

--- a/spatial-computing/macos-spatial-metal-engineer.md
+++ b/spatial-computing/macos-spatial-metal-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: macOS Spatial/Metal Engineer
 description: Native Swift and Metal specialist building high-performance 3D rendering systems and spatial computing experiences for macOS and Vision Pro
-color: metallic-blue
+color: "#3B5998"
 emoji: 🍎
 vibe: Pushes Metal to its limits for 3D rendering on macOS and Vision Pro.
 ---

--- a/spatial-computing/terminal-integration-specialist.md
+++ b/spatial-computing/terminal-integration-specialist.md
@@ -1,7 +1,7 @@
 ---
 name: Terminal Integration Specialist
 description: Terminal emulation, text rendering optimization, and SwiftTerm integration for modern Swift applications
-color: green
+color: "#008000"
 emoji: 🖥️
 vibe: Masters terminal emulation and text rendering in modern Swift applications.
 ---

--- a/spatial-computing/visionos-spatial-engineer.md
+++ b/spatial-computing/visionos-spatial-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: visionOS Spatial Engineer
 description: Native visionOS spatial computing, SwiftUI volumetric interfaces, and Liquid Glass design implementation
-color: indigo
+color: "#4B0082"
 emoji: 🥽
 vibe: Builds native volumetric interfaces and Liquid Glass experiences for visionOS.
 ---

--- a/spatial-computing/xr-cockpit-interaction-specialist.md
+++ b/spatial-computing/xr-cockpit-interaction-specialist.md
@@ -1,7 +1,7 @@
 ---
 name: XR Cockpit Interaction Specialist
 description: Specialist in designing and developing immersive cockpit-based control systems for XR environments
-color: orange
+color: "#FFA500"
 emoji: 🕹️
 vibe: Designs immersive cockpit control systems that feel natural in XR.
 ---

--- a/spatial-computing/xr-immersive-developer.md
+++ b/spatial-computing/xr-immersive-developer.md
@@ -1,7 +1,7 @@
 ---
 name: XR Immersive Developer
 description: Expert WebXR and immersive technology developer with specialization in browser-based AR/VR/XR applications
-color: neon-cyan
+color: "#00FFFF"
 emoji: 🌐
 vibe: Builds browser-based AR/VR/XR experiences that push WebXR to its limits.
 ---

--- a/spatial-computing/xr-interface-architect.md
+++ b/spatial-computing/xr-interface-architect.md
@@ -1,7 +1,7 @@
 ---
 name: XR Interface Architect
 description: Spatial interaction designer and interface strategist for immersive AR/VR/XR environments
-color: neon-green
+color: "#39FF14"
 emoji: 🫧
 vibe: Designs spatial interfaces where interaction feels like instinct, not instruction.
 ---

--- a/specialized/accounts-payable-agent.md
+++ b/specialized/accounts-payable-agent.md
@@ -1,7 +1,7 @@
 ---
 name: Accounts Payable Agent
 description: Autonomous payment processing specialist that executes vendor payments, contractor invoices, and recurring bills across any payment rail — crypto, fiat, stablecoins. Integrates with AI agent workflows via tool calls.
-color: green
+color: "#008000"
 emoji: 💸
 vibe: Moves money across any rail — crypto, fiat, stablecoins — so you don't have to.
 ---

--- a/specialized/agents-orchestrator.md
+++ b/specialized/agents-orchestrator.md
@@ -1,7 +1,7 @@
 ---
 name: Agents Orchestrator
 description: Autonomous pipeline manager that orchestrates the entire development workflow. You are the leader of this process.
-color: cyan
+color: "#00FFFF"
 emoji: 🎛️
 vibe: The conductor who runs the entire dev pipeline from spec to ship.
 ---

--- a/specialized/automation-governance-architect.md
+++ b/specialized/automation-governance-architect.md
@@ -3,7 +3,7 @@ name: Automation Governance Architect
 description: Governance-first architect for business automations (n8n-first) who audits value, risk, and maintainability before implementation.
 emoji: ⚙️
 vibe: Calm, skeptical, and operations-focused. Prefer reliable systems over automation hype.
-color: cyan
+color: "#00FFFF"
 ---
 
 # Automation Governance Architect

--- a/specialized/business-strategist.md
+++ b/specialized/business-strategist.md
@@ -2,7 +2,7 @@
 name: Business Strategist
 emoji: ♟️
 description: Senior management consulting specialist for competitive analysis, market entry strategy, business model design, growth planning, organizational strategy, and strategic decision-making — translating complex market dynamics into clear, actionable strategies that create sustainable competitive advantage
-color: indigo
+color: "#4B0082"
 vibe: Strategy without execution is hallucination. Execution without strategy is chaos. The best strategists build the bridge between where you are and where you need to be — and make sure it holds weight.
 ---
 

--- a/specialized/change-management-consultant.md
+++ b/specialized/change-management-consultant.md
@@ -2,7 +2,7 @@
 name: Change Management Consultant
 emoji: 🔄
 description: Expert change management specialist using ADKAR, Kotter, and Prosci frameworks to guide organizations through technology implementations, restructuring, culture transformation, and M&A integration — managing resistance, building adoption, and ensuring changes stick long after go-live
-color: amber
+color: "#FFBF00"
 vibe: Change doesn't fail because of bad technology or bad strategy — it fails because people don't adopt it. Every transformation is ultimately a human project. Win the hearts and minds, and the rest follows.
 ---
 

--- a/specialized/chief-financial-officer.md
+++ b/specialized/chief-financial-officer.md
@@ -2,7 +2,7 @@
 name: Chief Financial Officer
 emoji: 💼
 description: Strategic finance executive who governs capital allocation, treasury operations, financial planning, M&A finance, investor relations, and board reporting — translating financial complexity into clear decisions that drive business performance and stakeholder confidence.
-color: navy
+color: "#000080"
 vibe: Thinks in trade-offs, risk-adjusted returns, and long-term value creation — turns financial complexity into a clear decision while protecting the balance sheet, the controls, and the credibility of every number presented.
 ---
 

--- a/specialized/corporate-training-designer.md
+++ b/specialized/corporate-training-designer.md
@@ -1,7 +1,7 @@
 ---
 name: Corporate Training Designer
 description: Expert in enterprise training system design and curriculum development — proficient in training needs analysis, instructional design methodology, blended learning program design, internal trainer development, leadership programs, and training effectiveness evaluation and continuous optimization.
-color: orange
+color: "#FFA500"
 emoji: 📚
 vibe: Designs training programs that drive real behavior change — from needs analysis to Kirkpatrick Level 3 evaluation — because good training is measured by what learners do, not what instructors say.
 ---

--- a/specialized/customer-service.md
+++ b/specialized/customer-service.md
@@ -2,7 +2,7 @@
 name: Customer Service
 emoji: 🎧
 description: Friendly, professional customer service specialist for any industry — handling inquiries, complaints, account support, FAQs, and seamless escalation with warmth, efficiency, and a genuine commitment to customer satisfaction
-color: teal
+color: "#008080"
 vibe: Every customer interaction is a chance to turn a problem into loyalty — handle it with care, speed, and a human touch.
 ---
 

--- a/specialized/customer-success-manager.md
+++ b/specialized/customer-success-manager.md
@@ -2,7 +2,7 @@
 name: Customer Success Manager
 emoji: 🌟
 description: Strategic customer success specialist for onboarding, health scoring, QBR facilitation, churn prevention, expansion identification, and renewal management — driving net revenue retention by turning customers into long-term partners who achieve measurable outcomes
-color: green
+color: "#008000"
 vibe: Customer success isn't a department that reacts to problems — it's a discipline that prevents them. The best CSMs know their customers' goals better than the customers do, and show up with answers before questions are asked.
 ---
 

--- a/specialized/data-privacy-officer.md
+++ b/specialized/data-privacy-officer.md
@@ -2,7 +2,7 @@
 name: Data Privacy Officer
 emoji: 🔐
 description: Corporate data privacy specialist and DPO who builds GDPR, CCPA, and global privacy compliance programs — covering data mapping, privacy impact assessments, consent management, breach response, vendor due diligence, and regulatory engagement.
-color: purple
+color: "#800080"
 vibe: Treats personal data as a liability to be minimized rather than an asset to be hoarded — reads the regulation precisely, designs privacy in from the start, and assumes a regulator will one day ask to see the records.
 ---
 

--- a/specialized/esg-sustainability-officer.md
+++ b/specialized/esg-sustainability-officer.md
@@ -2,7 +2,7 @@
 name: ESG & Sustainability Officer
 emoji: 🌱
 description: Corporate sustainability strategist and ESG reporting specialist who builds environmental, social, and governance programs, manages disclosures, drives decarbonization initiatives, and aligns business strategy with stakeholder and regulatory expectations.
-color: green
+color: "#008000"
 vibe: Builds sustainability programs that hold up to scrutiny — grounds every claim in audited data and recognized frameworks, because a target without a credible path or a disclosure without evidence is greenwashing waiting to be exposed.
 ---
 

--- a/specialized/grant-writer.md
+++ b/specialized/grant-writer.md
@@ -2,7 +2,7 @@
 name: Grant Writer
 emoji: 📝
 description: Expert grant writing specialist for nonprofits, research institutions, and social enterprises — covering prospect research, letter of inquiry writing, full proposal development, budget narratives, federal and foundation grants, and post-award reporting to maximize funding success
-color: purple
+color: "#800080"
 vibe: Every grant is a conversation between your mission and a funder's priorities. The best grant writers don't beg — they build a compelling case that a funder's investment in your work is the highest-leverage use of their dollars.
 ---
 

--- a/specialized/healthcare-customer-service.md
+++ b/specialized/healthcare-customer-service.md
@@ -2,7 +2,7 @@
 name: Healthcare Customer Service
 emoji: 🏥
 description: Empathetic healthcare customer service specialist for patient support, billing inquiries, appointment management, insurance questions, complaint resolution, and seamless escalation to clinical or administrative staff
-color: teal
+color: "#008080"
 vibe: Every patient deserves to feel heard, respected, and supported — especially when they're scared, confused, or frustrated.
 ---
 

--- a/specialized/hospitality-guest-services.md
+++ b/specialized/hospitality-guest-services.md
@@ -2,7 +2,7 @@
 name: Hospitality Guest Services
 emoji: 🏨
 description: Comprehensive hospitality guest services specialist for hotels, resorts, restaurants, and event venues — covering reservations, check-in/check-out, concierge services, guest complaint resolution, loyalty program management, and post-stay follow-up to deliver exceptional guest experiences that drive loyalty and revenue
-color: teal
+color: "#008080"
 vibe: Hospitality is not a transaction — it's a feeling. Every guest interaction is an opportunity to create a memory, earn a return visit, and generate a five-star review.
 ---
 

--- a/specialized/hr-onboarding.md
+++ b/specialized/hr-onboarding.md
@@ -2,7 +2,7 @@
 name: HR Onboarding
 emoji: 🤝
 description: Comprehensive HR onboarding specialist for employee orientation, documentation management, compliance tracking, benefits enrollment, culture integration, and new hire support — delivering a seamless first-day-to-first-year experience that drives retention and productivity
-color: green
+color: "#008000"
 vibe: The first 90 days determine whether a new hire becomes a long-term contributor or a regrettable turnover. Get it right from day one.
 ---
 

--- a/specialized/language-translator.md
+++ b/specialized/language-translator.md
@@ -2,7 +2,7 @@
 name: Language Translator
 emoji: 🌐
 description: Real-time Spanish ↔ English translation specialist with cultural context, regional dialect awareness, travel phrase guidance, and tone-appropriate communication for everyday, business, and emergency situations
-color: teal
+color: "#008080"
 vibe: Bridges languages with precision, cultural respect, and the fluency of a native speaker who's lived in both worlds.
 ---
 

--- a/specialized/legal-billing-time-tracking.md
+++ b/specialized/legal-billing-time-tracking.md
@@ -2,7 +2,7 @@
 name: Legal Billing & Time Tracking
 emoji: ⏱️
 description: Comprehensive legal billing and time tracking specialist for accurate time capture, invoice generation, billing narrative writing, collections management, trust account compliance, and billing analysis — maximizing revenue recovery while maintaining client relationships and ethical compliance across any firm size or billing model
-color: green
+color: "#008000"
 vibe: Every six minutes of unbilled time is money left on the table. Every unclear billing narrative is a client dispute waiting to happen. Capture it all. Describe it clearly. Collect it professionally.
 ---
 

--- a/specialized/legal-client-intake.md
+++ b/specialized/legal-client-intake.md
@@ -2,7 +2,7 @@
 name: Legal Client Intake
 emoji: 📋
 description: Comprehensive legal client intake specialist for qualifying prospects, collecting case information, scheduling consultations, managing conflict checks, and delivering attorney-ready intake summaries across any practice area and firm size
-color: blue
+color: "#0000FF"
 vibe: The first conversation with a potential client sets the tone for the entire attorney-client relationship. Get it right — warm, professional, and thorough — from the very first touch.
 ---
 

--- a/specialized/legal-document-review.md
+++ b/specialized/legal-document-review.md
@@ -2,7 +2,7 @@
 name: Legal Document Review
 emoji: ⚖️
 description: Comprehensive legal document review specialist for contracts, litigation documents, and real estate agreements — summarizing documents, flagging risk clauses, comparing contract versions, and checking compliance across any law firm size or practice area
-color: blue
+color: "#0000FF"
 vibe: Every word in a legal document matters. Every missed clause is a liability. Every risk caught early is a client protected.
 ---
 

--- a/specialized/loan-officer-assistant.md
+++ b/specialized/loan-officer-assistant.md
@@ -2,7 +2,7 @@
 name: Loan Officer Assistant
 emoji: 🏦
 description: Comprehensive loan officer assistant for mortgage and lending professionals — covering borrower intake, pre-qualification, document collection, pipeline management, compliance tracking, rate quoting, and closing coordination across residential, commercial, and consumer lending
-color: blue
+color: "#0000FF"
 vibe: Every loan is someone's dream — a home, a business, a fresh start. Move it through the pipeline with precision, compliance, and genuine care for the person behind the application.
 ---
 

--- a/specialized/lsp-index-engineer.md
+++ b/specialized/lsp-index-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: LSP/Index Engineer
 description: Language Server Protocol specialist building unified code intelligence systems through LSP client orchestration and semantic indexing
-color: orange
+color: "#FFA500"
 emoji: 🔎
 vibe: Builds unified code intelligence through LSP orchestration and semantic indexing.
 ---

--- a/specialized/ma-integration-manager.md
+++ b/specialized/ma-integration-manager.md
@@ -2,7 +2,7 @@
 name: M&A Integration Manager
 emoji: 🤝
 description: Mergers and acquisitions integration specialist who designs and executes post-merger integration programs — covering Day 1 readiness, 100-day planning, synergy tracking, cultural integration, functional workstream coordination, and transition service agreement management.
-color: indigo
+color: "#4B0082"
 vibe: Treats the signed deal as the starting line, not the finish — runs post-merger integration like a program with a clock on it, because synergy value erodes every day Day 1 readiness slips and culture is left to chance.
 ---
 

--- a/specialized/medical-billing-coding-specialist.md
+++ b/specialized/medical-billing-coding-specialist.md
@@ -2,7 +2,7 @@
 name: Medical Billing & Coding Specialist
 emoji: 🏥
 description: Expert medical billing and coding specialist for ICD-10-CM/PCS, CPT, and HCPCS coding, claim submission, denial management, revenue cycle optimization, compliance auditing, and payer contract analysis — maximizing clean claim rates and revenue recovery for healthcare providers of all sizes
-color: blue
+color: "#0000FF"
 vibe: Every unsubmitted claim is lost revenue. Every unchallenged denial is money left on the table. Every compliance gap is a liability waiting to surface. The revenue cycle never stops — and neither do we.
 ---
 

--- a/specialized/operations-manager.md
+++ b/specialized/operations-manager.md
@@ -2,7 +2,7 @@
 name: Operations Manager
 emoji: ⚙️
 description: Business operations specialist who applies Lean, Six Sigma, and systems thinking to process mapping, capacity planning, KPI governance, vendor management, and organizational efficiency — turning operational complexity into repeatable, measurable performance.
-color: slate
+color: "#708090"
 vibe: Sees every business as a system of processes and treats waste, variation, and undocumented dependencies as defects to be measured and removed — because what isn't standardized and measured can't be scaled reliably.
 ---
 

--- a/specialized/organizational-psychologist.md
+++ b/specialized/organizational-psychologist.md
@@ -2,7 +2,7 @@
 name: Organizational Psychologist
 emoji: 🧠
 description: Applied organizational psychologist who diagnoses team dynamics, psychological safety, burnout risk, and culture health — using evidence-based frameworks to help leaders build high-performing, resilient, and psychologically safe organizations.
-color: teal
+color: "#008080"
 vibe: Treats team dysfunction like a clinician reads symptoms — grounds every diagnosis and intervention in peer-reviewed evidence, names the invisible pattern leaders can't see, and never mistakes pop psychology for the real thing.
 ---
 

--- a/specialized/personal-growth-mentor.md
+++ b/specialized/personal-growth-mentor.md
@@ -1,7 +1,7 @@
 ---
 name: Personal Growth Mentor
 description: Cross-domain personal development mentor for goal clarity, habit design, strategic decisions, and accountability without motivational fluff.
-color: teal
+color: "#008080"
 emoji: 🌱
 vibe: Systems over slogans. Clarity before action. Execution over inspiration.
 ---

--- a/specialized/real-estate-buyer-seller.md
+++ b/specialized/real-estate-buyer-seller.md
@@ -2,7 +2,7 @@
 name: Real Estate Buyer & Seller
 emoji: 🏠
 description: Comprehensive real estate agent assistant for buyer representation, seller representation, listing management, offer negotiation, transaction coordination, and closing support — delivering a world-class client experience from first showing to final closing across residential and investment real estate
-color: teal
+color: "#008080"
 vibe: Every transaction is someone's biggest financial decision. Every client deserves an agent who is organized, responsive, and genuinely invested in their outcome — not just the commission check.
 ---
 

--- a/specialized/recruitment-specialist.md
+++ b/specialized/recruitment-specialist.md
@@ -1,7 +1,7 @@
 ---
 name: Recruitment Specialist
 description: Expert recruitment operations and talent acquisition specialist — skilled in China's major hiring platforms, talent assessment frameworks, and labor law compliance. Helps companies efficiently attract, screen, and retain top talent while building a competitive employer brand.
-color: blue
+color: "#0000FF"
 emoji: 🎯
 vibe: Builds your full-cycle recruiting engine across China's hiring platforms, from sourcing to onboarding to compliance.
 ---

--- a/specialized/resume-tailor.md
+++ b/specialized/resume-tailor.md
@@ -1,7 +1,7 @@
 ---
 name: Resume Tailor
 description: Candidate-side resume optimization specialist who analyzes job descriptions, maps real experience to role requirements, improves ATS keyword alignment, and rewrites bullets without fabricating qualifications.
-color: teal
+color: "#008080"
 emoji: 🧾
 vibe: Tailors the resume to the role without tailoring the truth.
 ---

--- a/specialized/retail-customer-returns.md
+++ b/specialized/retail-customer-returns.md
@@ -2,7 +2,7 @@
 name: Retail Customer Returns
 emoji: 🛒
 description: Comprehensive retail customer returns specialist for processing returns, exchanges, and refunds across in-store, online, and omnichannel retail — handling policy enforcement, fraud prevention, customer retention, vendor returns, and returns analytics to maximize recovery while preserving customer loyalty
-color: amber
+color: "#FFBF00"
 vibe: A return is not a failure — it's an opportunity. Handle it with speed, fairness, and genuine care, and you'll turn a disappointed customer into a loyal one.
 ---
 

--- a/specialized/sales-outreach.md
+++ b/specialized/sales-outreach.md
@@ -2,7 +2,7 @@
 name: Sales Outreach
 emoji: 🎯
 description: Consultative B2B sales outreach specialist for cold prospecting, lead follow-up, objection handling, proposal writing, and pipeline management — combining data-driven targeting with genuine relationship-building to open doors and close deals
-color: amber
+color: "#FFBF00"
 vibe: The best salespeople don't sell — they help people buy. Every outreach is a conversation starter, not a pitch.
 ---
 

--- a/specialized/specialized-civil-engineer.md
+++ b/specialized/specialized-civil-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: Civil Engineer
 description: Expert civil and structural engineer with global standards coverage — Eurocode, DIN, ACI, AISC, ASCE, AS/NZS, CSA, GB, IS, AIJ, and more. Specializes in structural analysis, geotechnical design, construction documentation, building code compliance, and multi-standard international projects.
-color: yellow
+color: "#FFFF00"
 emoji: 🏗️
 vibe: Designs structures that stand across borders — from seismic Tokyo to wind-swept Dubai, always code-compliant and constructible.
 ---

--- a/specialized/specialized-codebase-archaeologist.md
+++ b/specialized/specialized-codebase-archaeologist.md
@@ -1,7 +1,7 @@
 ---
 name: Codebase Archaeologist
 description: Multi-session, multi-tool drift detection specialist who audits codebases touched by several AI coding tools (Claude, Cursor, Copilot, Windsurf, etc.) over time, finding silent logic mismatches, dead code, and doc-vs-code divergence that no single session would ever notice on its own.
-color: amber
+color: "#FFBF00"
 emoji: "🏺"
 vibe: I read code like tree rings — I can tell you which layer was written by which hand, and what got left half-finished when the next one took over.
 ---

--- a/specialized/specialized-developer-advocate.md
+++ b/specialized/specialized-developer-advocate.md
@@ -1,7 +1,7 @@
 ---
 name: Developer Advocate
 description: Expert developer advocate specializing in building developer communities, creating compelling technical content, optimizing developer experience (DX), and driving platform adoption through authentic engineering engagement. Bridges product and engineering teams with external developers.
-color: purple
+color: "#800080"
 emoji: 🗣️
 vibe: Bridges your product team and the developer community through authentic engagement.
 ---

--- a/specialized/specialized-document-generator.md
+++ b/specialized/specialized-document-generator.md
@@ -1,7 +1,7 @@
 ---
 name: Document Generator
 description: Expert document creation specialist who generates professional PDF, PPTX, DOCX, and XLSX files using code-based approaches with proper formatting, charts, and data visualization.
-color: blue
+color: "#0000FF"
 emoji: 📄
 vibe: Professional documents from code — PDFs, slides, spreadsheets, and reports.
 ---

--- a/specialized/specialized-fedramp-rmf-compliance.md
+++ b/specialized/specialized-fedramp-rmf-compliance.md
@@ -2,7 +2,7 @@
 name: FedRAMP & RMF Compliance Engineer
 emoji: 🛡️
 description: Expert FedRAMP and NIST Risk Management Framework compliance engineer specializing in both FedRAMP authorization pathways — the traditional Rev5 path (NIST 800-53 Rev 5 control implementation, System Security Plans, 3PAO assessment, agency authorization) and the modernized FedRAMP 20x path (Key Security Indicators, automated machine-readable validation, compliance-as-code) — plus the ATO process, continuous monitoring (ConMon), POA&M management, FIPS 199 categorization, authorization boundary diagrams, OSCAL machine-readable packages, and cloud security compliance for government and regulated industries
-color: red
+color: "#FF0000"
 vibe: A disciplined compliance engineer who guides systems through both FedRAMP authorization pathways — traditional Rev5 and the modernized, KSI-driven 20x — and the full NIST RMF lifecycle, turning abstract control requirements into concrete, auditable, ATO-ready evidence whether that evidence is a narrative implementation statement or a machine-validated Key Security Indicator, categorizing honestly, drawing the authorization boundary before writing a word of the SSP, treating every control as something that must be both implemented and provable, and refusing to paper over a gap with prose when a 3PAO — or an automated validation — is going to test the actual system, because in federal compliance an unproven control is an open finding waiting to happen.
 ---
 

--- a/specialized/specialized-mcp-builder.md
+++ b/specialized/specialized-mcp-builder.md
@@ -1,7 +1,7 @@
 ---
 name: MCP Builder
 description: Expert Model Context Protocol developer who designs, builds, and tests MCP servers that extend AI agent capabilities with custom tools, resources, and prompts.
-color: indigo
+color: "#4B0082"
 emoji: 🔌
 vibe: Builds the tools that make AI agents actually useful in the real world.
 ---

--- a/specialized/specialized-pricing-analyst.md
+++ b/specialized/specialized-pricing-analyst.md
@@ -1,10 +1,9 @@
 ---
 name: Pricing Analyst
 description: Specialized pricing analyst who develops optimal pricing models through market research, competitor analysis, cost structure evaluation, and margin optimization — turning pricing from guesswork into a data-driven competitive advantage.
-color: gold
+color: "#FFD700"
 emoji: 💰
 vibe: Finds the price point where value captured meets value delivered — then proves it with data.
-tools: WebFetch, WebSearch, Read, Write, Edit
 ---
 
 # Pricing Analyst Agent

--- a/specialized/specialized-workflow-architect.md
+++ b/specialized/specialized-workflow-architect.md
@@ -1,7 +1,7 @@
 ---
 name: Workflow Architect
 description: Workflow design specialist who maps complete workflow trees for every system, user journey, and agent interaction — covering happy paths, all branch conditions, failure modes, recovery paths, handoff contracts, and observable states to produce build-ready specs that agents can implement against and QA can test against.
-color: orange
+color: "#FFA500"
 emoji: "🗺️"
 vibe: Every path the system can take — mapped, named, and specified before a single line is written.
 ---

--- a/specialized/supply-chain-strategist.md
+++ b/specialized/supply-chain-strategist.md
@@ -1,7 +1,7 @@
 ---
 name: Supply Chain Strategist
 description: Expert supply chain management and procurement strategy specialist — skilled in supplier development, strategic sourcing, quality control, and supply chain digitalization. Grounded in China's manufacturing ecosystem, helps companies build efficient, resilient, and sustainable supply chains.
-color: blue
+color: "#0000FF"
 emoji: 🔗
 vibe: Builds your procurement engine and supply chain resilience across China's manufacturing ecosystem, from supplier sourcing to risk management.
 ---

--- a/specialized/zk-steward.md
+++ b/specialized/zk-steward.md
@@ -1,7 +1,7 @@
 ---
 name: ZK Steward
 description: "Knowledge-base steward in the spirit of Niklas Luhmann's Zettelkasten. Default perspective: Luhmann; switches to domain experts (Feynman, Munger, Ogilvy, etc.) by task. Enforces atomic notes, connectivity, and validation loops. Use for knowledge-base building, note linking, complex task breakdown, and cross-domain decision support."
-color: teal
+color: "#008080"
 emoji: 🗃️
 vibe: Channels Luhmann's Zettelkasten to build connected, validated knowledge bases.
 ---

--- a/support/support-analytics-reporter.md
+++ b/support/support-analytics-reporter.md
@@ -1,7 +1,7 @@
 ---
 name: Analytics Reporter
 description: Expert data analyst transforming raw data into actionable business insights. Creates dashboards, performs statistical analysis, tracks KPIs, and provides strategic decision support through data visualization and reporting.
-color: teal
+color: "#008080"
 emoji: 📊
 vibe: Transforms raw data into the insights that drive your next decision.
 ---

--- a/support/support-executive-summary-generator.md
+++ b/support/support-executive-summary-generator.md
@@ -1,7 +1,7 @@
 ---
 name: Executive Summary Generator
 description: Consultant-grade AI specialist trained to think and communicate like a senior strategy consultant. Transforms complex business inputs into concise, actionable executive summaries using McKinsey SCQA, BCG Pyramid Principle, and Bain frameworks for C-suite decision-makers.
-color: purple
+color: "#800080"
 emoji: 📝
 vibe: Thinks like a McKinsey consultant, writes for the C-suite.
 ---

--- a/support/support-finance-tracker.md
+++ b/support/support-finance-tracker.md
@@ -1,7 +1,7 @@
 ---
 name: Finance Tracker
 description: Expert financial analyst and controller specializing in financial planning, budget management, and business performance analysis. Maintains financial health, optimizes cash flow, and provides strategic financial insights for business growth.
-color: green
+color: "#008000"
 emoji: 💰
 vibe: Keeps the books clean, the cash flowing, and the forecasts honest.
 ---

--- a/support/support-infrastructure-maintainer.md
+++ b/support/support-infrastructure-maintainer.md
@@ -1,7 +1,7 @@
 ---
 name: Infrastructure Maintainer
 description: Expert infrastructure specialist focused on system reliability, performance optimization, and technical operations management. Maintains robust, scalable infrastructure supporting business operations with security, performance, and cost efficiency.
-color: orange
+color: "#FFA500"
 emoji: 🏢
 vibe: Keeps the lights on, the servers humming, and the alerts quiet.
 ---

--- a/support/support-legal-compliance-checker.md
+++ b/support/support-legal-compliance-checker.md
@@ -1,7 +1,7 @@
 ---
 name: Legal Compliance Checker
 description: Expert legal and compliance specialist ensuring business operations, data handling, and content creation comply with relevant laws, regulations, and industry standards across multiple jurisdictions.
-color: red
+color: "#FF0000"
 emoji: ⚖️
 vibe: Ensures your operations comply with the law across every jurisdiction that matters.
 ---

--- a/support/support-support-responder.md
+++ b/support/support-support-responder.md
@@ -1,7 +1,7 @@
 ---
 name: Support Responder
 description: Expert customer support specialist delivering exceptional customer service, issue resolution, and user experience optimization. Specializes in multi-channel support, proactive customer care, and turning support interactions into positive brand experiences.
-color: blue
+color: "#0000FF"
 emoji: 💬
 vibe: Turns frustrated users into loyal advocates, one interaction at a time.
 ---

--- a/testing/testing-api-tester.md
+++ b/testing/testing-api-tester.md
@@ -1,7 +1,7 @@
 ---
 name: API Tester
 description: Expert API testing specialist focused on comprehensive API validation, performance testing, and quality assurance across all systems and third-party integrations
-color: purple
+color: "#800080"
 emoji: 🔌
 vibe: Breaks your API before your users do.
 ---

--- a/testing/testing-evidence-collector.md
+++ b/testing/testing-evidence-collector.md
@@ -1,7 +1,7 @@
 ---
 name: Evidence Collector
 description: Screenshot-obsessed, fantasy-allergic QA specialist - Default to finding 3-5 issues, requires visual proof for everything
-color: orange
+color: "#FFA500"
 emoji: 📸
 vibe: Screenshot-obsessed QA who won't approve anything without visual proof.
 ---

--- a/testing/testing-performance-benchmarker.md
+++ b/testing/testing-performance-benchmarker.md
@@ -1,7 +1,7 @@
 ---
 name: Performance Benchmarker
 description: Expert performance testing and optimization specialist focused on measuring, analyzing, and improving system performance across all applications and infrastructure
-color: orange
+color: "#FFA500"
 emoji: ⏱️
 vibe: Measures everything, optimizes what matters, and proves the improvement.
 ---

--- a/testing/testing-reality-checker.md
+++ b/testing/testing-reality-checker.md
@@ -1,7 +1,7 @@
 ---
 name: Reality Checker
 description: Stops fantasy approvals, evidence-based certification - Default to "NEEDS WORK", requires overwhelming proof for production readiness
-color: red
+color: "#FF0000"
 emoji: 🧐
 vibe: Defaults to "NEEDS WORK" — requires overwhelming proof for production readiness.
 ---

--- a/testing/testing-test-results-analyzer.md
+++ b/testing/testing-test-results-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: Test Results Analyzer
 description: Expert test analysis specialist focused on comprehensive test result evaluation, quality metrics analysis, and actionable insight generation from testing activities
-color: indigo
+color: "#4B0082"
 emoji: 📋
 vibe: Reads test results like a detective reads evidence — nothing gets past.
 ---

--- a/testing/testing-tool-evaluator.md
+++ b/testing/testing-tool-evaluator.md
@@ -1,7 +1,7 @@
 ---
 name: Tool Evaluator
 description: Expert technology assessment specialist focused on evaluating, testing, and recommending tools, software, and platforms for business use and productivity optimization
-color: teal
+color: "#008080"
 emoji: 🔧
 vibe: Tests and recommends the right tools so your team doesn't waste time on the wrong ones.
 ---

--- a/testing/testing-workflow-optimizer.md
+++ b/testing/testing-workflow-optimizer.md
@@ -1,7 +1,7 @@
 ---
 name: Workflow Optimizer
 description: Expert process improvement specialist focused on analyzing, optimizing, and automating workflows across all business functions for maximum productivity and efficiency
-color: green
+color: "#008000"
 emoji: ⚡
 vibe: Finds the bottleneck, fixes the process, automates the rest.
 ---


### PR DESCRIPTION
fix: normalize frontmatter for OpenCode schema compliance (#796)

## What does this PR do?

Fixes #796. OpenCode requires `color` to be `#RRGGBB` hex and `tools` to be an object or undefined. Many agent files use CSS color names and comma-separated tools strings, causing `opencode agent list` to fail.

- Convert 178 CSS color names (blue, teal, purple, etc.) to `#RRGGBB` hex codes
- Remove 17 non-standard comma-separated `tools:` fields

## Agent Information

N/A (frontmatter normalization only, no agent logic changed)

## Checklist

- [x] Follows the agent template structure from CONTRIBUTING.md
- [x] Includes YAML frontmatter with `name`, `description`, `color`
- [ ] Has concrete code/template examples — N/A
- [x] Tested in real scenarios — verified locally with OpenCode, `opencode agent list` passes without errors
- [x] Proofread and formatted correctly — scanned all 271 agent files, zero violations remaining