### PR TITLE
docs(opencode): warn against manual source file copying

### DIFF
--- a/integrations/opencode/README.md
+++ b/integrations/opencode/README.md
@@ -1,5 +1,22 @@
 # OpenCode Integration
 
+> **❌ Don't do this:**
+>
+> ```bash
+> # WRONG — will fail with schema validation errors
+> cp agency-agents/engineering/*.md .opencode/agents/
+> ```
+>
+> **✅ Do this instead:**
+>
+> ```bash
+> /path/to/agency-agents/scripts/install.sh --tool opencode
+> ```
+>
+> The source files use named colors and a `tools` field that OpenCode rejects.
+> The installer converts them to `#RRGGBB` hex and strips incompatible fields
+> automatically.
+
 OpenCode agents are `.md` files with YAML frontmatter stored in
 `.opencode/agents/`. The converter maps named colors to hex codes and adds
 `mode: subagent` so agents are invoked on-demand via `@agent-name` rather


### PR DESCRIPTION
docs(opencode): warn against manual source file copying

Closes #796.

## What does this PR do?

Users were copying source `.md` files directly into `.opencode/agents/`,
causing `opencode agent list` to fail with schema validation errors.
The source files use named colors and a `tools` field that OpenCode rejects.

Added a warning at the top of `integrations/opencode/README.md`:
- ❌ wrong: manual copy of source files
- ✅ right: `install.sh --tool opencode`

## Agent Information (if adding/modifying an agent)

N/A (documentation only)

## Checklist

- [ ] Follows the agent template structure from CONTRIBUTING.md
- [ ] Includes YAML frontmatter with `name`, `description`, `color`
- [ ] Has concrete code/template examples (for new agents)
- [ ] Tested in real scenarios
- [x] Proofread and formatted correctly
