### PR TITLE
Fix OpenClaw fenced-section splitting

### DIFF
--- a/scripts/convert.sh
+++ b/scripts/convert.sh
@@ -329,9 +329,30 @@ convert_openclaw() {
   local current_target="agents"  # default bucket
   local current_section=""
 
+  # A `## ` line inside a fenced code block is block content, not a section
+  # boundary: splitting on one tears the block in half and leaves both output
+  # files with an unbalanced fence. Track fence state and only let headings
+  # outside a fence split. A closing fence must be at least as long as the run
+  # that opened it, so a ``` block nested in a ```` block stays contained.
+  local fence_re='^(`{3,}|~{3,})'
+  local fence_marker="" fence_len=0
+
   while IFS= read -r line; do
+    if [[ "$line" =~ $fence_re ]]; then
+      local marker="${BASH_REMATCH[1]}"
+      if [[ -z "$fence_marker" ]]; then
+        fence_marker="${marker:0:1}"
+        fence_len=${#marker}
+      elif [[ "${marker:0:1}" == "$fence_marker" && ${#marker} -ge $fence_len ]]; then
+        fence_marker=""
+        fence_len=0
+      fi
+      current_section+="$line"$'\n'
+      continue
+    fi
+
     # Detect ## headers (with or without emoji prefixes)
-    if [[ "$line" =~ ^##[[:space:]] ]]; then
+    if [[ -z "$fence_marker" && "$line" =~ ^##[[:space:]] ]]; then
       # Flush previous section
       if [[ -n "$current_section" ]]; then
         if [[ "$current_target" == "soul" ]]; then

--- a/scripts/lint-agents.sh
+++ b/scripts/lint-agents.sh
@@ -121,10 +121,27 @@ lint_file() {
     warnings=$((warnings + 1))
   fi
 
+  # Must mirror convert.sh's splitter: a `## ` line inside a fenced code block
+  # is block content, not a section boundary, so it maps to neither bucket.
+  # Counting one here would report a persona section that convert.sh never emits.
+  local fence_re='^(`{3,}|~{3,})'
+  local fence_marker="" fence_len=0
   local soul_headers=0
   local agents_headers=0
   while IFS= read -r line; do
-    if [[ "$line" =~ ^##[[:space:]] ]]; then
+    if [[ "$line" =~ $fence_re ]]; then
+      local marker="${BASH_REMATCH[1]}"
+      if [[ -z "$fence_marker" ]]; then
+        fence_marker="${marker:0:1}"
+        fence_len=${#marker}
+      elif [[ "${marker:0:1}" == "$fence_marker" && ${#marker} -ge $fence_len ]]; then
+        fence_marker=""
+        fence_len=0
+      fi
+      continue
+    fi
+
+    if [[ -z "$fence_marker" && "$line" =~ ^##[[:space:]] ]]; then
       local header_lower
       header_lower=$(printf '%s' "$line" | tr '[:upper:]' '[:lower:]')
       local target

--- a/scripts/test-convert-outputs.sh
+++ b/scripts/test-convert-outputs.sh
@@ -288,6 +288,71 @@ for tool in TOOLS:
     report(tool, bad_parse, bad_trip,
            "parse and round-trip" if fmt in ("yaml-fm", "toml") else "parse, carry their slug, and have their prose file")
 
+# --- Layer A (split integrity): a source fenced block must survive whole -------
+# openclaw is the one tool that splits a single agent body across two files, at
+# `## ` headings: SOUL.md (persona) / AGENTS.md (operations). A heading inside a
+# fenced code block is block content, not a boundary. Splitting on one cuts the
+# block in half and leaves each file holding a dangling fence, which renders as
+# broken markdown for every user of that integration (#849). So every fenced
+# block in a source must land intact in exactly one of the two files.
+SPLIT_FENCE = re.compile(r"^(`{3,}|~{3,})")
+
+def body_lines(text):
+    """Mirror lib.sh's get_body, including `$(...)`'s trailing-newline strip."""
+    out, fm = [], 0
+    for line in text.split("\n"):
+        if line == "---":
+            fm += 1
+            continue
+        if fm >= 2:
+            out.append(line)
+    while out and out[-1] == "":
+        out.pop()
+    return out
+
+def fence_blocks(lines):
+    """Inclusive (opener, closer) index pairs; closer = last line if unterminated."""
+    res, marker, mlen, start = [], "", 0, None
+    for i, line in enumerate(lines):
+        m = SPLIT_FENCE.match(line)
+        if not m:
+            continue
+        tok = m.group(1)
+        if not marker:
+            marker, mlen, start = tok[0], len(tok), i
+        elif tok[0] == marker and len(tok) >= mlen:
+            res.append((start, i)); marker, mlen, start = "", 0, None
+    if marker and start is not None:
+        res.append((start, len(lines) - 1))
+    return res
+
+def has_run(hay, needle):
+    n = len(needle)
+    return n > 0 and n <= len(hay) and any(hay[i:i+n] == needle for i in range(len(hay) - n + 1))
+
+split_bad = 0
+for slug, (_d, _n, path) in sorted(src.items()):
+    sfile = os.path.join(OUT, "openclaw", slug, "SOUL.md")
+    afile = os.path.join(OUT, "openclaw", slug, "AGENTS.md")
+    if not (os.path.isfile(sfile) and os.path.isfile(afile)):
+        continue
+    body = body_lines(open(os.path.join(R, path), encoding="utf-8").read())
+    bl = fence_blocks(body)
+    if not bl:
+        continue
+    outs = [open(sfile, encoding="utf-8").read().split("\n"),
+            open(afile, encoding="utf-8").read().split("\n")]
+    for a, b in bl:
+        if not any(has_run(o, body[a:b + 1]) for o in outs):
+            split_bad += 1
+            if split_bad <= 3:
+                bad(f"openclaw: {slug} source fenced block at lines {a+1}-{b+1} is torn across "
+                    f"SOUL.md/AGENTS.md — a `## ` heading inside the fence was treated as a section boundary")
+if split_bad:
+    if split_bad > 3: bad(f"openclaw: ...and {split_bad-3} more torn fenced blocks")
+else:
+    ok(f"openclaw: all {N} agents keep every source fenced block whole in one output file")
+
 # --- Layer A (app-facing): every SOURCE frontmatter strict-parsed above -------
 for m in src_bad[:5]: bad(m)
 if len(src_bad) > 5: bad(f"...and {len(src_bad)-5} more source frontmatter problems")


### PR DESCRIPTION
## What does this PR do?

Fixes the OpenClaw converter and agent linter so `##` headings inside fenced code blocks remain code content instead of being treated as section boundaries. The converter regression checks now verify that every source fenced block reaches one output file intact.

## Why is this needed?

Issue #849 reports that fenced examples can be split between `SOUL.md` and `AGENTS.md`, leaving invalid OpenClaw workspaces. The fix tracks both backtick and tilde fences, including longer closing fences for nested runs.

## Validation

- `bash -n scripts/convert.sh scripts/lint-agents.sh scripts/test-convert-outputs.sh`
- `bash scripts/check-tools.sh` — passed
- `bash scripts/lint-agents.sh` — 0 errors, 58 recommended-section warnings on unrelated files
- Whole-roster splitter audit — 279 agents; 5 reproductions in the old splitter, 0 with the fixed algorithm
- Real OpenClaw conversion — 279 agents; `verify_split.py` — 279 checked, 0 torn fenced blocks
