### PR TITLE
docs(security): clarify private advisory reporting path (fixes #763)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,11 @@
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability in this project, please report it responsibly. Do NOT open a public GitHub issue for security vulnerabilities. Open a private security advisory via GitHub Security tab.
+If you discover a security vulnerability in this project, please report it responsibly. Do NOT open a public GitHub issue for security vulnerabilities.
+
+Report it through a private security advisory: open the repository's `Security` tab and choose `Report a vulnerability`. This keeps the details private until a fix is available.
+
+Note: if the advisory form is unavailable, private vulnerability reporting is not enabled for this repository yet. In that case, please do not post the details publicly; check back after the maintainer enables it.
 
 ## Response Timeline
 


### PR DESCRIPTION
Fixes #763. Problem: SECURITY.md tells reporters to use GitHub private advisories, but the /security/new form returns 404 while that feature is unavailable. Change: documents the exact private reporting path (Security tab, Report a vulnerability) and states what to do when the form is unavailable (do not post publicly; wait until the maintainer enables it). No new contact channel is introduced and no scope changes.