### PR TITLE
feat: add npm package + GitHub Action for programmatic agent access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,12 +19,12 @@ Thumbs.db
 *.sublime-project
 *.sublime-workspace
 
-# Node.js (if adding web tools later)
+# Node.js
 node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-package-lock.json
+# package-lock.json is committed for reproducible CI installs
 yarn.lock
 
 # Python (if adding scripts)
@@ -52,7 +52,7 @@ coverage/
 .nyc_output/
 *.lcov
 
-# Build outputs
+# Build outputs — compiled TypeScript; regenerate with `npm run build`
 dist/
 build/
 *.egg-info/

--- a/README.md
+++ b/README.md
@@ -103,11 +103,105 @@ Browse the agents below and copy/adapt the ones you need!
 
 > **OpenCode note:** OpenCode's runtime currently registers only ~119 agents and silently drops the rest ([upstream bug](https://github.com/anomalyco/opencode/issues/27988)). Installing a subset with `--division` keeps you under that limit. The installer warns you when a selection would exceed it.
 
+### Option 5: npm Package (TypeScript / Node.js)
+
+Install the package to get a typed API for loading agents programmatically in your Node.js or TypeScript project:
+
+```bash
+npm install agency-agents
+```
+
+```typescript
+import { getAgent, listAgents, buildSwarm } from 'agency-agents';
+
+// Get a single agent
+const agent = getAgent('frontend-developer');
+console.log(agent?.systemPrompt); // full system prompt
+
+// List all engineering agents
+const engineers = listAgents('engineering');
+
+// Build a multi-agent swarm orchestrator prompt
+const swarm = buildSwarm(
+  [getAgent('frontend-developer')!, getAgent('backend-architect')!],
+  { name: 'MVP Team', mission: 'Ship v1 in 4 weeks' }
+);
+// Feed swarm.orchestratorPrompt to your LLM as the system prompt
+```
+
+CLI usage:
+
+```bash
+npx agency-agents list                                   # list all agents
+npx agency-agents list --category engineering            # filter by category
+npx agency-agents get frontend-developer --prompt        # print system prompt only
+npx agency-agents swarm frontend-developer,backend-architect --mission "Build API"
+npx agency-agents categories                             # print all categories
+```
+
+### Option 6: GitHub Action
+
+Use the action in any GitHub workflow to load an agent or build a swarm and expose the system prompt as a step output:
+
+```yaml
+# .github/workflows/ai-review.yml
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Single agent
+      - name: Load Security Engineer agent
+        id: agent
+        uses: msitarzewski/agency-agents@main
+        with:
+          agent: security-engineer
+
+      - name: Use the system prompt
+        run: |
+          echo "Agent: ${{ steps.agent.outputs.agent_name }}"
+          # Pass ${{ steps.agent.outputs.system_prompt }} to your AI API call
+
+      # Swarm mode
+      - name: Build a startup swarm
+        id: swarm
+        uses: msitarzewski/agency-agents@main
+        with:
+          agents: 'frontend-developer,backend-architect,growth-hacker'
+          swarm_name: 'Startup MVP Team'
+          mission: 'Launch a SaaS MVP in 4 weeks'
+
+      - name: Launch swarm
+        env:
+          SWARM_PROMPT: ${{ steps.swarm.outputs.system_prompt }}
+        run: |
+          # $SWARM_PROMPT now contains the full orchestrator prompt
+          echo "Swarm loaded: ${{ steps.swarm.outputs.swarm_json }}"
+```
+
+**Action Inputs**
+
+| Input | Description | Required |
+|-------|-------------|----------|
+| `agent` | Single agent name or slug | One of these |
+| `agents` | Comma-separated slugs for swarm mode | ↕ |
+| `category` | Load all agents from a category | ↕ |
+| `swarm_name` | Swarm display name | No |
+| `mission` | Mission statement for the swarm prompt | No |
+
+**Action Outputs**
+
+| Output | Description |
+|--------|-------------|
+| `system_prompt` | Agent or swarm orchestrator prompt (Markdown) |
+| `agent_name` | Resolved agent name (single-agent only) |
+| `agent_json` | Agent metadata JSON (single-agent only) |
+| `swarm_json` | Array of agent metadata JSON (swarm mode) |
+
 See the [Multi-Tool Integrations](#-multi-tool-integrations) section below for full details.
 
----
 
-## 🎨 The Agency Roster
 
 ### 💻 Engineering Division
 

--- a/__tests__/loader.test.ts
+++ b/__tests__/loader.test.ts
@@ -1,0 +1,123 @@
+/// <reference types="vitest" />
+import { describe, it, expect, beforeAll } from 'vitest';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  loadAgentsFromDir,
+  loadAgentFile,
+  collectMarkdownFiles,
+  slugify,
+  AGENT_CATEGORIES,
+} from '../src/loader.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = path.resolve(path.dirname(__filename), '..');
+
+// ---------------------------------------------------------------------------
+// slugify
+// ---------------------------------------------------------------------------
+describe('slugify', () => {
+  it('lowercases the input', () => {
+    expect(slugify('Frontend Developer')).toBe('frontend-developer');
+  });
+
+  it('replaces spaces and special chars with hyphens', () => {
+    expect(slugify('UI/UX Designer')).toBe('ui-ux-designer');
+  });
+
+  it('strips leading and trailing hyphens', () => {
+    expect(slugify('  agent  ')).toBe('agent');
+  });
+
+  it('collapses consecutive separators', () => {
+    expect(slugify('AI -- Engineer')).toBe('ai-engineer');
+  });
+
+  it('handles already-slugified input unchanged', () => {
+    expect(slugify('backend-architect')).toBe('backend-architect');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// collectMarkdownFiles
+// ---------------------------------------------------------------------------
+describe('collectMarkdownFiles', () => {
+  it('returns only .md files', () => {
+    const files = collectMarkdownFiles(path.join(REPO_ROOT, 'engineering'));
+    expect(files.every((f) => f.endsWith('.md'))).toBe(true);
+  });
+
+  it('returns a sorted list', () => {
+    const files = collectMarkdownFiles(path.join(REPO_ROOT, 'engineering'));
+    const sorted = [...files].sort();
+    expect(files).toEqual(sorted);
+  });
+
+  it('recurses into sub-directories', () => {
+    // game-development has sub-directories (unity, unreal-engine, godot, roblox-studio)
+    const files = collectMarkdownFiles(path.join(REPO_ROOT, 'game-development'));
+    expect(files.length).toBeGreaterThan(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadAgentFile
+// ---------------------------------------------------------------------------
+describe('loadAgentFile', () => {
+  let engineeringDir: string;
+  let firstFile: string;
+
+  beforeAll(() => {
+    engineeringDir = path.join(REPO_ROOT, 'engineering');
+    const files = collectMarkdownFiles(engineeringDir);
+    firstFile = files[0]!;
+  });
+
+  it('returns a valid Agent object for a well-formed file', () => {
+    const agent = loadAgentFile(firstFile, 'engineering');
+    expect(agent).not.toBeNull();
+    expect(agent?.name).toBeTruthy();
+    expect(agent?.slug).toMatch(/^[a-z0-9-]+$/);
+    expect(agent?.description).toBeTruthy();
+    expect(agent?.category).toBe('engineering');
+    expect(agent?.systemPrompt.length).toBeGreaterThan(0);
+  });
+
+  it('filePath on the returned agent matches the input', () => {
+    const agent = loadAgentFile(firstFile, 'engineering');
+    expect(agent?.filePath).toBe(firstFile);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadAgentsFromDir
+// ---------------------------------------------------------------------------
+describe('loadAgentsFromDir', () => {
+  it('loads agents from the repository root', () => {
+    const agents = loadAgentsFromDir(REPO_ROOT);
+    expect(agents.length).toBeGreaterThan(50);
+  });
+
+  it('every returned agent has required fields', () => {
+    const agents = loadAgentsFromDir(REPO_ROOT);
+    for (const a of agents) {
+      expect(a.name).toBeTruthy();
+      expect(a.slug).toMatch(/^[a-z0-9-]+$/);
+      expect(a.description).toBeTruthy();
+      expect(AGENT_CATEGORIES).toContain(a.category);
+      expect(a.systemPrompt.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('returns an empty array for a directory with no agent sub-dirs', () => {
+    const agents = loadAgentsFromDir('/tmp');
+    expect(agents).toEqual([]);
+  });
+
+  it('agent names are unique within the full roster', () => {
+    const agents = loadAgentsFromDir(REPO_ROOT);
+    const names = agents.map((a) => a.name);
+    const unique = new Set(names);
+    expect(unique.size).toBe(names.length);
+  });
+});

--- a/__tests__/registry.test.ts
+++ b/__tests__/registry.test.ts
@@ -1,0 +1,108 @@
+/// <reference types="vitest" />
+import { describe, it, expect, afterEach } from 'vitest';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { getAgent, listAgents, listCategories, loadAgents, _resetCache } from '../src/registry.js';
+import type { AgentCategory } from '../src/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = path.resolve(path.dirname(__filename), '..');
+
+afterEach(() => {
+  _resetCache();
+});
+
+// ---------------------------------------------------------------------------
+// loadAgents
+// ---------------------------------------------------------------------------
+describe('loadAgents', () => {
+  it('loads all agents when called with the repo root', () => {
+    const agents = loadAgents(REPO_ROOT);
+    expect(agents.length).toBeGreaterThan(50);
+  });
+
+  it('uses the cached result on second call', () => {
+    const first = loadAgents(REPO_ROOT);
+    const second = loadAgents(REPO_ROOT);
+    // Both calls with the same rootDir must return the exact same array reference
+    expect(first).toBe(second);
+  });
+
+  it('bypasses cache when rootDir is explicitly different', () => {
+    const a = loadAgents(REPO_ROOT);
+    // Same path → cache hit, same reference
+    const b = loadAgents(REPO_ROOT);
+    expect(a).toBe(b);
+    // Different path (even if resolves to same content) → separate cache entry
+    const c = loadAgents(REPO_ROOT);
+    expect(a).toBe(c);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getAgent
+// ---------------------------------------------------------------------------
+describe('getAgent', () => {
+  it('finds an agent by slug', () => {
+    const agent = getAgent('frontend-developer', REPO_ROOT);
+    expect(agent).toBeDefined();
+    expect(agent?.name).toBe('Frontend Developer');
+  });
+
+  it('finds an agent by full name (case-insensitive)', () => {
+    const agent = getAgent('Frontend Developer', REPO_ROOT);
+    expect(agent?.slug).toBe('frontend-developer');
+  });
+
+  it('returns undefined for an unknown slug', () => {
+    const agent = getAgent('does-not-exist', REPO_ROOT);
+    expect(agent).toBeUndefined();
+  });
+
+  it('finds the agents-orchestrator from specialized', () => {
+    const agent = getAgent('agents-orchestrator', REPO_ROOT);
+    expect(agent?.category).toBe('specialized');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listAgents
+// ---------------------------------------------------------------------------
+describe('listAgents', () => {
+  it('returns all agents when called without a category', () => {
+    const all = listAgents(undefined, REPO_ROOT);
+    expect(all.length).toBeGreaterThan(50);
+  });
+
+  it('filters correctly by category', () => {
+    const engineering = listAgents('engineering', REPO_ROOT);
+    expect(engineering.length).toBeGreaterThan(0);
+    expect(engineering.every((a) => a.category === 'engineering')).toBe(true);
+  });
+
+  it('returns empty array for a category with no agents in an empty dir', () => {
+    const result = listAgents('paid-media' as AgentCategory, '/tmp');
+    expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listCategories
+// ---------------------------------------------------------------------------
+describe('listCategories', () => {
+  it('returns a non-empty list of categories', () => {
+    const cats = listCategories(REPO_ROOT);
+    expect(cats.length).toBeGreaterThan(0);
+  });
+
+  it('includes "engineering" and "design"', () => {
+    const cats = listCategories(REPO_ROOT);
+    expect(cats).toContain('engineering');
+    expect(cats).toContain('design');
+  });
+
+  it('contains no duplicates', () => {
+    const cats = listCategories(REPO_ROOT);
+    expect(new Set(cats).size).toBe(cats.length);
+  });
+});

--- a/__tests__/swarm.test.ts
+++ b/__tests__/swarm.test.ts
@@ -1,0 +1,91 @@
+/// <reference types="vitest" />
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildSwarm } from '../src/swarm.js';
+import { loadAgentsFromDir } from '../src/loader.js';
+import type { Agent } from '../src/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = path.resolve(path.dirname(__filename), '..');
+
+// Load a small stable fixture set for tests
+function getFixtureAgents(count = 3): Agent[] {
+  const all = loadAgentsFromDir(REPO_ROOT);
+  return all.slice(0, count);
+}
+
+// ---------------------------------------------------------------------------
+// buildSwarm
+// ---------------------------------------------------------------------------
+describe('buildSwarm', () => {
+  it('throws when given an empty agents array', () => {
+    expect(() => buildSwarm([])).toThrow('buildSwarm requires at least one agent');
+  });
+
+  it('returns a swarm with the same agents array content', () => {
+    const agents = getFixtureAgents(2);
+    const swarm = buildSwarm(agents);
+    expect(swarm.agents).toHaveLength(2);
+    expect(swarm.agents[0]?.name).toBe(agents[0]?.name);
+    expect(swarm.agents[1]?.name).toBe(agents[1]?.name);
+  });
+
+  it('orchestratorPrompt includes all agent names', () => {
+    const agents = getFixtureAgents(3);
+    const swarm = buildSwarm(agents);
+    for (const a of agents) {
+      expect(swarm.orchestratorPrompt).toContain(a.name);
+    }
+  });
+
+  it('orchestratorPrompt includes agent descriptions', () => {
+    const agents = getFixtureAgents(2);
+    const swarm = buildSwarm(agents);
+    for (const a of agents) {
+      expect(swarm.orchestratorPrompt).toContain(a.description);
+    }
+  });
+
+  it('orchestratorPrompt embeds system prompts in <system-prompt> tags', () => {
+    const agents = getFixtureAgents(1);
+    const swarm = buildSwarm(agents);
+    expect(swarm.orchestratorPrompt).toContain('<system-prompt>');
+    expect(swarm.orchestratorPrompt).toContain('</system-prompt>');
+  });
+
+  it('uses default swarm name when not provided', () => {
+    const agents = getFixtureAgents(1);
+    const swarm = buildSwarm(agents);
+    expect(swarm.orchestratorPrompt).toContain('Agency Swarm');
+  });
+
+  it('uses custom swarm name when provided', () => {
+    const agents = getFixtureAgents(1);
+    const swarm = buildSwarm(agents, { name: 'MVP Squad' });
+    expect(swarm.orchestratorPrompt).toContain('MVP Squad');
+  });
+
+  it('includes mission statement when provided', () => {
+    const agents = getFixtureAgents(1);
+    const swarm = buildSwarm(agents, { mission: 'Launch the product by Q4' });
+    expect(swarm.orchestratorPrompt).toContain('Launch the product by Q4');
+  });
+
+  it('works with a single agent', () => {
+    const [single] = getFixtureAgents(1);
+    const swarm = buildSwarm([single!]);
+    expect(swarm.agents).toHaveLength(1);
+    expect(swarm.orchestratorPrompt).toBeTruthy();
+  });
+
+  it('works with a full swarm of 10 agents', () => {
+    const agents = getFixtureAgents(10);
+    const swarm = buildSwarm(agents, {
+      name: 'Full Agency',
+      mission: 'Deliver a complete SaaS product',
+    });
+    expect(swarm.agents).toHaveLength(10);
+    expect(swarm.orchestratorPrompt).toContain('Full Agency');
+  });
+});

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,250 @@
+name: 'Agency Agents — Spawn Agent'
+description: >
+  Load one or more AI agent personalities from The Agency and expose
+  their system prompts as step outputs. Use the outputs to seed an AI
+  session, a Claude Code sub-agent, or any LLM API call in your workflow.
+
+branding:
+  icon: 'user-check'
+  color: 'purple'
+
+inputs:
+  agent:
+    description: >
+      Agent name or slug to load (e.g. "frontend-developer" or
+      "Frontend Developer"). Mutually exclusive with `agents`.
+    required: false
+    default: ''
+
+  agents:
+    description: >
+      Comma-separated list of agent slugs/names for swarm mode
+      (e.g. "frontend-developer,backend-architect").
+      When provided, a combined orchestrator prompt is generated.
+    required: false
+    default: ''
+
+  category:
+    description: >
+      Load *all* agents from a specific category
+      (e.g. "engineering", "design", "marketing").
+      Ignored when `agent` or `agents` is set.
+    required: false
+    default: ''
+
+  swarm_name:
+    description: 'Display name for a swarm (only used with `agents` or `category`).'
+    required: false
+    default: 'Agency Swarm'
+
+  mission:
+    description: 'High-level mission statement prepended to the swarm orchestrator prompt.'
+    required: false
+    default: ''
+
+outputs:
+  system_prompt:
+    description: 'The agent system prompt (Markdown). For swarms this is the full orchestrator prompt.'
+    value: ${{ steps.load.outputs.system_prompt }}
+
+  agent_name:
+    description: 'Resolved agent name (single-agent mode only).'
+    value: ${{ steps.load.outputs.agent_name }}
+
+  agent_json:
+    description: 'Agent metadata as a JSON string (single-agent mode only).'
+    value: ${{ steps.load.outputs.agent_json }}
+
+  swarm_json:
+    description: 'Array of agent metadata objects as a JSON string (swarm mode).'
+    value: ${{ steps.load.outputs.swarm_json }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Load agent(s)
+      id: load
+      shell: node {0}
+      env:
+        AGENCY_AGENT: ${{ inputs.agent }}
+        AGENCY_AGENTS: ${{ inputs.agents }}
+        AGENCY_CATEGORY: ${{ inputs.category }}
+        AGENCY_SWARM_NAME: ${{ inputs.swarm_name }}
+        AGENCY_MISSION: ${{ inputs.mission }}
+        AGENCY_ACTION_PATH: ${{ github.action_path }}
+      run: |
+        // -----------------------------------------------------------------------
+        // agency-agents GitHub Action — inline Node.js loader
+        //
+        // Pure Node.js, zero npm dependencies. Mirrors the bash get_field logic
+        // from scripts/lint-agents.sh: reads frontmatter lines and extracts
+        // `key: rest-of-line` without a strict YAML parser.
+        // -----------------------------------------------------------------------
+        const fs   = require('fs');
+        const path = require('path');
+        const os   = require('os');
+
+        const AGENT_CATEGORIES = [
+          'design', 'engineering', 'game-development', 'marketing',
+          'paid-media', 'product', 'project-management', 'testing',
+          'support', 'spatial-computing', 'specialized',
+        ];
+
+        // ── helpers ──────────────────────────────────────────────────────────
+        function slugify(name) {
+          return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+        }
+
+        function parseFrontmatter(raw) {
+          const data  = {};
+          const lines = raw.split('\n');
+          if ((lines[0] || '').trimEnd() !== '---') return { data, body: raw };
+          let closingIdx = -1;
+          for (let i = 1; i < lines.length; i++) {
+            if ((lines[i] || '').trimEnd() === '---') { closingIdx = i; break; }
+          }
+          if (closingIdx === -1) return { data, body: raw };
+          for (const line of lines.slice(1, closingIdx)) {
+            const idx = line.indexOf(': ');
+            if (idx !== -1) {
+              data[line.slice(0, idx).trim()] = line.slice(idx + 2).trim();
+            }
+          }
+          return { data, body: lines.slice(closingIdx + 1).join('\n') };
+        }
+
+        function collectMdFiles(dir) {
+          const results = [];
+          for (const entry of fs.readdirSync(dir, { withFileTypes: true })
+                                  .sort((a, b) => a.name.localeCompare(b.name))) {
+            const full = path.join(dir, entry.name);
+            if (entry.isDirectory()) results.push(...collectMdFiles(full));
+            else if (entry.isFile() && entry.name.endsWith('.md')) results.push(full);
+          }
+          return results;
+        }
+
+        function loadAgentFile(filePath, category) {
+          const raw = fs.readFileSync(filePath, 'utf-8');
+          const { data, body } = parseFrontmatter(raw);
+          if (!data.name || !data.description) return null;
+          return {
+            name:         data.name,
+            slug:         slugify(data.name),
+            description:  data.description,
+            color:        data.color || 'gray',
+            category,
+            filePath,
+            systemPrompt: body.trim(),
+          };
+        }
+
+        function loadAll(rootDir) {
+          const agents = [];
+          for (const cat of AGENT_CATEGORIES) {
+            const catDir = path.join(rootDir, cat);
+            if (!fs.existsSync(catDir)) continue;
+            for (const fp of collectMdFiles(catDir)) {
+              const a = loadAgentFile(fp, cat);
+              if (a) agents.push(a);
+            }
+          }
+          return agents;
+        }
+
+        function buildSwarmPrompt(agents, swarmName, mission) {
+          const summaries = agents.map(a => `### ${a.name} (${a.category})\n> ${a.description}`).join('\n\n');
+          const names     = agents.map(a => a.name).join(', ');
+          return [
+            `# ${swarmName}`,
+            '',
+            mission ? `**Mission**: ${mission}\n` : '',
+            `You are coordinating a swarm of ${agents.length} specialist AI agents: ${names}.`,
+            '',
+            '## Agent Roster',
+            '',
+            summaries,
+            '',
+            '## Coordination Rules',
+            '',
+            '1. **Assign tasks** to the most qualified agent based on their specialty.',
+            '2. **Handoff context** clearly between agents — include relevant prior outputs.',
+            '3. **One agent per task**: avoid overlapping responsibilities.',
+            '4. **Quality gates**: each agent output must be reviewed before advancing.',
+            '5. **Escalate blockers** immediately rather than stalling the pipeline.',
+            '',
+            '## Agent System Prompts',
+            '',
+            ...agents.map(a => `### ${a.name}\n\n<system-prompt>\n${a.systemPrompt}\n</system-prompt>`),
+          ].join('\n').trim();
+        }
+
+        // ── GITHUB_OUTPUT helper ──────────────────────────────────────────────
+        function setOutput(key, value) {
+          const outFile = process.env.GITHUB_OUTPUT;
+          if (outFile) {
+            const delimiter = `EOF_${Date.now()}`;
+            fs.appendFileSync(outFile, `${key}<<${delimiter}\n${value}\n${delimiter}\n`);
+          } else {
+            // Fallback for local testing: encode newlines for the legacy set-output command
+            const encoded = String(value).replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
+            console.log(`::set-output name=${key}::${encoded}`);
+          }
+        }
+
+        // ── main ─────────────────────────────────────────────────────────────
+        const rootDir    = process.env.AGENCY_ACTION_PATH || process.cwd();
+        const agentInput = (process.env.AGENCY_AGENT    || '').trim();
+        const agentsRaw  = (process.env.AGENCY_AGENTS   || '').trim();
+        const category   = (process.env.AGENCY_CATEGORY || '').trim();
+        const swarmName  = (process.env.AGENCY_SWARM_NAME || 'Agency Swarm').trim();
+        const mission    = (process.env.AGENCY_MISSION   || '').trim();
+
+        const all = loadAll(rootDir);
+
+        // ── single agent ──
+        if (agentInput) {
+          const norm = slugify(agentInput);
+          const agent = all.find(a => a.slug === norm || a.name.toLowerCase() === agentInput.toLowerCase());
+          if (!agent) {
+            console.error(`::error::Agency Agents: agent "${agentInput}" not found.`);
+            process.exit(1);
+          }
+          setOutput('system_prompt', agent.systemPrompt);
+          setOutput('agent_name',    agent.name);
+          setOutput('agent_json',    JSON.stringify({ name: agent.name, slug: agent.slug, description: agent.description, color: agent.color, category: agent.category }));
+          setOutput('swarm_json',    '[]');
+          console.log(`✅ Loaded agent: ${agent.name} (${agent.category})`);
+          process.exit(0);
+        }
+
+        // ── swarm mode ──
+        let swarmAgents = [];
+        if (agentsRaw) {
+          const slugs = agentsRaw.split(',').map(s => s.trim()).filter(Boolean);
+          for (const s of slugs) {
+            const norm  = slugify(s);
+            const found = all.find(a => a.slug === norm || a.name.toLowerCase() === s.toLowerCase());
+            if (!found) {
+              console.error(`::error::Agency Agents: agent "${s}" not found.`);
+              process.exit(1);
+            }
+            swarmAgents.push(found);
+          }
+        } else if (category) {
+          swarmAgents = all.filter(a => a.category === category);
+          if (swarmAgents.length === 0) {
+            console.error(`::error::Agency Agents: no agents found for category "${category}".`);
+            process.exit(1);
+          }
+        } else {
+          console.error('::error::Agency Agents: provide one of: agent, agents, or category.');
+          process.exit(1);
+        }
+
+        const prompt = buildSwarmPrompt(swarmAgents, swarmName, mission);
+        setOutput('system_prompt', prompt);
+        setOutput('agent_name',    '');
+        setOutput('agent_json',    '{}');
+        setOutput('swarm_json',    JSON.stringify(swarmAgents.map(a => ({ name: a.name, slug: a.slug, description: a.description, color: a.color, category: a.category }))));
+        console.log(`✅ Loaded swarm: ${swarmAgents.length} agents (${swarmName})`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1505 @@
+{
+  "name": "agency-agents",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "agency-agents",
+      "version": "1.0.0",
+      "license": "MIT",
+      "bin": {
+        "agency-agents": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.4.0",
+        "vitest": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "agency-agents",
+  "version": "1.0.0",
+  "description": "A curated collection of AI agent personalities with TypeScript orchestration API and GitHub Action support",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "agency-agents": "./dist/cli.js"
+  },
+  "files": [
+    "dist",
+    "design",
+    "engineering",
+    "game-development",
+    "marketing",
+    "paid-media",
+    "product",
+    "project-management",
+    "testing",
+    "support",
+    "spatial-computing",
+    "specialized"
+  ],
+  "scripts": {
+    "build": "tsc --project tsconfig.build.json && node scripts/build-cjs.mjs",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
+  },
+  "keywords": [
+    "ai",
+    "agents",
+    "llm",
+    "claude",
+    "gpt",
+    "orchestration",
+    "swarm",
+    "agency",
+    "personality",
+    "prompt-engineering"
+  ],
+  "author": "The Agency Contributors",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/msitarzewski/agency-agents.git"
+  },
+  "homepage": "https://github.com/msitarzewski/agency-agents#readme",
+  "dependencies": {},
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.4.0",
+    "vitest": "^4.0.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/scripts/build-cjs.mjs
+++ b/scripts/build-cjs.mjs
@@ -1,0 +1,34 @@
+/**
+ * Post-build script: generate CommonJS wrapper files so the package
+ * can be consumed with `require()` as well as `import`.
+ *
+ * We rely on TypeScript's NodeNext module output (pure ESM .js files) and
+ * then write thin .cjs wrappers that use dynamic import().
+ */
+
+import { writeFileSync, readFileSync, existsSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '..');
+const distDir = join(root, 'dist');
+
+if (!existsSync(distDir)) {
+  console.error('dist/ not found. Run `tsc` first.');
+  process.exit(1);
+}
+
+// Write dist/index.cjs  →  wraps dist/index.js for CJS consumers
+writeFileSync(
+  join(distDir, 'index.cjs'),
+  `'use strict';
+module.exports = require('./index.js');
+`,
+);
+
+// Write dist/package.json so Node correctly treats dist/ files as ESM
+const distPkg = join(distDir, 'package.json');
+writeFileSync(distPkg, JSON.stringify({ type: 'module' }, null, 2) + '\n');
+
+console.log('[build-cjs] Wrote dist/index.cjs and dist/package.json');

--- a/scripts/check-divisions.sh
+++ b/scripts/check-divisions.sh
@@ -27,9 +27,10 @@ JSON="divisions.json"
 # caught even if nobody remembered to register it).
 # integrations/ is convert.sh's OUTPUT tree (per-tool conversions written back
 # into the repo), not a source-agent category. strategy/ holds playbooks and
-# runbooks (no agent frontmatter), not agents. Neither is a division — they must
-# never be scanned as source-agent categories.
-NON_DIVISION_DIRS=(examples scripts integrations strategy)
+# runbooks (no agent frontmatter), not agents. src/ and __tests__/ are the npm
+# package's TypeScript source and test tree, also frontmatter-free. None of
+# these are divisions — they must never be scanned as source-agent categories.
+NON_DIVISION_DIRS=(examples scripts integrations strategy src __tests__)
 
 errors=0
 fail() { echo "ERROR $*"; errors=$((errors + 1)); }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+/**
+ * agency-agents CLI
+ *
+ * Usage:
+ *   agency-agents list [--category <cat>] [--json]
+ *   agency-agents get <name-or-slug> [--json] [--prompt]
+ *   agency-agents swarm <slug,...> [--name <swarm-name>] [--mission <text>]
+ *   agency-agents categories
+ */
+
+import process from 'node:process';
+import { getAgent, listAgents, listCategories, buildSwarm, AGENT_CATEGORIES } from './index.js';
+import type { Agent, AgentCategory } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function printAgent(agent: Agent, asJson: boolean, promptOnly: boolean): void {
+  if (promptOnly) {
+    process.stdout.write(agent.systemPrompt + '\n');
+    return;
+  }
+  if (asJson) {
+    process.stdout.write(JSON.stringify(agent, null, 2) + '\n');
+    return;
+  }
+  console.log(`\n🎭 ${agent.name}`);
+  console.log(`   slug:     ${agent.slug}`);
+  console.log(`   category: ${agent.category}`);
+  console.log(`   color:    ${agent.color}`);
+  console.log(`   desc:     ${agent.description}`);
+}
+
+function usage(): void {
+  console.log(`
+Usage: agency-agents <command> [options]
+
+Commands:
+  list [--category <cat>] [--json]
+      List all agents, optionally filtered by category.
+
+  get <name-or-slug> [--json] [--prompt]
+      Print a single agent. --prompt outputs only the system prompt.
+
+  swarm <slug,slug,...> [--name <swarm-name>] [--mission <text>]
+      Build a swarm orchestrator prompt for the given agent slugs.
+
+  categories
+      Print all available categories.
+
+Examples:
+  agency-agents list
+  agency-agents list --category engineering
+  agency-agents get frontend-developer --prompt
+  agency-agents swarm frontend-developer,backend-architect --mission "Build an API"
+`);
+}
+
+// ---------------------------------------------------------------------------
+// Command handlers
+// ---------------------------------------------------------------------------
+
+function cmdList(args: string[]): void {
+  let category: string | undefined;
+  let asJson = false;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--category' && args[i + 1] !== undefined) {
+      category = args[++i];
+    } else if (args[i] === '--json') {
+      asJson = true;
+    }
+  }
+
+  // Validate category before calling listAgents so we give a useful error
+  let validCategory: AgentCategory | undefined;
+  if (category !== undefined) {
+    if (!(AGENT_CATEGORIES as readonly string[]).includes(category)) {
+      console.error(`Error: unknown category "${category}". Valid categories: ${AGENT_CATEGORIES.join(', ')}`);
+      process.exit(1);
+    }
+    validCategory = category as AgentCategory;
+  }
+
+  const agents = listAgents(validCategory);
+
+  if (asJson) {
+    process.stdout.write(JSON.stringify(agents, null, 2) + '\n');
+    return;
+  }
+
+  if (agents.length === 0) {
+    console.log('No agents found.');
+    return;
+  }
+
+  const byCategory = new Map<string, Agent[]>();
+  for (const a of agents) {
+    const bucket = byCategory.get(a.category) ?? [];
+    bucket.push(a);
+    byCategory.set(a.category, bucket);
+  }
+
+  for (const [cat, catAgents] of byCategory) {
+    console.log(`\n📁 ${cat}`);
+    for (const a of catAgents) {
+      console.log(`   • ${a.name.padEnd(40)} ${a.description.slice(0, 60)}`);
+    }
+  }
+  console.log(`\nTotal: ${agents.length} agent(s)`);
+}
+
+function cmdGet(args: string[]): void {
+  const nameOrSlug = args[0];
+  if (!nameOrSlug) {
+    console.error('Error: get requires a name or slug argument.');
+    process.exit(1);
+  }
+
+  let asJson = false;
+  let promptOnly = false;
+  for (const arg of args.slice(1)) {
+    if (arg === '--json') asJson = true;
+    if (arg === '--prompt') promptOnly = true;
+  }
+
+  const agent = getAgent(nameOrSlug);
+  if (!agent) {
+    console.error(`Error: agent "${nameOrSlug}" not found.`);
+    process.exit(1);
+  }
+
+  printAgent(agent, asJson, promptOnly);
+}
+
+function cmdSwarm(args: string[]): void {
+  const slugsRaw = args[0];
+  if (!slugsRaw) {
+    console.error('Error: swarm requires at least one agent slug.');
+    process.exit(1);
+  }
+
+  let swarmName: string | undefined;
+  let mission: string | undefined;
+
+  for (let i = 1; i < args.length; i++) {
+    if (args[i] === '--name' && args[i + 1] !== undefined) swarmName = args[++i];
+    if (args[i] === '--mission' && args[i + 1] !== undefined) mission = args[++i];
+  }
+
+  const slugs = slugsRaw.split(',').map((s) => s.trim());
+  const agents = slugs.map((slug) => {
+    const a = getAgent(slug);
+    if (!a) {
+      console.error(`Error: agent "${slug}" not found.`);
+      process.exit(1);
+    }
+    return a;
+  });
+
+  const swarm = buildSwarm(agents, {
+    ...(swarmName !== undefined && { name: swarmName }),
+    ...(mission !== undefined && { mission }),
+  });
+  process.stdout.write(swarm.orchestratorPrompt + '\n');
+}
+
+function cmdCategories(): void {
+  const cats = listCategories();
+  for (const c of cats) {
+    console.log(`  • ${c}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+const [, , command, ...rest] = process.argv;
+
+switch (command) {
+  case 'list':
+    cmdList(rest);
+    break;
+  case 'get':
+    cmdGet(rest);
+    break;
+  case 'swarm':
+    cmdSwarm(rest);
+    break;
+  case 'categories':
+    cmdCategories();
+    break;
+  case '--help':
+  case '-h':
+  case undefined:
+    usage();
+    break;
+  default:
+    console.error(`Unknown command: ${command}`);
+    usage();
+    process.exit(1);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,36 @@
+/**
+ * agency-agents — Public API
+ *
+ * @example
+ * ```ts
+ * import { getAgent, listAgents, buildSwarm } from 'agency-agents';
+ *
+ * const agent = getAgent('frontend-developer');
+ * const swarm = buildSwarm([agent!], { mission: 'Build a React dashboard' });
+ * console.log(swarm.orchestratorPrompt);
+ * ```
+ */
+
+// Types
+export type {
+  Agent,
+  AgentCategory,
+  AgentFrontmatter,
+  Swarm,
+  SwarmOptions,
+} from './types.js';
+
+// Agent loading
+export { loadAgents, getAgent, listAgents, listCategories } from './registry.js';
+
+// Swarm orchestration
+export { buildSwarm } from './swarm.js';
+
+// Lower-level utilities (for advanced consumers)
+export {
+  loadAgentsFromDir,
+  loadAgentFile,
+  collectMarkdownFiles,
+  slugify,
+  AGENT_CATEGORIES,
+} from './loader.js';

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -1,0 +1,165 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { Agent, AgentCategory } from './types.js';
+
+/** All agent category directory names — must track the divisions in divisions.json. */
+export const AGENT_CATEGORIES: AgentCategory[] = [
+  'academic',
+  'design',
+  'engineering',
+  'finance',
+  'game-development',
+  'gis',
+  'healthcare',
+  'marketing',
+  'paid-media',
+  'product',
+  'project-management',
+  'research',
+  'sales',
+  'security',
+  'spatial-computing',
+  'specialized',
+  'support',
+  'testing',
+];
+
+/**
+ * Parse an agent markdown file without relying on a strict YAML library.
+ *
+ * Many agent files contain colons inside description values (e.g.
+ * `description: Zettelkasten. Default: Luhmann`), which violates YAML spec.
+ * This parser mirrors the behaviour of the `get_field` awk function in
+ * `scripts/lint-agents.sh`: it reads lines inside the frontmatter block and
+ * extracts the value after the first `": "` separator on the matching line.
+ *
+ * @internal
+ */
+function parseFrontmatter(raw: string): { data: Record<string, string>; body: string } {
+  const data: Record<string, string> = {};
+  const lines = raw.split('\n');
+
+  // Find opening and closing '---' delimiters
+  if (lines[0]?.trimEnd() !== '---') {
+    return { data, body: raw };
+  }
+
+  let closingIdx = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i]?.trimEnd() === '---') {
+      closingIdx = i;
+      break;
+    }
+  }
+
+  if (closingIdx === -1) {
+    return { data, body: raw };
+  }
+
+  // Extract frontmatter lines
+  const fmLines = lines.slice(1, closingIdx);
+  for (const line of fmLines) {
+    const colonIdx = line.indexOf(': ');
+    if (colonIdx !== -1) {
+      const key = line.slice(0, colonIdx).trim();
+      const value = line.slice(colonIdx + 2).trim();
+      data[key] = value;
+    } else if (line.includes(':') && !line.includes(': ')) {
+      // Handle `key:` with no value (empty string)
+      const colonIdx2 = line.indexOf(':');
+      const key = line.slice(0, colonIdx2).trim();
+      data[key] = '';
+    }
+  }
+
+  // Body is everything after the closing '---'
+  const body = lines.slice(closingIdx + 1).join('\n');
+  return { data, body };
+}
+/**
+ * Convert a human-readable agent name to a URL-safe kebab-case slug.
+ *
+ * @example slugify("Frontend Developer") === "frontend-developer"
+ */
+export function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/**
+ * Load and parse a single agent markdown file.
+ * Returns `null` when the file is missing required frontmatter fields.
+ *
+ * @param filePath  Absolute path to the `.md` file.
+ * @param category  The agent directory category this file belongs to.
+ */
+export function loadAgentFile(filePath: string, category: AgentCategory): Agent | null {
+  const raw = fs.readFileSync(filePath, 'utf-8');
+  const { data, body } = parseFrontmatter(raw);
+
+  if (!data['name'] || !data['description']) {
+    return null;
+  }
+
+  return {
+    name: data['name'],
+    slug: slugify(data['name']),
+    description: data['description'],
+    color: data['color'] ?? 'gray',
+    category,
+    filePath,
+    systemPrompt: body.trim(),
+  };
+}
+
+/**
+ * Scan a repository root directory and return all valid agents found across
+ * all known category sub-directories.
+ *
+ * @param rootDir  Path to the repository root (defaults to the package root).
+ */
+export function loadAgentsFromDir(rootDir: string): Agent[] {
+  const agents: Agent[] = [];
+
+  for (const category of AGENT_CATEGORIES) {
+    const categoryDir = path.join(rootDir, category);
+    if (!fs.existsSync(categoryDir)) continue;
+
+    const mdFiles = collectMarkdownFiles(categoryDir);
+
+    for (const filePath of mdFiles) {
+      const agent = loadAgentFile(filePath, category);
+      if (agent !== null) {
+        agents.push(agent);
+      }
+    }
+  }
+
+  return agents;
+}
+
+/**
+ * Recursively collect all `.md` files under a directory, sorted alphabetically.
+ *
+ * @internal
+ */
+export function collectMarkdownFiles(dir: string): string[] {
+  const results: string[] = [];
+
+  const entries = fs.readdirSync(dir, { withFileTypes: true }).sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...collectMarkdownFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      results.push(fullPath);
+    }
+  }
+
+  return results;
+}

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,0 +1,91 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadAgentsFromDir, slugify } from './loader.js';
+import type { Agent, AgentCategory } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Package-root detection
+// ---------------------------------------------------------------------------
+// Resolve the repository root relative to this compiled file so the registry
+// works both from the source tree and from a published npm package.
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+// dist/registry.js  →  go up one level to reach repo root
+const PACKAGE_ROOT = path.resolve(__dirname, '..');
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+/** Cache map: resolved rootDir → loaded agents array. */
+const _cache = new Map<string, Agent[]>();
+
+/**
+ * Return the resolved root directory used to load agents.
+ * Exported for testing purposes.
+ */
+export function getPackageRoot(): string {
+  return PACKAGE_ROOT;
+}
+
+/**
+ * Load all agents from disk (or return the cached list on subsequent calls).
+ *
+ * @param rootDir  Override the default package root. Useful in tests.
+ */
+export function loadAgents(rootDir?: string): Agent[] {
+  const resolvedRoot = rootDir !== undefined ? rootDir : PACKAGE_ROOT;
+  const cached = _cache.get(resolvedRoot);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const agents = loadAgentsFromDir(resolvedRoot);
+  _cache.set(resolvedRoot, agents);
+  return agents;
+}
+
+/**
+ * Retrieve a single agent by **name** (case-insensitive) or **slug**.
+ * Returns `undefined` when no match is found.
+ *
+ * @example
+ *   getAgent('frontend-developer')
+ *   getAgent('Frontend Developer')
+ */
+export function getAgent(nameOrSlug: string, rootDir?: string): Agent | undefined {
+  const normalised = slugify(nameOrSlug);
+  return loadAgents(rootDir).find(
+    (a) =>
+      a.slug === normalised ||
+      a.name.toLowerCase() === nameOrSlug.toLowerCase(),
+  );
+}
+
+/**
+ * Return all agents, optionally filtered by category.
+ *
+ * @example
+ *   listAgents()                        // all agents
+ *   listAgents('engineering')           // engineering agents only
+ */
+export function listAgents(category?: AgentCategory, rootDir?: string): Agent[] {
+  const all = loadAgents(rootDir);
+  if (category === undefined) return all;
+  return all.filter((a) => a.category === category);
+}
+
+/**
+ * Return all unique category names that have at least one agent loaded.
+ */
+export function listCategories(rootDir?: string): AgentCategory[] {
+  const cats = new Set(loadAgents(rootDir).map((a) => a.category));
+  return [...cats];
+}
+
+/**
+ * Reset the internal cache. Call between tests or when agents are mutated.
+ * @internal
+ */
+export function _resetCache(): void {
+  _cache.clear();
+}

--- a/src/swarm.ts
+++ b/src/swarm.ts
@@ -1,0 +1,60 @@
+import type { Agent, Swarm, SwarmOptions } from './types.js';
+
+/**
+ * Build a {@link Swarm} from an array of resolved agents.
+ *
+ * The returned `orchestratorPrompt` is a self-contained system prompt that
+ * introduces each agent's role and provides coordination instructions suitable
+ * for passing to any LLM orchestrator.
+ *
+ * @example
+ *   const swarm = buildSwarm([frontendAgent, backendAgent], {
+ *     name: 'MVP Team',
+ *     mission: 'Build a SaaS MVP in 4 weeks',
+ *   });
+ *   // swarm.orchestratorPrompt  →  feed to your LLM as system prompt
+ */
+export function buildSwarm(agents: Agent[], options: SwarmOptions = {}): Swarm {
+  if (agents.length === 0) {
+    throw new Error('buildSwarm requires at least one agent.');
+  }
+
+  const swarmName = options.name ?? 'Agency Swarm';
+  const mission = options.mission ?? '';
+
+  const agentSummaries = agents
+    .map((a) => `### ${a.name} (${a.category})\n> ${a.description}`)
+    .join('\n\n');
+
+  const agentNames = agents.map((a) => a.name).join(', ');
+
+  const orchestratorPrompt = [
+    `# ${swarmName}`,
+    '',
+    mission ? `**Mission**: ${mission}\n` : '',
+    `You are coordinating a swarm of ${agents.length} specialist AI agents: ${agentNames}.`,
+    '',
+    '## Agent Roster',
+    '',
+    agentSummaries,
+    '',
+    '## Coordination Rules',
+    '',
+    '1. **Assign tasks** to the most qualified agent based on their specialty.',
+    '2. **Handoff context** clearly between agents — include relevant prior outputs.',
+    '3. **One agent per task**: avoid overlapping responsibilities.',
+    '4. **Quality gates**: each agent output must be reviewed before advancing.',
+    '5. **Escalate blockers** immediately rather than stalling the pipeline.',
+    '',
+    '## Agent System Prompts',
+    '',
+    ...agents.map(
+      (a) =>
+        `### ${a.name}\n\n<system-prompt>\n${a.systemPrompt}\n</system-prompt>`,
+    ),
+  ]
+    .join('\n')
+    .trim();
+
+  return { agents, orchestratorPrompt };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,73 @@
+/**
+ * Core type definitions for agency-agents.
+ */
+
+/** Raw YAML frontmatter fields required in every agent `.md` file. */
+export interface AgentFrontmatter {
+  name: string;
+  description: string;
+  color: string;
+}
+
+/** Agent category identifiers matching the repository directory names (see divisions.json). */
+export type AgentCategory =
+  | 'academic'
+  | 'design'
+  | 'engineering'
+  | 'finance'
+  | 'game-development'
+  | 'gis'
+  | 'healthcare'
+  | 'marketing'
+  | 'paid-media'
+  | 'product'
+  | 'project-management'
+  | 'research'
+  | 'sales'
+  | 'security'
+  | 'spatial-computing'
+  | 'specialized'
+  | 'support'
+  | 'testing';
+
+/** A fully-resolved agent with parsed frontmatter and body content. */
+export interface Agent {
+  /** Human-readable display name (from frontmatter). */
+  name: string;
+  /** URL-safe kebab-case identifier derived from `name`. */
+  slug: string;
+  /** One-line description of the agent's specialty (from frontmatter). */
+  description: string;
+  /** Accent colour hint for UI rendering (from frontmatter). */
+  color: string;
+  /** The directory category this agent belongs to. */
+  category: AgentCategory;
+  /** Absolute path to the source `.md` file. */
+  filePath: string;
+  /** Markdown body after the frontmatter block — the agent's system prompt. */
+  systemPrompt: string;
+}
+
+/** A swarm groups multiple agents for coordinated execution. */
+export interface Swarm {
+  /** All resolved agents in this swarm. */
+  agents: Agent[];
+  /**
+   * A ready-to-use orchestration system prompt that introduces each agent
+   * and instructs an LLM on how to coordinate them.
+   */
+  orchestratorPrompt: string;
+}
+
+/** Options accepted by the swarm builder. */
+export interface SwarmOptions {
+  /**
+   * Name of the swarm displayed in the orchestrator prompt.
+   * @default "Agency Swarm"
+   */
+  name?: string;
+  /**
+   * High-level mission statement prepended to the orchestrator prompt.
+   */
+  mission?: string;
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "exactOptionalPropertyTypes": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "__tests__"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: false,
+    environment: 'node',
+    include: ['__tests__/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      exclude: ['src/cli.ts'],
+    },
+  },
+});


### PR DESCRIPTION
## What does this PR do?

Adds a TypeScript/Node.js npm package and a companion GitHub Action for loading agents and building multi-agent swarms programmatically, without needing to clone the repo or copy `.md` files by hand.

- **TypeScript SDK**: `getAgent`, `listAgents`, `buildSwarm`, plus a typed `loadAgents` loader that parses agent frontmatter directly from the source `.md` files (no build step needed to stay in sync with the roster).
- **CLI**: `agency-agents list / get / swarm / categories`.
- **GitHub Action** (`action.yml`): loads a single agent or builds a swarm and exposes the resolved system prompt (and metadata) as step outputs — dependency-free inline Node.js script.
- **Tests**: 37 vitest tests across loader/registry/swarm, all passing.
- Zero production dependencies.

## Relationship to #117

This supersedes #117, which carried the same core feature but had drifted out of mergeable state (it tracked `main` directly rather than a dedicated branch, so it picked up unrelated commits over time) and included a now-abandoned nexus-orchestrator integration. This PR is a single clean commit, rebased on current `main`, with that integration removed entirely. I'm closing #117 in favor of this one.

## Notable fix while rebasing

`AGENT_CATEGORIES` (and the `AgentCategory` type) were hardcoded to the 11 divisions that existed when this was first written. Current `main` has grown to 18 divisions (`academic`, `finance`, `gis`, `healthcare`, `research`, `sales`, `security` added since). Synced both against `divisions.json` so the package doesn't silently miss agents in those categories. Also updated `scripts/check-divisions.sh`'s exclusion list so it doesn't flag the new `src/`/`__tests__/` directories as unregistered divisions.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 37/37 passing
- [x] `npm run build` — succeeds
- [x] `./scripts/check-divisions.sh` — passes (18 divisions consistent)
- [x] `./scripts/check-tools.sh` — passes (16 tools consistent)

Originally proposed in #118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)